### PR TITLE
fix: add preStop hook and rolling update strategy to prevent 502

### DIFF
--- a/k8s/application/backend-deployment.yaml.template
+++ b/k8s/application/backend-deployment.yaml.template
@@ -13,6 +13,11 @@ metadata:
     app: backend
 spec:
   replicas: 2
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 0
+      maxSurge: 1
   selector:
     matchLabels:
       app: backend
@@ -23,6 +28,7 @@ spec:
       annotations:
         instrumentation.opentelemetry.io/inject-python: "false"
     spec:
+      terminationGracePeriodSeconds: 65
       serviceAccountName: backend
       nodeSelector:
         karpenter.sh/nodepool: common-nodepool
@@ -111,6 +117,10 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.hostIP
+        lifecycle:
+          preStop:
+            exec:
+              command: ["sleep", "15"]
         resources:
           requests:
             cpu: ${BACKEND_CPU_REQUEST}

--- a/k8s/application/frontend-deployment.yaml.template
+++ b/k8s/application/frontend-deployment.yaml.template
@@ -7,6 +7,11 @@ metadata:
     app: frontend
 spec:
   replicas: 1
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 0
+      maxSurge: 1
   selector:
     matchLabels:
       app: frontend
@@ -15,6 +20,7 @@ spec:
       labels:
         app: frontend
     spec:
+      terminationGracePeriodSeconds: 30
       nodeSelector:
         karpenter.sh/nodepool: common-nodepool
       containers:
@@ -27,6 +33,10 @@ spec:
         envFrom:
         - configMapRef:
             name: frontend-config
+        lifecycle:
+          preStop:
+            exec:
+              command: ["sleep", "10"]
         resources:
           requests:
             cpu: ${FRONTEND_CPU_REQUEST}


### PR DESCRIPTION
## Summary
- Add `preStop: sleep 15/10` to backend/frontend pods — keeps pod alive during ALB target deregistration
- Set `maxUnavailable: 0, maxSurge: 1` — ensures new pod is ready before old one terminates
- Set `terminationGracePeriodSeconds: 65` (backend) / `30` (frontend) — enough time for preStop + graceful shutdown

## Root Cause
During rolling updates, pod receives SIGTERM and exits immediately. ALB still has the pod registered as a healthy target (deregistration takes seconds), so it routes traffic to a dead pod → 502.

## Test plan
- [ ] `kubectl apply` and trigger a rolling update (`kubectl rollout restart deployment/backend -n kbp`)
- [ ] During rollout, send continuous requests — verify zero 502s
- [ ] Check `kubectl get pods -w -n kbp` — new pod should be Running+Ready before old pod terminates