### PR TITLE
fix: pass through thinking blocks instead of stripping them

### DIFF
--- a/backend/app/schemas/anthropic.py
+++ b/backend/app/schemas/anthropic.py
@@ -163,6 +163,7 @@ class AnthropicResponseThinkingContent(BaseModel):
 
     type: Literal["thinking"] = "thinking"
     thinking: str
+    signature: Optional[str] = None
 
 
 class AnthropicResponseRedactedThinkingContent(BaseModel):

--- a/backend/app/schemas/bedrock.py
+++ b/backend/app/schemas/bedrock.py
@@ -8,9 +8,9 @@ from pydantic import BaseModel, Field
 
 
 class BedrockContentPart(BaseModel):
-    """Content part in Bedrock format (text, image, tool_use, or tool_result)."""
+    """Content part in Bedrock format (text, image, tool_use, tool_result, thinking, or redacted_thinking)."""
 
-    type: str  # "text", "image", "tool_use", "tool_result"
+    type: str  # "text", "image", "tool_use", "tool_result", "thinking", "redacted_thinking"
     text: Optional[str] = None
     source: Optional[Dict[str, Any]] = (
         None  # For images: {"type": "base64", "media_type": "...", "data": "..."}
@@ -22,6 +22,11 @@ class BedrockContentPart(BaseModel):
     # For tool_result type
     tool_use_id: Optional[str] = None
     content: Optional[str] = None  # Tool result content as string
+    # For thinking type
+    thinking: Optional[str] = None
+    signature: Optional[str] = None
+    # For redacted_thinking type
+    data: Optional[str] = None
 
 
 class BedrockMessage(BaseModel):
@@ -69,12 +74,17 @@ class BedrockRequest(BaseModel):
 class BedrockContentBlock(BaseModel):
     """Content block in Bedrock response."""
 
-    type: str  # "text", "tool_use", "image"
+    type: str  # "text", "tool_use", "image", "thinking", "redacted_thinking"
     text: Optional[str] = None
     # For tool_use type
     id: Optional[str] = None
     name: Optional[str] = None
     input: Optional[Dict[str, Any]] = None
+    # For thinking type
+    thinking: Optional[str] = None
+    signature: Optional[str] = None
+    # For redacted_thinking type
+    data: Optional[str] = None
 
 
 class BedrockUsage(BaseModel):

--- a/backend/app/services/anthropic_translator.py
+++ b/backend/app/services/anthropic_translator.py
@@ -11,6 +11,7 @@ import logging
 from app.schemas.anthropic import (
     AnthropicMessagesRequest,
     AnthropicMessagesResponse,
+    AnthropicResponseRedactedThinkingContent,
     AnthropicResponseTextContent,
     AnthropicResponseThinkingContent,
     AnthropicResponseToolUseContent,
@@ -103,10 +104,21 @@ class AnthropicRequestTranslator:
                                 else str(content_val),
                             )
                         )
-                    elif block_type in ("thinking", "redacted_thinking"):
-                        # Strip thinking blocks — Bedrock doesn't support
-                        # adaptive signature-only thinking blocks
-                        continue
+                    elif block_type == "thinking":
+                        parts.append(
+                            BedrockContentPart(
+                                type="thinking",
+                                thinking=part_dict.get("thinking", ""),
+                                signature=part_dict.get("signature"),
+                            )
+                        )
+                    elif block_type == "redacted_thinking":
+                        parts.append(
+                            BedrockContentPart(
+                                type="redacted_thinking",
+                                data=part_dict.get("data", ""),
+                            )
+                        )
                     else:
                         # Unknown type - pass through as dict
                         parts.append(part_dict)
@@ -190,10 +202,6 @@ class AnthropicRequestTranslator:
                         part = dict(block)
                     else:
                         part = block.model_dump(exclude_none=True)
-                    # Strip thinking/redacted_thinking blocks from history —
-                    # Bedrock doesn't support adaptive signature-only thinking blocks
-                    if part.get("type") in ("thinking", "redacted_thinking"):
-                        continue
                     parts.append(part)
                 messages.append({"role": msg.role, "content": parts})
         body["messages"] = messages
@@ -268,10 +276,17 @@ class AnthropicResponseTranslator:
                     )
                 )
             elif block.type == "thinking":
-                # Include thinking blocks in Anthropic format (unlike OpenAI which skips them)
-                if block.text:
+                if block.thinking is not None:
                     content.append(
-                        AnthropicResponseThinkingContent(thinking=block.text)
+                        AnthropicResponseThinkingContent(
+                            thinking=block.thinking,
+                            signature=block.signature,
+                        )
+                    )
+            elif block.type == "redacted_thinking":
+                if block.data is not None:
+                    content.append(
+                        AnthropicResponseRedactedThinkingContent(data=block.data)
                     )
 
         usage = AnthropicUsage(
@@ -412,6 +427,11 @@ class AnthropicResponseTranslator:
                     delta = {
                         "type": "thinking_delta",
                         "thinking": event.delta["thinking"],
+                    }
+                elif "signature" in event.delta:
+                    delta = {
+                        "type": "signature_delta",
+                        "signature": event.delta["signature"],
                     }
 
             data = {

--- a/backend/app/services/bedrock.py
+++ b/backend/app/services/bedrock.py
@@ -971,13 +971,6 @@ class BedrockClient:
                         p = part.model_dump(exclude_none=True)
                     else:
                         p = dict(part) if isinstance(part, dict) else part
-                    # Strip thinking/redacted_thinking blocks from history —
-                    # Bedrock doesn't support adaptive signature-only thinking blocks
-                    if isinstance(p, dict) and p.get("type") in (
-                        "thinking",
-                        "redacted_thinking",
-                    ):
-                        continue
                     parts.append(p)
                 messages.append({"role": msg.role, "content": parts})
 
@@ -1047,11 +1040,18 @@ class BedrockClient:
                 f"Effort parameter '{effort_value}' wrapped in output_config with beta flag"
             )
 
-        # --- auto-fix max_tokens vs thinking.budget_tokens constraint ---
-        # Anthropic requires max_tokens > thinking.budget_tokens.
+        # --- auto-fix thinking.budget_tokens constraints ---
+        # Bedrock requires budget_tokens >= 1024 and max_tokens > budget_tokens.
         thinking_cfg = body.get("thinking")
         if isinstance(thinking_cfg, dict) and "budget_tokens" in thinking_cfg:
             budget = thinking_cfg["budget_tokens"]
+            if budget < 1024:
+                logger.info(
+                    f"Adjusting thinking.budget_tokens from {budget} to 1024 "
+                    f"(Bedrock minimum)"
+                )
+                thinking_cfg["budget_tokens"] = 1024
+                budget = 1024
             if body["max_tokens"] <= budget:
                 new_max = budget + body["max_tokens"]
                 logger.info(
@@ -1485,11 +1485,19 @@ class BedrockClient:
                                         )
                                     )
                                 elif block_type == "thinking":
-                                    logger.debug(
-                                        "Skipping thinking content block in non-streaming response"
-                                    )
                                     content_blocks.append(
-                                        BedrockContentBlock(type="thinking")
+                                        BedrockContentBlock(
+                                            type="thinking",
+                                            thinking=item.get("thinking", ""),
+                                            signature=item.get("signature"),
+                                        )
+                                    )
+                                elif block_type == "redacted_thinking":
+                                    content_blocks.append(
+                                        BedrockContentBlock(
+                                            type="redacted_thinking",
+                                            data=item.get("data", ""),
+                                        )
                                     )
 
                             # Usage — Anthropic format uses snake_case
@@ -1989,6 +1997,12 @@ class BedrockClient:
                     type="content_block_delta",
                     index=index,
                     delta={"thinking": delta.get("thinking", "")},
+                )
+            elif delta_type == "signature_delta":
+                return BedrockStreamEvent(
+                    type="content_block_delta",
+                    index=index,
+                    delta={"signature": delta.get("signature", "")},
                 )
 
         elif event_type == "content_block_stop":


### PR DESCRIPTION
## Summary

- **Stop stripping `thinking`/`redacted_thinking` blocks** from assistant message history — Bedrock requires them when `thinking` is enabled, causing `ValidationException` on multi-turn conversations
- **Forward `signature_delta`** in streaming responses so clients receive valid signatures for subsequent turns
- **Fix non-streaming response** to include actual thinking text and signature (was creating empty blocks)
- **Auto-adjust `budget_tokens`** to Bedrock minimum (1024) when clients send smaller values
- **Add `signature` field** to `AnthropicResponseThinkingContent` for non-streaming response path

## Files changed

| File | Change |
|------|--------|
| `backend/app/schemas/bedrock.py` | Add `thinking`/`signature`/`data` fields to `BedrockContentPart` and `BedrockContentBlock` |
| `backend/app/schemas/anthropic.py` | Add `signature` to `AnthropicResponseThinkingContent` |
| `backend/app/services/anthropic_translator.py` | Remove 2 strip locations, add thinking block passthrough, fix response field access, add `signature_delta` streaming |
| `backend/app/services/bedrock.py` | Remove 1 strip location, fix non-streaming response parsing, add `signature_delta` streaming, add `budget_tokens` minimum |

## Test plan

- [x] `uv run pytest tests/ --ignore=tests/test_pricing.py` — 62 passed
- [x] Single-turn + thinking via curl — success
- [x] Multi-turn + real thinking block with signature via curl — success
- [x] Basic request without thinking (regression check) — success

🤖 Generated with [Claude Code](https://claude.com/claude-code)