### PR TITLE
fix: cache_control ttl model check + batch create with explicit names

### DIFF
--- a/backend/app/api/admin/endpoints/tokens.py
+++ b/backend/app/api/admin/endpoints/tokens.py
@@ -75,7 +75,9 @@ class BatchCreateTokenRequest(BaseModel):
         """Parse comma-separated names. Supports ASCII comma, Chinese comma, semicolons, and newlines."""
         import re
 
-        return [n for n in (s.strip() for s in re.split(r"[,，;；\n]+", self.names)) if n]
+        return [
+            n for n in (s.strip() for s in re.split(r"[,，;；\n]+", self.names)) if n
+        ]
 
 
 class UpdateTokenRequest(BaseModel):

--- a/backend/app/api/admin/endpoints/tokens.py
+++ b/backend/app/api/admin/endpoints/tokens.py
@@ -72,8 +72,10 @@ class BatchCreateTokenRequest(BaseModel):
     model_names: List[str] | None = None
 
     def parsed_names(self) -> List[str]:
-        """Parse and deduplicate comma-separated names."""
-        return [n for n in (s.strip() for s in self.names.split(",")) if n]
+        """Parse comma-separated names. Supports ASCII comma, Chinese comma, semicolons, and newlines."""
+        import re
+
+        return [n for n in (s.strip() for s in re.split(r"[,，;；\n]+", self.names)) if n]
 
 
 class UpdateTokenRequest(BaseModel):

--- a/backend/app/api/admin/endpoints/tokens.py
+++ b/backend/app/api/admin/endpoints/tokens.py
@@ -7,7 +7,7 @@ from decimal import Decimal
 from typing import List
 
 from fastapi import APIRouter, Depends, HTTPException, status
-from pydantic import BaseModel, Field
+from pydantic import BaseModel
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -58,15 +58,22 @@ class CreateTokenRequest(BaseModel):
 
 
 class BatchCreateTokenRequest(BaseModel):
-    """Batch create tokens request."""
+    """Batch create tokens request.
 
-    count: int = Field(ge=1, le=100)
-    name_prefix: str
+    ``names`` is a comma-separated string of token names (e.g. "alice, bob, charlie").
+    Whitespace around each name is automatically trimmed and empty entries are ignored.
+    """
+
+    names: str
     expires_at: datetime | None = None
     quota_usd: Decimal | None = None
     allowed_ips: List[str] | None = None
     token_metadata: dict | None = None
     model_names: List[str] | None = None
+
+    def parsed_names(self) -> List[str]:
+        """Parse and deduplicate comma-separated names."""
+        return [n for n in (s.strip() for s in self.names.split(",")) if n]
 
 
 class UpdateTokenRequest(BaseModel):
@@ -217,10 +224,21 @@ async def batch_create_tokens(
     """
     Batch create API tokens with optional shared model list.
 
-    - **count**: Number of tokens to create (1-100)
-    - **name_prefix**: Name prefix, tokens named {prefix}-001, {prefix}-002, ...
+    - **names**: Comma-separated token names (e.g. "alice, bob, charlie")
     - **model_names**: Optional list of model names to assign to all tokens
     """
+    names = request.parsed_names()
+    if not names:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="No valid names provided",
+        )
+    if len(names) > 100:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"Too many names ({len(names)}), maximum is 100",
+        )
+
     try:
         validated_meta = validate_token_metadata(request.token_metadata)
     except ValueError as e:
@@ -228,8 +246,7 @@ async def batch_create_tokens(
 
     results = await token_service.create_tokens_batch(
         user_id=current_user.id,
-        count=request.count,
-        name_prefix=request.name_prefix,
+        names=names,
         expires_at=request.expires_at,
         quota_usd=request.quota_usd,
         allowed_ips=request.allowed_ips,

--- a/backend/app/services/bedrock.py
+++ b/backend/app/services/bedrock.py
@@ -683,7 +683,7 @@ class BedrockClient:
         if use_converse:
             converse_params = self._build_converse_params(request, model_id)
         else:
-            body = self._build_anthropic_body(request)
+            body = self._build_anthropic_body(request, model_id=model_id)
             invoke_kwargs = self._build_invoke_kwargs(request, model_id)
 
         content_received = False
@@ -806,12 +806,34 @@ class BedrockClient:
 
     # ------------------------------------------------------------------
 
+    # Models that support the extended 1-hour cache TTL.
+    # Only Claude 4.5 family models support ``ttl`` in ``cache_control``;
+    # older/newer families (Claude 4, etc.) reject it with
+    # ``Extra inputs are not permitted``.
+    _EXTENDED_TTL_MODEL_PATTERNS = (
+        "claude-opus-4-5",
+        "claude-sonnet-4-5",
+        "claude-haiku-4-5",
+    )
+
+    @classmethod
+    def _model_supports_cache_ttl(cls, model_id: str | None) -> bool:
+        """Check if a model supports the extended ``ttl`` field in cache_control."""
+        if not model_id:
+            return False
+        return any(pat in model_id for pat in cls._EXTENDED_TTL_MODEL_PATTERNS)
+
     @staticmethod
-    def _new_cache_marker(ttl: str | None = None) -> dict:
-        """Create a cache_control marker with configured TTL."""
+    def _new_cache_marker(ttl: str | None = None, model_id: str | None = None) -> dict:
+        """Create a cache_control marker with configured TTL.
+
+        The ``ttl`` field is only supported by Claude 4.5 family models.
+        For unsupported models the field must be omitted, otherwise Bedrock
+        returns ``Extra inputs are not permitted``.
+        """
         cache_ttl = ttl or get_settings().PROMPT_CACHE_TTL
         marker: dict = {"type": "ephemeral"}
-        if cache_ttl != "5m":
+        if cache_ttl != "5m" and BedrockClient._model_supports_cache_ttl(model_id):
             marker["ttl"] = cache_ttl
         return marker
 
@@ -846,7 +868,9 @@ class BedrockClient:
         return len(BedrockClient._collect_cache_blocks(body)) > 0
 
     @staticmethod
-    def _inject_prompt_cache_breakpoints(body: dict, ttl: str | None = None) -> None:
+    def _inject_prompt_cache_breakpoints(
+        body: dict, ttl: str | None = None, model_id: str | None = None
+    ) -> None:
         """Inject up to 4 cache_control breakpoints into the request body.
 
         Strategy aligned with claudecode-bedrock-proxy:
@@ -860,17 +884,24 @@ class BedrockClient:
         count against this budget.
         """
         cache_ttl = ttl or get_settings().PROMPT_CACHE_TTL
-        marker = BedrockClient._new_cache_marker(ttl=cache_ttl)
+        supports_ttl = BedrockClient._model_supports_cache_ttl(model_id)
+        marker = BedrockClient._new_cache_marker(ttl=cache_ttl, model_id=model_id)
 
         # --- Step 1: Upgrade TTL on pre-existing breakpoints ---
         existing_blocks = BedrockClient._collect_cache_blocks(body)
         upgraded = 0
-        if cache_ttl != "5m":
+        if cache_ttl != "5m" and supports_ttl:
             for block in existing_blocks:
                 cc = block.get("cache_control")
                 if isinstance(cc, dict):
                     cc["ttl"] = cache_ttl
                     upgraded += 1
+        elif not supports_ttl:
+            # Strip ttl from pre-existing breakpoints for unsupported models
+            for block in existing_blocks:
+                cc = block.get("cache_control")
+                if isinstance(cc, dict) and "ttl" in cc:
+                    del cc["ttl"]
 
         existing = len(existing_blocks)
         budget = BedrockClient.MAX_CACHE_BREAKPOINTS - existing
@@ -951,7 +982,9 @@ class BedrockClient:
             )
 
     @staticmethod
-    def _build_anthropic_body(request: BedrockRequest) -> dict:
+    def _build_anthropic_body(
+        request: BedrockRequest, model_id: str | None = None
+    ) -> dict:
         """
         Build an Anthropic Messages API request body from a BedrockRequest.
 
@@ -1019,7 +1052,9 @@ class BedrockClient:
             BedrockClient._body_has_cache_control(body) if should_inject else False
         )
         if should_inject and not has_cache:
-            BedrockClient._inject_prompt_cache_breakpoints(body, ttl=request.cache_ttl)
+            BedrockClient._inject_prompt_cache_breakpoints(
+                body, ttl=request.cache_ttl, model_id=model_id
+            )
 
         # --- effort parameter: requires beta flag + output_config wrapper ---
         # Users may pass "effort" as a top-level field (via additional_model_request_fields).
@@ -1425,7 +1460,7 @@ class BedrockClient:
                 },
             )
         else:
-            body = self._build_anthropic_body(request)
+            body = self._build_anthropic_body(request, model_id=model_id)
             invoke_kwargs = self._build_invoke_kwargs(request, model_id)
 
         max_retries = 3
@@ -1745,7 +1780,7 @@ class BedrockClient:
                 },
             )
         else:
-            body = self._build_anthropic_body(request)
+            body = self._build_anthropic_body(request, model_id=model_id)
             invoke_kwargs = self._build_invoke_kwargs(request, model_id)
 
         max_retries = 4

--- a/backend/app/services/token.py
+++ b/backend/app/services/token.py
@@ -87,8 +87,7 @@ class TokenService:
     async def create_tokens_batch(
         self,
         user_id: UUID,
-        count: int,
-        name_prefix: str,
+        names: List[str],
         expires_at: Optional[datetime] = None,
         quota_usd: Optional[Decimal] = None,
         allowed_ips: Optional[List[str]] = None,
@@ -96,7 +95,7 @@ class TokenService:
         model_names: Optional[List[str]] = None,
     ) -> List[tuple[APIToken, str]]:
         """
-        Batch create API tokens with optional shared model list.
+        Batch create API tokens with explicit names and optional shared model list.
 
         All tokens are inserted in a single transaction (atomic).
 
@@ -105,14 +104,14 @@ class TokenService:
         """
         tokens_and_keys: List[tuple[APIToken, str]] = []
 
-        for i in range(1, count + 1):
+        for name in names:
             plain_token = generate_api_token()
             token_hash = hash_token(plain_token)
             encrypted = encrypt_token(plain_token)
 
             token = APIToken(
                 user_id=user_id,
-                name=f"{name_prefix}-{i:03d}",
+                name=name,
                 token_hash=token_hash,
                 encrypted_token=encrypted,
                 expires_at=expires_at,

--- a/backend/tests/test_prompt_cache_injection.py
+++ b/backend/tests/test_prompt_cache_injection.py
@@ -16,8 +16,14 @@ from unittest.mock import patch
 
 from app.services.bedrock import BedrockClient
 
-# Default marker with 1h TTL (matching default config)
-MARKER = {"type": "ephemeral", "ttl": "1h"}
+# Default marker with 1h TTL (matching default config) — global model only
+MARKER_TTL = {"type": "ephemeral", "ttl": "1h"}
+# Marker without TTL — for non-global models or 5m default
+MARKER = {"type": "ephemeral"}
+
+TTL_MODEL = "us.anthropic.claude-sonnet-4-5-20250929-v1:0"  # Claude 4.5 supports ttl
+NO_TTL_MODEL = "us.anthropic.claude-sonnet-4-20250514-v1:0"  # Claude 4 does not
+
 LONG_TEXT = "x" * 5000
 
 
@@ -38,13 +44,13 @@ def _mock_settings(**overrides):
     return s
 
 
-def _inject(body, ttl="1h"):
+def _inject(body, ttl="1h", model_id=TTL_MODEL):
     """Helper: inject breakpoints with mocked settings."""
     with patch(
         "app.services.bedrock.get_settings",
         return_value=_mock_settings(PROMPT_CACHE_TTL=ttl),
     ):
-        BedrockClient._inject_prompt_cache_breakpoints(body)
+        BedrockClient._inject_prompt_cache_breakpoints(body, model_id=model_id)
 
 
 # ---------------------------------------------------------------------------
@@ -61,7 +67,7 @@ def test_inject_last_tool():
     body = {"tools": tools, "messages": []}
     _inject(body)
     assert "cache_control" not in tools[0]
-    assert tools[1]["cache_control"] == MARKER
+    assert tools[1]["cache_control"] == MARKER_TTL
 
 
 def test_inject_single_tool():
@@ -69,7 +75,7 @@ def test_inject_single_tool():
     tools = [{"name": "a", "description": "b", "input_schema": {}}]
     body = {"tools": tools, "messages": []}
     _inject(body)
-    assert tools[0]["cache_control"] == MARKER
+    assert tools[0]["cache_control"] == MARKER_TTL
 
 
 # ---------------------------------------------------------------------------
@@ -83,7 +89,7 @@ def test_inject_system_string():
     _inject(body)
     assert isinstance(body["system"], list)
     assert len(body["system"]) == 1
-    assert body["system"][0]["cache_control"] == MARKER
+    assert body["system"][0]["cache_control"] == MARKER_TTL
     assert body["system"][0]["text"] == LONG_TEXT
 
 
@@ -92,7 +98,7 @@ def test_inject_system_short_string():
     body = {"system": "hi", "messages": []}
     _inject(body)
     assert isinstance(body["system"], list)
-    assert body["system"][0]["cache_control"] == MARKER
+    assert body["system"][0]["cache_control"] == MARKER_TTL
 
 
 def test_inject_system_array():
@@ -106,7 +112,7 @@ def test_inject_system_array():
     }
     _inject(body)
     assert "cache_control" not in body["system"][0]
-    assert body["system"][1]["cache_control"] == MARKER
+    assert body["system"][1]["cache_control"] == MARKER_TTL
 
 
 # ---------------------------------------------------------------------------
@@ -126,7 +132,7 @@ def test_inject_last_assistant_msg():
     _inject(body)
     assistant = body["messages"][1]
     assert isinstance(assistant["content"], list)
-    assert assistant["content"][0]["cache_control"] == MARKER
+    assert assistant["content"][0]["cache_control"] == MARKER_TTL
 
 
 def test_inject_assistant_skips_thinking():
@@ -149,7 +155,7 @@ def test_inject_assistant_skips_thinking():
     # Thinking block should NOT get cache_control
     assert "cache_control" not in content[1]
     # Text block should get it
-    assert content[0]["cache_control"] == MARKER
+    assert content[0]["cache_control"] == MARKER_TTL
 
 
 def test_inject_assistant_skips_redacted_thinking():
@@ -170,7 +176,7 @@ def test_inject_assistant_skips_redacted_thinking():
     _inject(body)
     content = body["messages"][1]["content"]
     assert "cache_control" not in content[1]
-    assert content[0]["cache_control"] == MARKER
+    assert content[0]["cache_control"] == MARKER_TTL
 
 
 def test_no_assistant_message():
@@ -182,7 +188,7 @@ def test_no_assistant_message():
     _inject(body)
     # System should be injected
     assert isinstance(body["system"], list)
-    assert body["system"][0]["cache_control"] == MARKER
+    assert body["system"][0]["cache_control"] == MARKER_TTL
     # User message should NOT be touched
     assert body["messages"][0]["content"] == "hello"
 
@@ -196,28 +202,53 @@ def test_ttl_5m_no_ttl_field():
     """With TTL=5m, marker should be just {"type": "ephemeral"} (no ttl field)."""
     body = {"system": "prompt", "messages": []}
     _inject(body, ttl="5m")
-    assert body["system"][0]["cache_control"] == {"type": "ephemeral"}
+    assert body["system"][0]["cache_control"] == MARKER
     assert "ttl" not in body["system"][0]["cache_control"]
 
 
-def test_ttl_1h_has_ttl_field():
-    """With TTL=1h, marker should include ttl field."""
+def test_ttl_1h_has_ttl_field_supported_model():
+    """With TTL=1h on Claude 4.5 model, marker should include ttl field."""
     body = {"system": "prompt", "messages": []}
-    _inject(body, ttl="1h")
+    _inject(body, ttl="1h", model_id=TTL_MODEL)
     assert body["system"][0]["cache_control"]["ttl"] == "1h"
 
 
-def test_upgrade_existing_ttl():
-    """Pre-existing breakpoints get their TTL upgraded to configured value."""
+def test_ttl_1h_no_ttl_field_unsupported_model():
+    """With TTL=1h on Claude 4 model, marker should NOT include ttl field."""
+    body = {"system": "prompt", "messages": []}
+    _inject(body, ttl="1h", model_id=NO_TTL_MODEL)
+    assert "ttl" not in body["system"][0]["cache_control"]
+    assert body["system"][0]["cache_control"] == MARKER
+
+
+def test_upgrade_existing_ttl_supported_model():
+    """Pre-existing breakpoints get their TTL upgraded on supported models."""
     body = {
         "system": [
             {"type": "text", "text": "prompt", "cache_control": {"type": "ephemeral"}}
         ],
         "messages": [],
     }
-    _inject(body, ttl="1h")
+    _inject(body, ttl="1h", model_id=TTL_MODEL)
     # TTL should be upgraded on existing marker
     assert body["system"][0]["cache_control"]["ttl"] == "1h"
+
+
+def test_strip_existing_ttl_unsupported_model():
+    """Pre-existing breakpoints get ttl stripped on unsupported models."""
+    body = {
+        "system": [
+            {
+                "type": "text",
+                "text": "prompt",
+                "cache_control": {"type": "ephemeral", "ttl": "1h"},
+            }
+        ],
+        "messages": [],
+    }
+    _inject(body, ttl="1h", model_id=NO_TTL_MODEL)
+    # TTL should be stripped for unsupported model
+    assert "ttl" not in body["system"][0]["cache_control"]
 
 
 # ---------------------------------------------------------------------------
@@ -250,7 +281,7 @@ def test_budget_limit():
     }
     _inject(body, ttl="1h")
     # No new breakpoints should be added (budget exhausted)
-    # But TTL should be upgraded
+    # But TTL should be upgraded (global model)
     assert body["system"][0]["cache_control"]["ttl"] == "1h"
     assert body["tools"][0]["cache_control"]["ttl"] == "1h"
 
@@ -273,10 +304,10 @@ def test_partial_budget():
     }
     _inject(body)
     # t2 should get cache_control (tools priority)
-    assert body["tools"][1]["cache_control"] == MARKER
+    assert body["tools"][1]["cache_control"] == MARKER_TTL
     # Assistant message should also get it (budget allows 2 more)
     assert isinstance(body["messages"][1]["content"], list)
-    assert body["messages"][1]["content"][0]["cache_control"] == MARKER
+    assert body["messages"][1]["content"][0]["cache_control"] == MARKER_TTL
 
 
 # ---------------------------------------------------------------------------
@@ -352,16 +383,16 @@ def test_combined_all_breakpoints():
     _inject(body)
 
     # Last tool → cache_control
-    assert body["tools"][0]["cache_control"] == MARKER
+    assert body["tools"][0]["cache_control"] == MARKER_TTL
 
     # System → array with cache_control
     assert isinstance(body["system"], list)
-    assert body["system"][0]["cache_control"] == MARKER
+    assert body["system"][0]["cache_control"] == MARKER_TTL
 
     # Last assistant message → array with cache_control
     assistant = body["messages"][1]
     assert isinstance(assistant["content"], list)
-    assert assistant["content"][0]["cache_control"] == MARKER
+    assert assistant["content"][0]["cache_control"] == MARKER_TTL
 
 
 def test_empty_system_not_injected():
@@ -383,28 +414,48 @@ def test_inject_with_explicit_ttl_5m():
         "app.services.bedrock.get_settings",
         return_value=_mock_settings(PROMPT_CACHE_TTL="1h"),
     ):
-        BedrockClient._inject_prompt_cache_breakpoints(body, ttl="5m")
-    assert body["system"][0]["cache_control"] == {"type": "ephemeral"}
+        BedrockClient._inject_prompt_cache_breakpoints(
+            body, ttl="5m", model_id=TTL_MODEL
+        )
+    assert body["system"][0]["cache_control"] == MARKER
     assert "ttl" not in body["system"][0]["cache_control"]
 
 
 def test_inject_with_explicit_ttl_1h():
-    """Passing ttl='1h' directly overrides server default of 5m."""
+    """Passing ttl='1h' directly overrides server default of 5m (supported model)."""
     body = {"system": "prompt", "messages": []}
     with patch(
         "app.services.bedrock.get_settings",
         return_value=_mock_settings(PROMPT_CACHE_TTL="5m"),
     ):
-        BedrockClient._inject_prompt_cache_breakpoints(body, ttl="1h")
-    assert body["system"][0]["cache_control"] == {"type": "ephemeral", "ttl": "1h"}
+        BedrockClient._inject_prompt_cache_breakpoints(
+            body, ttl="1h", model_id=TTL_MODEL
+        )
+    assert body["system"][0]["cache_control"] == MARKER_TTL
+
+
+def test_inject_with_explicit_ttl_1h_unsupported():
+    """Passing ttl='1h' on unsupported model produces marker without ttl."""
+    body = {"system": "prompt", "messages": []}
+    with patch(
+        "app.services.bedrock.get_settings",
+        return_value=_mock_settings(PROMPT_CACHE_TTL="5m"),
+    ):
+        BedrockClient._inject_prompt_cache_breakpoints(
+            body, ttl="1h", model_id=NO_TTL_MODEL
+        )
+    assert body["system"][0]["cache_control"] == MARKER
+    assert "ttl" not in body["system"][0]["cache_control"]
 
 
 def test_inject_ttl_none_uses_server_default():
-    """Passing ttl=None falls back to server setting."""
+    """Passing ttl=None falls back to server setting (supported model)."""
     body = {"system": "prompt", "messages": []}
     with patch(
         "app.services.bedrock.get_settings",
         return_value=_mock_settings(PROMPT_CACHE_TTL="1h"),
     ):
-        BedrockClient._inject_prompt_cache_breakpoints(body, ttl=None)
-    assert body["system"][0]["cache_control"] == {"type": "ephemeral", "ttl": "1h"}
+        BedrockClient._inject_prompt_cache_breakpoints(
+            body, ttl=None, model_id=TTL_MODEL
+        )
+    assert body["system"][0]["cache_control"] == MARKER_TTL

--- a/backend/tests/test_stream_failover.py
+++ b/backend/tests/test_stream_failover.py
@@ -178,7 +178,10 @@ def _patch_bedrock_client(
     bc.session.client = mock_client_cm
 
     # Mock build helpers to be pass-through
-    bc._build_anthropic_body = lambda req: {"messages": [], "max_tokens": 100}
+    bc._build_anthropic_body = lambda req, model_id=None: {
+        "messages": [],
+        "max_tokens": 100,
+    }
     bc._build_invoke_kwargs = staticmethod(
         lambda req, mid: {
             "modelId": mid,

--- a/frontend/src/pages/TokensPage.vue
+++ b/frontend/src/pages/TokensPage.vue
@@ -399,26 +399,15 @@
         <q-card-section class="q-pt-none">
           <q-form @submit="handleBatchCreate">
             <q-input
-              v-model="batchForm.name_prefix"
-              label="Name Prefix"
+              v-model="batchForm.names"
+              label="Names"
               outlined
               rounded
               dark
-              :rules="[(val) => !!val || 'Please enter name prefix']"
-              hint="Keys will be named {prefix}-001, {prefix}-002, ..."
-              class="q-mb-md"
-            />
-
-            <q-input
-              v-model.number="batchForm.count"
-              label="Count"
-              outlined
-              rounded
-              dark
-              type="number"
-              :rules="[
-                (val) => (val >= 1 && val <= 100) || 'Must be between 1 and 100',
-              ]"
+              type="textarea"
+              autogrow
+              :rules="[(val) => !!val?.trim() || 'Please enter at least one name']"
+              hint="Comma-separated, e.g. alice, bob, charlie"
               class="q-mb-md"
             />
 
@@ -590,8 +579,7 @@ const showBatchResultDialog = ref(false);
 const batchCreating = ref(false);
 const batchResults = ref<APITokenWithKey[]>([]);
 const batchForm = ref({
-  name_prefix: '',
-  count: 10,
+  names: '',
   quota_usd: undefined as number | undefined,
   expires_at: '',
   model_names: [] as string[],
@@ -914,8 +902,7 @@ function deleteToken(token: APIToken) {
 
 function openBatchCreate() {
   batchForm.value = {
-    name_prefix: '',
-    count: 10,
+    names: '',
     quota_usd: undefined,
     expires_at: '',
     model_names: [],
@@ -930,8 +917,7 @@ async function handleBatchCreate() {
   batchCreating.value = true;
   try {
     const data: BatchCreateTokenRequest = {
-      count: batchForm.value.count,
-      name_prefix: batchForm.value.name_prefix,
+      names: batchForm.value.names,
     };
 
     if (batchForm.value.quota_usd !== undefined) {

--- a/frontend/src/pages/TokensPage.vue
+++ b/frontend/src/pages/TokensPage.vue
@@ -407,7 +407,7 @@
               type="textarea"
               autogrow
               :rules="[(val) => !!val?.trim() || 'Please enter at least one name']"
-              hint="Comma-separated, e.g. alice, bob, charlie"
+              hint="Separate with comma or newline, e.g. alice, bob, charlie"
               class="q-mb-md"
             />
 

--- a/frontend/src/stores/tokens.ts
+++ b/frontend/src/stores/tokens.ts
@@ -39,8 +39,7 @@ export interface CreateTokenRequest {
 }
 
 export interface BatchCreateTokenRequest {
-  count: number;
-  name_prefix: string;
+  names: string;
   expires_at?: string;
   quota_usd?: number;
   allowed_ips?: string[];


### PR DESCRIPTION
## Summary
- **Cache TTL fix**: Only add `ttl` field to `cache_control` for Claude 4.5 family models (Opus 4.5, Sonnet 4.5, Haiku 4.5). Non-4.5 models like Sonnet 4 reject `ttl` with `ValidationException: Extra inputs are not permitted`. Also strips `ttl` from pre-existing client breakpoints on unsupported models.
- **Batch token creation**: Replace `count` + `name_prefix` (auto-generated `prefix-001`, `prefix-002`) with comma-separated `names` input. Frontend uses a textarea; backend auto-trims whitespace and ignores empty entries.

## Changed files
| File | Change |
|------|--------|
| `backend/app/services/bedrock.py` | `_model_supports_cache_ttl()`, `_new_cache_marker()`, `_inject_prompt_cache_breakpoints()` accept `model_id`; `_build_anthropic_body()` passes `model_id` through |
| `backend/app/api/admin/endpoints/tokens.py` | `BatchCreateTokenRequest`: `count`+`name_prefix` → `names` (comma-separated string) |
| `backend/app/services/token.py` | `create_tokens_batch()`: `count`+`name_prefix` → `names: List[str]` |
| `backend/tests/test_prompt_cache_injection.py` | Updated for model-aware TTL; added supported/unsupported model tests |
| `backend/tests/test_stream_failover.py` | Mock signature fix for `model_id` param |
| `frontend/src/stores/tokens.ts` | `BatchCreateTokenRequest` interface updated |
| `frontend/src/pages/TokensPage.vue` | Batch dialog: textarea replaces prefix+count inputs |

## Test plan
- [x] 27 prompt cache injection tests pass (including new TTL model checks)
- [x] 65 total tests pass (excluding unrelated pricing test)
- [x] Pre-commit hooks pass
- [ ] Verify Sonnet 4 + `X-Bedrock-Auto-Cache: true` + system prompt no longer returns `Extra inputs are not permitted`
- [ ] Verify Sonnet 4.5 still gets `ttl: "1h"` in cache_control
- [ ] Verify batch create with comma-separated names creates multiple tokens