### PR TITLE
fix: propagate Bedrock error details instead of generic 500

### DIFF
--- a/backend/app/api/anthropic/endpoints/messages.py
+++ b/backend/app/api/anthropic/endpoints/messages.py
@@ -7,6 +7,7 @@ import time
 import uuid
 from typing import AsyncGenerator
 
+from botocore.exceptions import ClientError
 from fastapi import APIRouter, Depends, HTTPException, Request
 from fastapi.responses import StreamingResponse
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -246,6 +247,25 @@ async def create_message(
             exc_info=True,
         )
         raise HTTPException(status_code=400, detail="Invalid request")
+    except ClientError as e:
+        error_code = e.response.get("Error", {}).get("Code", "Unknown")
+        error_message = e.response.get("Error", {}).get("Message", str(e))
+        logger.error(
+            f"Bedrock error: model={request_data.model}, request_id={request_id}, "
+            f"code={error_code}, message={error_message}",
+        )
+        status_map = {
+            "ValidationException": 400,
+            "AccessDeniedException": 403,
+            "ThrottlingException": 429,
+            "ModelNotReadyException": 529,
+            "ServiceUnavailableException": 529,
+        }
+        status_code = status_map.get(error_code, 502)
+        raise HTTPException(
+            status_code=status_code,
+            detail=error_message,
+        )
     except Exception as e:
         logger.error(
             f"Anthropic messages failed: model={request_data.model}, request_id={request_id}, error={e}",
@@ -385,19 +405,40 @@ async def stream_anthropic_messages(
             cache_read_tokens=total_cache_read,
         )
 
+    except ClientError as e:
+        error_code = e.response.get("Error", {}).get("Code", "Unknown")
+        error_message = e.response.get("Error", {}).get("Message", str(e))
+        logger.error(
+            f"Bedrock streaming error: model={model}, request_id={request_id}, "
+            f"code={error_code}, message={error_message}",
+        )
+        import json as _json
+
+        error_type_map = {
+            "ValidationException": "invalid_request_error",
+            "AccessDeniedException": "permission_error",
+            "ThrottlingException": "rate_limit_error",
+            "ModelNotReadyException": "overloaded_error",
+            "ServiceUnavailableException": "overloaded_error",
+        }
+        error_type = error_type_map.get(error_code, "api_error")
+        error_data = {
+            "type": "error",
+            "error": {"type": error_type, "message": error_message},
+        }
+        yield f"event: error\ndata: {_json.dumps(error_data)}\n\n"
     except Exception as e:
         logger.error(
             f"Anthropic streaming failed: model={model}, request_id={request_id}, error={e}",
             exc_info=True,
         )
-        # Send error in Anthropic SSE format
-        import json
+        import json as _json
 
         error_data = {
             "type": "error",
             "error": {"type": "server_error", "message": "Internal server error"},
         }
-        yield f"event: error\ndata: {json.dumps(error_data)}\n\n"
+        yield f"event: error\ndata: {_json.dumps(error_data)}\n\n"
 
 
 async def record_usage(

--- a/backend/app/api/v1/endpoints/chat.py
+++ b/backend/app/api/v1/endpoints/chat.py
@@ -7,6 +7,7 @@ import time
 import uuid
 from typing import AsyncGenerator
 
+from botocore.exceptions import ClientError
 from fastapi import APIRouter, Depends, HTTPException, Request
 from fastapi.responses import StreamingResponse
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -336,6 +337,25 @@ async def create_chat_completion(
             exc_info=True,
         )
         raise HTTPException(status_code=400, detail=str(e))
+    except ClientError as e:
+        error_code = e.response.get("Error", {}).get("Code", "Unknown")
+        error_message = e.response.get("Error", {}).get("Message", str(e))
+        logger.error(
+            f"Bedrock error: model={request_data.model}, request_id={request_id}, "
+            f"code={error_code}, message={error_message}",
+        )
+        status_map = {
+            "ValidationException": 400,
+            "AccessDeniedException": 403,
+            "ThrottlingException": 429,
+            "ModelNotReadyException": 503,
+            "ServiceUnavailableException": 503,
+        }
+        status_code = status_map.get(error_code, 502)
+        raise HTTPException(
+            status_code=status_code,
+            detail=error_message,
+        )
     except Exception as e:
         logger.error(
             f"Chat completion failed: model={request_data.model}, request_id={request_id}, error={e}",
@@ -777,6 +797,21 @@ async def stream_chat_completion(
             cache_read_tokens=total_cache_read_tokens,
         )
 
+    except ClientError as e:
+        error_code = e.response.get("Error", {}).get("Code", "Unknown")
+        error_message = e.response.get("Error", {}).get("Message", str(e))
+        logger.error(
+            f"Bedrock streaming error: model={model}, request_id={request_id}, "
+            f"code={error_code}, message={error_message}",
+        )
+        error_response = ErrorResponse(
+            error=ErrorDetail(
+                message=error_message,
+                type=error_code,
+                code=error_code,
+            )
+        )
+        yield f"data: {error_response.model_dump_json()}\n\n"
     except Exception as e:
         logger.error(
             f"Streaming failed: model={model}, request_id={request_id}, error={e}",


### PR DESCRIPTION
## Summary
- Bedrock `ClientError` 之前被通用 `except Exception` 捕获，统一返回 500 Internal Server Error，客户端（Claude Code 等）看不到具体错误原因
- 现在将 Bedrock 错误映射为对应 HTTP 状态码（400/403/429/502/529）并透传原始错误信息
- 覆盖 4 条路径：Anthropic 非流式/流式 + OpenAI 非流式/流式

## 错误映射

| Bedrock Error | HTTP Status | 场景 |
|---|---|---|
| `ValidationException` | 400 | 参数错误（如 budget_tokens < 1024） |
| `AccessDeniedException` | 403 | 模型未开通 |
| `ThrottlingException` | 429 | 限流 |
| `ModelNotReadyException` | 529/503 | 模型过载 |
| `ServiceUnavailableException` | 529/503 | 服务不可用 |
| 其他 | 502 | 上游错误 |

## Test plan
- [x] `pytest` 65 passed（排除已有 pricing 测试问题）
- [ ] 部署后用无效模型名测试，确认返回 400 + 具体错误信息而非 500
- [ ] 部署后触发限流，确认返回 429