### PR TITLE
feat: support strict tool definitions and disable_parallel_tool_use

### DIFF
--- a/backend/app/schemas/anthropic.py
+++ b/backend/app/schemas/anthropic.py
@@ -95,6 +95,7 @@ class AnthropicToolDefinition(BaseModel):
     description: Optional[str] = None
     input_schema: Dict[str, Any]
     cache_control: Optional[Dict[str, str]] = None
+    strict: Optional[bool] = None
 
 
 class AnthropicSystemBlock(BaseModel):
@@ -126,6 +127,7 @@ class AnthropicMessagesRequest(BaseModel):
     stream: Optional[bool] = False
     tools: Optional[List[AnthropicToolDefinition]] = None
     tool_choice: Optional[Dict[str, Any]] = None
+    disable_parallel_tool_use: Optional[bool] = None
     metadata: Optional[Dict[str, Any]] = None
     thinking: Optional[AnthropicThinkingConfig] = None
 

--- a/backend/app/schemas/bedrock.py
+++ b/backend/app/schemas/bedrock.py
@@ -44,6 +44,7 @@ class BedrockTool(BaseModel):
     name: str
     description: str
     input_schema: Dict[str, Any]
+    strict: Optional[bool] = None
 
 
 class BedrockRequest(BaseModel):

--- a/backend/app/services/anthropic_translator.py
+++ b/backend/app/services/anthropic_translator.py
@@ -144,6 +144,11 @@ class AnthropicRequestTranslator:
         if request.top_k is not None:
             additional_fields["top_k"] = request.top_k
 
+        if request.disable_parallel_tool_use is not None:
+            additional_fields["disable_parallel_tool_use"] = (
+                request.disable_parallel_tool_use
+            )
+
         # Convert tools
         bedrock_tools = None
         if request.tools:
@@ -152,6 +157,7 @@ class AnthropicRequestTranslator:
                     name=tool.name,
                     description=tool.description or "",
                     input_schema=tool.input_schema,
+                    strict=tool.strict,
                 )
                 for tool in request.tools
             ]

--- a/backend/app/services/bedrock.py
+++ b/backend/app/services/bedrock.py
@@ -1025,14 +1025,16 @@ class BedrockClient:
 
         # --- tools / tool_choice ---
         if request.tools:
-            body["tools"] = [
-                {
+            body["tools"] = []
+            for t in request.tools:
+                tool_dict = {
                     "name": t.name,
                     "description": t.description,
                     "input_schema": t.input_schema,
                 }
-                for t in request.tools
-            ]
+                if t.strict is not None:
+                    tool_dict["strict"] = t.strict
+                body["tools"].append(tool_dict)
         if request.tool_choice:
             body["tool_choice"] = request.tool_choice
 

--- a/backend/app/services/translator.py
+++ b/backend/app/services/translator.py
@@ -325,6 +325,7 @@ class RequestTranslator:
                             name=func.get("name", ""),
                             description=func.get("description", ""),
                             input_schema=func.get("parameters", {}),
+                            strict=func.get("strict"),
                         )
                     )
             if bedrock_tools:


### PR DESCRIPTION
## Summary
- Tool 定义新增 `strict: true` 支持，保证 tool_use 参数 100% 符合 schema（约束解码）
- 新增 `disable_parallel_tool_use` 参数，禁止 Claude 一次返回多个 tool_use
- 两个参数均透传到 Bedrock `invoke_model` 原生 payload
- `strict` 同时支持 OpenAI 翻译路径（`function.strict` → `BedrockTool.strict`）

## 改动文件
| 文件 | 改动 |
|------|------|
| `schemas/anthropic.py` | `AnthropicToolDefinition` +strict，`AnthropicMessagesRequest` +disable_parallel_tool_use |
| `schemas/bedrock.py` | `BedrockTool` +strict |
| `services/anthropic_translator.py` | 翻译时传递 strict 和 disable_parallel_tool_use |
| `services/bedrock.py` | body 构建时包含 strict 字段 |
| `services/translator.py` | OpenAI function.strict → BedrockTool.strict |

## Test plan
- [x] `pytest` 65 passed
- [ ] 发送带 `strict: true` 的 tool 定义，确认 Bedrock 响应中 tool_use 参数符合 schema
- [ ] 发送 `disable_parallel_tool_use: true`，确认只返回单个 tool_use