### PR TITLE
feat: Vertex AI Gemini dual-channel support

### DIFF
--- a/backend/app/api/admin/endpoints/models.py
+++ b/backend/app/api/admin/endpoints/models.py
@@ -17,7 +17,7 @@ from app.core.config import get_settings
 from app.core.database import get_db
 from app.models.model import Model
 from app.services.bedrock import BedrockClient
-from app.services.gemini_client import GeminiClient
+from app.services.gemini_client import GeminiClient, is_gemini_configured
 
 router = APIRouter()
 logger = logging.getLogger(__name__)
@@ -154,10 +154,9 @@ async def list_aws_available_models(
 
         logger.info(f"Built model list from profile cache: {len(models)} models")
 
-        # Append Gemini models dynamically (only if API key is configured)
-        if settings.GEMINI_API_KEY:
+        if is_gemini_configured():
             try:
-                gemini_models = await GeminiClient.list_models(settings.GEMINI_API_KEY)
+                gemini_models = await GeminiClient.list_models()
                 models.extend(gemini_models)
                 logger.info(
                     f"Added {len(gemini_models)} Gemini models to available list"

--- a/backend/app/api/anthropic/endpoints/messages.py
+++ b/backend/app/api/anthropic/endpoints/messages.py
@@ -530,13 +530,13 @@ async def _handle_gemini_via_anthropic(
     from app.services.gemini_client import (
         GeminiClient,
         extract_cached_tokens,
+        is_gemini_configured,
     )
 
-    settings = get_settings()
-    if not settings.GEMINI_API_KEY:
+    if not is_gemini_configured():
         raise HTTPException(
             status_code=503,
-            detail="Gemini API key is not configured on this server",
+            detail="Gemini API is not configured on this server",
         )
 
     # Convert Anthropic messages to OpenAI-style messages for the Gemini
@@ -577,7 +577,6 @@ async def _handle_gemini_via_anthropic(
         return StreamingResponse(
             _stream_gemini_as_anthropic(
                 payload=payload,
-                api_key=settings.GEMINI_API_KEY,
                 request_id=request_id,
                 model=request_data.model,
                 token=token,
@@ -592,7 +591,7 @@ async def _handle_gemini_via_anthropic(
 
     # Non-streaming
     try:
-        response_data = await GeminiClient.invoke(payload, settings.GEMINI_API_KEY)
+        response_data = await GeminiClient.invoke(payload)
     except httpx.HTTPStatusError as e:
         raise HTTPException(
             status_code=e.response.status_code,
@@ -649,7 +648,6 @@ async def _handle_gemini_via_anthropic(
 
 async def _stream_gemini_as_anthropic(
     payload: dict,
-    api_key: str,
     request_id: str,
     model: str,
     token: APIToken,
@@ -679,7 +677,7 @@ async def _stream_gemini_as_anthropic(
             f"data: {_json.dumps({'type': 'message_start', 'message': {'id': request_id, 'type': 'message', 'role': 'assistant', 'content': [], 'model': model, 'usage': {'input_tokens': 0, 'output_tokens': 0}}})}\n\n"
         )
 
-        async for chunk in GeminiClient.invoke_stream(payload, api_key):
+        async for chunk in GeminiClient.invoke_stream(payload):
             for line in chunk.splitlines():
                 if not line.startswith("data: ") or line.strip() == "data: [DONE]":
                     continue

--- a/backend/app/api/gemini/endpoints/generate.py
+++ b/backend/app/api/gemini/endpoints/generate.py
@@ -11,7 +11,7 @@ import logging
 import time
 import uuid
 from decimal import Decimal
-from typing import AsyncGenerator
+from typing import AsyncGenerator, Dict
 
 import httpx
 from fastapi import APIRouter, Depends, HTTPException, Request
@@ -20,19 +20,17 @@ from sqlalchemy import select, func
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.api.deps import get_current_token_from_gemini_key
-from app.core.config import get_settings
 from app.core.database import get_db
 from app.models.model import Model
 from app.models.token import APIToken
 from app.models.usage import UsageRecord
 from app.services.background_tasks import BackgroundTaskManager
+from app.services.gemini_client import build_gemini_url_and_headers, is_gemini_configured
 from app.services.pricing import ModelPricing
 
 router = APIRouter()
 logger = logging.getLogger(__name__)
 background_tasks = BackgroundTaskManager()
-
-GEMINI_BASE_URL = "https://generativelanguage.googleapis.com/v1beta/models"
 
 
 # ---------------------------------------------------------------------------
@@ -175,9 +173,8 @@ async def generate_content(
     Authenticates using the proxy token, then forwards the raw request body
     to the real Google Gemini API and returns the response as-is.
     """
-    settings = get_settings()
-    if not settings.GEMINI_API_KEY:
-        raise HTTPException(status_code=503, detail="Gemini API key is not configured")
+    if not is_gemini_configured():
+        raise HTTPException(status_code=503, detail="Gemini API is not configured")
 
     model_name = _normalize_model(model_path)
     request_id = f"gemini-{uuid.uuid4().hex[:16]}"
@@ -192,15 +189,16 @@ async def generate_content(
 
     # Read raw body and forward
     raw_body = await request.body()
-    url = (
-        f"{GEMINI_BASE_URL}/{model_name}:generateContent?key={settings.GEMINI_API_KEY}"
+    url, extra_headers = await build_gemini_url_and_headers(
+        model_name, "generateContent"
     )
 
     try:
+        headers = {"Content-Type": "application/json", **extra_headers}
         async with httpx.AsyncClient(timeout=3600) as client:
             resp = await client.post(
                 url,
-                headers={"Content-Type": "application/json"},
+                headers=headers,
                 content=raw_body,
             )
     except httpx.TimeoutException:
@@ -266,9 +264,8 @@ async def stream_generate_content(
     Authenticates, then streams the upstream SSE response through to the
     client.  Usage is extracted from the final chunk for billing.
     """
-    settings = get_settings()
-    if not settings.GEMINI_API_KEY:
-        raise HTTPException(status_code=503, detail="Gemini API key is not configured")
+    if not is_gemini_configured():
+        raise HTTPException(status_code=503, detail="Gemini API is not configured")
 
     model_name = _normalize_model(model_path)
     request_id = f"gemini-{uuid.uuid4().hex[:16]}"
@@ -282,15 +279,16 @@ async def stream_generate_content(
     await _validate_access(token, model_name, db)
 
     raw_body = await request.body()
-    url = (
-        f"{GEMINI_BASE_URL}/{model_name}:streamGenerateContent"
-        f"?alt=sse&key={settings.GEMINI_API_KEY}"
+    url, extra_headers = await build_gemini_url_and_headers(
+        model_name, "streamGenerateContent",
     )
+    url += "&alt=sse" if "?" in url else "?alt=sse"
 
     return StreamingResponse(
         _stream_proxy(
             url=url,
             raw_body=raw_body,
+            extra_headers=extra_headers,
             model_name=model_name,
             request_id=request_id,
             token=token,
@@ -307,6 +305,7 @@ async def stream_generate_content(
 async def _stream_proxy(
     url: str,
     raw_body: bytes,
+    extra_headers: Dict[str, str],
     model_name: str,
     request_id: str,
     token: APIToken,
@@ -322,7 +321,7 @@ async def _stream_proxy(
             async with client.stream(
                 "POST",
                 url,
-                headers={"Content-Type": "application/json"},
+                headers={"Content-Type": "application/json", **extra_headers},
                 content=raw_body,
             ) as resp:
                 if resp.status_code != 200:

--- a/backend/app/api/gemini/endpoints/generate.py
+++ b/backend/app/api/gemini/endpoints/generate.py
@@ -25,7 +25,10 @@ from app.models.model import Model
 from app.models.token import APIToken
 from app.models.usage import UsageRecord
 from app.services.background_tasks import BackgroundTaskManager
-from app.services.gemini_client import build_gemini_url_and_headers, is_gemini_configured
+from app.services.gemini_client import (
+    build_gemini_url_and_headers,
+    is_gemini_configured,
+)
 from app.services.pricing import ModelPricing
 
 router = APIRouter()
@@ -280,7 +283,8 @@ async def stream_generate_content(
 
     raw_body = await request.body()
     url, extra_headers = await build_gemini_url_and_headers(
-        model_name, "streamGenerateContent",
+        model_name,
+        "streamGenerateContent",
     )
     url += "&alt=sse" if "?" in url else "?alt=sse"
 

--- a/backend/app/api/v1/endpoints/chat.py
+++ b/backend/app/api/v1/endpoints/chat.py
@@ -28,6 +28,7 @@ from app.services.background_tasks import BackgroundTaskManager
 from app.services.bedrock import BedrockClient, get_fallback_models
 from app.services.gemini_client import (
     GeminiClient,
+    is_gemini_configured,
     is_gemini_model as _is_gemini_model,
     extract_cached_tokens,
     extract_cached_tokens_from_chunk,
@@ -379,22 +380,18 @@ async def _handle_gemini_request(
     Converts OpenAI-format payload to Gemini GenerateContentRequest internally;
     all bedrock_* and OpenAI-only fields are ignored by the converter.
     """
-    settings = get_settings()
-    if not settings.GEMINI_API_KEY:
+    if not is_gemini_configured():
         raise HTTPException(
             status_code=503,
-            detail="Gemini API key is not configured on this server",
+            detail="Gemini API is not configured on this server",
         )
 
-    # Pass the full payload — GeminiClient.invoke / invoke_stream only reads
-    # the fields it understands (model, messages, temperature, etc.).
     payload = request_data.model_dump(exclude_none=True)
 
     if request_data.stream:
         return StreamingResponse(
             stream_gemini_completion(
                 payload=payload,
-                api_key=settings.GEMINI_API_KEY,
                 request_id=request_id,
                 model=request_data.model,
                 token=token,
@@ -405,7 +402,7 @@ async def _handle_gemini_request(
 
     # Non-streaming
     try:
-        response_data = await GeminiClient.invoke(payload, settings.GEMINI_API_KEY)
+        response_data = await GeminiClient.invoke(payload)
     except httpx.HTTPStatusError as e:
         logger.error(f"Gemini API error: {e}")
         raise HTTPException(
@@ -447,7 +444,6 @@ async def _handle_gemini_request(
 
 async def stream_gemini_completion(
     payload: dict,
-    api_key: str,
     request_id: str,
     model: str,
     token: APIToken,
@@ -468,7 +464,7 @@ async def stream_gemini_completion(
     last_heartbeat = time.time()
 
     try:
-        async for chunk in GeminiClient.invoke_stream(payload, api_key):
+        async for chunk in GeminiClient.invoke_stream(payload):
             current_time = time.time()
 
             # Send heartbeat if idle too long

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -59,7 +59,15 @@ class Settings(BaseSettings):
     # Google Gemini settings
     GEMINI_API_KEY: Optional[str] = Field(
         default=None,
-        description="Google Gemini API key for direct Gemini model access",
+        description="Google Gemini API key for direct Gemini model access (AI Studio)",
+    )
+    GCP_PROJECT_ID: Optional[str] = Field(
+        default=None,
+        description="Google Cloud project ID for Vertex AI Gemini access",
+    )
+    GCP_REGION: str = Field(
+        default="us-central1",
+        description="Google Cloud region for Vertex AI",
     )
 
     # AWS Bedrock settings

--- a/backend/app/services/gemini_client.py
+++ b/backend/app/services/gemini_client.py
@@ -105,6 +105,7 @@ async def build_gemini_url_and_headers(
     url = f"{GEMINI_BASE_URL}/{model_id}:{method}?key={settings.GEMINI_API_KEY}"
     return url, {}
 
+
 # Gemini finishReason → OpenAI finish_reason
 _FINISH_REASON_MAP: Dict[str, str] = {
     "STOP": "stop",
@@ -629,9 +630,7 @@ class GeminiClient:
     @classmethod
     async def _list_models_aistudio(cls, api_key: str) -> List[Dict]:
         """Fetch models from AI Studio (personal API key)."""
-        url = (
-            f"{GEMINI_BASE_URL}?key={api_key}&pageSize=100"
-        )
+        url = f"{GEMINI_BASE_URL}?key={api_key}&pageSize=100"
         models = []
 
         async with httpx.AsyncClient(timeout=30) as client:

--- a/backend/app/services/gemini_client.py
+++ b/backend/app/services/gemini_client.py
@@ -2,10 +2,15 @@
 Google Gemini API client service.
 
 Uses the native Gemini generateContent / streamGenerateContent API.
+Supports two backends:
+  1. AI Studio (personal API key) — generativelanguage.googleapis.com
+  2. Vertex AI (GCP service account) — {region}-aiplatform.googleapis.com
+
 Converts OpenAI-format requests to Gemini native format and responses back,
 so the rest of the pipeline (chat.py, usage recording) remains unchanged.
 """
 
+import asyncio
 import json
 import logging
 import re
@@ -15,10 +20,90 @@ from typing import Any, AsyncGenerator, Dict, List, Optional, Tuple
 
 import httpx
 
+from app.core.config import get_settings
+
 logger = logging.getLogger(__name__)
 
-# Google Gemini API base URL (v1beta)
+# Google Gemini API base URL (v1beta) — AI Studio
 GEMINI_BASE_URL = "https://generativelanguage.googleapis.com/v1beta/models"
+
+# --- Vertex AI token cache ---
+
+_vertex_cache: Dict[str, Any] = {
+    "credentials": None,
+    "token": None,
+    "expires_at": 0,
+}
+_vertex_lock = asyncio.Lock()
+
+
+async def _get_vertex_access_token() -> str:
+    """Get an OAuth2 access token via Application Default Credentials (ADC).
+
+    Credentials object is cached and reused; only .refresh() is called on
+    expiry.  The refresh is run in a thread to avoid blocking the event loop.
+    An asyncio.Lock prevents thundering-herd duplicate refreshes.
+    """
+    now = time.time()
+    if _vertex_cache["token"] and now < _vertex_cache["expires_at"] - 60:
+        return _vertex_cache["token"]
+
+    async with _vertex_lock:
+        now = time.time()
+        if _vertex_cache["token"] and now < _vertex_cache["expires_at"] - 60:
+            return _vertex_cache["token"]
+
+        import google.auth
+        import google.auth.transport.requests
+
+        creds = _vertex_cache["credentials"]
+        if creds is None:
+            creds, _ = google.auth.default(
+                scopes=["https://www.googleapis.com/auth/cloud-platform"]
+            )
+            _vertex_cache["credentials"] = creds
+
+        request_obj = google.auth.transport.requests.Request()
+        await asyncio.to_thread(creds.refresh, request_obj)
+
+        _vertex_cache["token"] = creds.token
+        _vertex_cache["expires_at"] = (
+            creds.expiry.timestamp() if creds.expiry else now + 3600
+        )
+        return _vertex_cache["token"]
+
+
+def _vertex_url(project: str, region: str, model_id: str, method: str) -> str:
+    """Build Vertex AI Gemini endpoint URL."""
+    return (
+        f"https://{region}-aiplatform.googleapis.com/v1/"
+        f"projects/{project}/locations/{region}/"
+        f"publishers/google/models/{model_id}:{method}"
+    )
+
+
+# --- Shared helpers ---
+
+
+def is_gemini_configured() -> bool:
+    """Return True if either AI Studio or Vertex AI is configured."""
+    settings = get_settings()
+    return bool(settings.GEMINI_API_KEY or settings.GCP_PROJECT_ID)
+
+
+async def build_gemini_url_and_headers(
+    model_id: str, method: str
+) -> Tuple[str, Dict[str, str]]:
+    """Return (url, extra_headers) for AI Studio or Vertex AI."""
+    settings = get_settings()
+    if settings.GCP_PROJECT_ID:
+        url = _vertex_url(
+            settings.GCP_PROJECT_ID, settings.GCP_REGION, model_id, method
+        )
+        token = await _get_vertex_access_token()
+        return url, {"Authorization": f"Bearer {token}"}
+    url = f"{GEMINI_BASE_URL}/{model_id}:{method}?key={settings.GEMINI_API_KEY}"
+    return url, {}
 
 # Gemini finishReason → OpenAI finish_reason
 _FINISH_REASON_MAP: Dict[str, str] = {
@@ -45,6 +130,31 @@ def _make_friendly_name(model_id: str, display_name: str) -> str:
         return display_name
     parts = model_id.replace("gemini-", "").split("-")
     return "Gemini " + " ".join(p.capitalize() for p in parts)
+
+
+_EXCLUDED_KEYWORDS = ("embed", "aqa", "retrieval")
+
+
+def _format_model_entry(model_id: str, display_name: str) -> Optional[Dict]:
+    """Validate and format a Gemini model ID into a UI-compatible dict.
+
+    Returns None if the model should be filtered out (non-Gemini-2+, embedding, etc).
+    """
+    m = re.match(r"gemini-([0-9]+)", model_id)
+    if not m or int(m.group(1)) < 2:
+        return None
+    if any(kw in model_id for kw in _EXCLUDED_KEYWORDS):
+        return None
+    friendly_name = _make_friendly_name(model_id, display_name)
+    return {
+        "model_id": model_id,
+        "model_name": friendly_name,
+        "friendly_name": friendly_name,
+        "provider": "google",
+        "is_cross_region": False,
+        "cross_region_type": None,
+        "streaming_supported": True,
+    }
 
 
 # ---------------------------------------------------------------------------
@@ -503,16 +613,24 @@ class GeminiClient:
     """Client for Google Gemini native generateContent API."""
 
     @classmethod
-    async def list_models(cls, api_key: str) -> List[Dict]:
-        """
-        Fetch available Gemini models from Google API.
+    async def list_models(cls) -> List[Dict]:
+        """Fetch available Gemini models.
 
+        Uses Vertex AI if GCP_PROJECT_ID is configured, otherwise AI Studio.
         Filters to Gemini 2+ models that support generateContent.
-        Returns list in same format as Bedrock models for UI compatibility.
         """
+        settings = get_settings()
+        if settings.GCP_PROJECT_ID:
+            return await cls._list_models_vertex(
+                settings.GCP_PROJECT_ID, settings.GCP_REGION
+            )
+        return await cls._list_models_aistudio(settings.GEMINI_API_KEY or "")
+
+    @classmethod
+    async def _list_models_aistudio(cls, api_key: str) -> List[Dict]:
+        """Fetch models from AI Studio (personal API key)."""
         url = (
-            "https://generativelanguage.googleapis.com/v1beta/models"
-            f"?key={api_key}&pageSize=100"
+            f"{GEMINI_BASE_URL}?key={api_key}&pageSize=100"
         )
         models = []
 
@@ -522,73 +640,72 @@ class GeminiClient:
                 resp.raise_for_status()
                 data = resp.json()
 
-                for model in data.get("models", []):
-                    name = model.get("name", "")  # e.g. "models/gemini-2.5-pro"
-
-                    m = re.match(r"models/gemini-([0-9]+)", name)
-                    if not m or int(m.group(1)) < 2:
+                for raw in data.get("models", []):
+                    name = raw.get("name", "")
+                    supported = raw.get("supportedGenerationMethods", [])
+                    if "generateContent" not in supported:
                         continue
-
-                    supported_methods = model.get("supportedGenerationMethods", [])
-                    if "generateContent" not in supported_methods:
-                        continue
-
-                    model_id = name[len("models/") :]
-                    if any(kw in model_id for kw in ("embed", "aqa", "retrieval")):
-                        continue
-
-                    display_name = model.get("displayName", "")
-                    friendly_name = _make_friendly_name(model_id, display_name)
-                    models.append(
-                        {
-                            "model_id": model_id,
-                            "model_name": friendly_name,
-                            "friendly_name": friendly_name,
-                            "provider": "google",
-                            "is_cross_region": False,
-                            "cross_region_type": None,
-                            "streaming_supported": True,
-                        }
-                    )
+                    model_id = name.removeprefix("models/")
+                    entry = _format_model_entry(model_id, raw.get("displayName", ""))
+                    if entry:
+                        models.append(entry)
 
                 next_token = data.get("nextPageToken")
                 url = (
-                    f"https://generativelanguage.googleapis.com/v1beta/models"
-                    f"?key={api_key}&pageSize=100&pageToken={next_token}"
+                    f"{GEMINI_BASE_URL}?key={api_key}&pageSize=100"
+                    f"&pageToken={next_token}"
                     if next_token
                     else None
                 )
 
         models.sort(key=lambda m: m["model_id"])
-        logger.info(f"Fetched {len(models)} Gemini models from Google API")
+        logger.info(f"Fetched {len(models)} Gemini models from AI Studio")
         return models
 
     @classmethod
-    async def invoke(
-        cls,
-        payload: dict,
-        api_key: str,
-    ) -> dict:
-        """
-        Non-streaming request to Gemini native :generateContent endpoint.
+    async def _list_models_vertex(cls, project: str, region: str) -> List[Dict]:
+        """Fetch models from Vertex AI."""
+        token = await _get_vertex_access_token()
+        url = (
+            f"https://{region}-aiplatform.googleapis.com/v1/"
+            f"projects/{project}/locations/{region}/publishers/google/models"
+        )
+        models = []
 
-        Converts OpenAI-format payload → Gemini GenerateContentRequest,
-        calls the API, converts the response back to OpenAI format,
-        and returns it as a plain dict.
-        """
+        async with httpx.AsyncClient(timeout=30) as client:
+            resp = await client.get(
+                url,
+                headers={"Authorization": f"Bearer {token}"},
+            )
+            resp.raise_for_status()
+            data = resp.json()
+
+            for raw in data.get("models", data.get("publisherModels", [])):
+                name = raw.get("name", "")
+                model_id = name.split("/")[-1] if "/" in name else name
+                entry = _format_model_entry(model_id, raw.get("displayName", ""))
+                if entry:
+                    models.append(entry)
+
+        models.sort(key=lambda m: m["model_id"])
+        logger.info(f"Fetched {len(models)} Gemini models from Vertex AI ({region})")
+        return models
+
+    @classmethod
+    async def invoke(cls, payload: dict) -> dict:
+        """Non-streaming request to Gemini :generateContent endpoint."""
         model = payload.get("model", "")
         model_id = model.removeprefix("models/")
-        url = f"{GEMINI_BASE_URL}/{model_id}:generateContent?key={api_key}"
-
         gemini_body = _openai_to_gemini_payload(payload)
         request_id = f"chatcmpl-{uuid.uuid4().hex}"
 
+        url, extra_headers = await build_gemini_url_and_headers(
+            model_id, "generateContent"
+        )
+        headers = {"Content-Type": "application/json", **extra_headers}
+
         async with httpx.AsyncClient(timeout=3600) as client:
-            resp = await client.post(
-                url,
-                headers={"Content-Type": "application/json"},
-                json=gemini_body,
-            )
+            resp = await client.post(url, headers=headers, json=gemini_body)
 
         if resp.status_code != 200:
             logger.error(
@@ -603,23 +720,16 @@ class GeminiClient:
         return _gemini_response_to_openai(resp.json(), model, request_id)
 
     @classmethod
-    async def invoke_stream(
-        cls,
-        payload: dict,
-        api_key: str,
-    ) -> AsyncGenerator[str, None]:
-        """
-        Streaming request to Gemini native :streamGenerateContent endpoint.
-
-        Converts OpenAI-format payload → Gemini GenerateContentRequest,
-        streams via :streamGenerateContent?alt=sse, converts each chunk to
-        OpenAI SSE format, and yields raw SSE text (including final [DONE]).
-        """
+    async def invoke_stream(cls, payload: dict) -> AsyncGenerator[str, None]:
+        """Streaming request to Gemini :streamGenerateContent endpoint."""
         model = payload.get("model", "")
         model_id = model.removeprefix("models/")
-        url = (
-            f"{GEMINI_BASE_URL}/{model_id}:streamGenerateContent?alt=sse&key={api_key}"
+
+        url, extra_headers = await build_gemini_url_and_headers(
+            model_id, "streamGenerateContent"
         )
+        url += "&alt=sse" if "?" in url else "?alt=sse"
+        headers = {"Content-Type": "application/json", **extra_headers}
 
         gemini_body = _openai_to_gemini_payload(payload)
         chunk_id = f"chatcmpl-{uuid.uuid4().hex}"
@@ -629,7 +739,7 @@ class GeminiClient:
             async with client.stream(
                 "POST",
                 url,
-                headers={"Content-Type": "application/json"},
+                headers=headers,
                 json=gemini_body,
             ) as resp:
                 if resp.status_code != 200:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,8 @@ dependencies = [
     "python-multipart>=0.0.26",
     # HTTP client
     "httpx>=0.25.0",
+    # Google Cloud (Vertex AI Gemini)
+    "google-auth>=2.25.0",
     # Background tasks
     "apscheduler>=3.10.0",
     # Email

--- a/uv.lock
+++ b/uv.lock
@@ -1024,6 +1024,19 @@ wheels = [
 ]
 
 [[package]]
+name = "google-auth"
+version = "2.49.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cryptography" },
+    { name = "pyasn1-modules" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c6/fc/e925290a1ad95c975c459e2df070fac2b90954e13a0370ac505dff78cb99/google_auth-2.49.2.tar.gz", hash = "sha256:c1ae38500e73065dcae57355adb6278cf8b5c8e391994ae9cbadbcb9631ab409", size = 333958, upload-time = "2026-04-10T00:41:21.888Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/73/76/d241a5c927433420507215df6cac1b1fa4ac0ba7a794df42a84326c68da8/google_auth-2.49.2-py3-none-any.whl", hash = "sha256:c2720924dfc82dedb962c9f52cabb2ab16714fd0a6a707e40561d217574ed6d5", size = 240638, upload-time = "2026-04-10T00:41:14.501Z" },
+]
+
+[[package]]
 name = "googleapis-common-protos"
 version = "1.73.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1392,6 +1405,7 @@ dependencies = [
     { name = "cryptography" },
     { name = "email-validator" },
     { name = "fastapi" },
+    { name = "google-auth" },
     { name = "httpx" },
     { name = "jinja2" },
     { name = "openai" },
@@ -1446,6 +1460,7 @@ requires-dist = [
     { name = "cryptography", specifier = ">=46.0.7" },
     { name = "email-validator", specifier = ">=2.3.0" },
     { name = "fastapi", specifier = ">=0.104.0" },
+    { name = "google-auth", specifier = ">=2.25.0" },
     { name = "httpx", specifier = ">=0.25.0" },
     { name = "jinja2", specifier = ">=3.1.0" },
     { name = "openai", specifier = ">=2.21.0" },
@@ -2193,6 +2208,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/5c/5f/6583902b6f79b399c9c40674ac384fd9cd77805f9e6205075f828ef11fb2/pyasn1-0.6.3.tar.gz", hash = "sha256:697a8ecd6d98891189184ca1fa05d1bb00e2f84b5977c481452050549c8a72cf", size = 148685, upload-time = "2026-03-17T01:06:53.382Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/5d/a0/7d793dce3fa811fe047d6ae2431c672364b462850c6235ae306c0efd025f/pyasn1-0.6.3-py3-none-any.whl", hash = "sha256:a80184d120f0864a52a073acc6fc642847d0be408e7c7252f31390c0f4eadcde", size = 83997, upload-time = "2026-03-17T01:06:52.036Z" },
+]
+
+[[package]]
+name = "pyasn1-modules"
+version = "0.4.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyasn1" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e9/e6/78ebbb10a8c8e4b61a59249394a4a594c1a7af95593dc933a349c8d00964/pyasn1_modules-0.4.2.tar.gz", hash = "sha256:677091de870a80aae844b1ca6134f54652fa2c8c5a52aa396440ac3106e941e6", size = 307892, upload-time = "2025-03-28T02:41:22.17Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/47/8d/d529b5d697919ba8c11ad626e835d4039be708a35b0d22de83a269a6682c/pyasn1_modules-0.4.2-py3-none-any.whl", hash = "sha256:29253a9207ce32b64c3ac6600edc75368f98473906e8fd1043bd6b5b1de2c14a", size = 181259, upload-time = "2025-03-28T02:41:19.028Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Add Vertex AI as a second Gemini backend alongside AI Studio (personal API key)
- When `GCP_PROJECT_ID` is configured, all Gemini requests route through Vertex AI using OAuth2 (ADC); otherwise falls back to AI Studio (`GEMINI_API_KEY`)
- Both text and image inputs supported on both paths

## Changes
| File | What |
|------|------|
| `config.py` | New `GCP_PROJECT_ID`, `GCP_REGION` settings |
| `gemini_client.py` | Vertex AI token cache (asyncio.Lock + to_thread), `build_gemini_url_and_headers()`, `is_gemini_configured()`, `_format_model_entry()`, removed `api_key` from public API |
| `generate.py` | Native Gemini proxy uses shared URL builder + auth headers |
| `messages.py` | Anthropic→Gemini path uses `is_gemini_configured()` |
| `chat.py` | OpenAI→Gemini path uses `is_gemini_configured()` |
| `models.py` | Model listing uses `is_gemini_configured()` + `list_models()` |
| `pyproject.toml` | Added `google-auth>=2.25.0` dependency |

## Config
```env
# Vertex AI (recommended for production)
KBR_GCP_PROJECT_ID=my-gcp-project
KBR_GCP_REGION=us-central1          # default

# AI Studio (personal, unchanged)
KBR_GEMINI_API_KEY=AIza...
```

## Test plan
- [ ] Verify existing AI Studio path still works when only `GEMINI_API_KEY` is set
- [ ] Verify Vertex AI path works when `GCP_PROJECT_ID` is set (requires GCP credentials)
- [ ] Verify model listing returns Gemini models from correct backend
- [ ] Verify text + image inputs work through both channels
- [ ] Run `pytest tests/ -x -q` — 65 tests pass