### PR TITLE
feat: implement RedisCache for token validation caching

### DIFF
--- a/backend/app/api/admin/endpoints/tokens.py
+++ b/backend/app/api/admin/endpoints/tokens.py
@@ -26,6 +26,17 @@ ALLOWED_METADATA_KEYS = {"prompt_cache_enabled", "prompt_cache_ttl"}
 ALLOWED_CACHE_TTL_VALUES = {"5m", "1h"}
 
 
+async def _invalidate_token_cache(token_hash: str) -> None:
+    try:
+        from app.core.redis import get_redis, RedisCache
+
+        redis_client = await get_redis()
+        cache = RedisCache(redis_client)
+        await cache.delete(f"token:{token_hash}")
+    except Exception:
+        pass
+
+
 def validate_token_metadata(meta: dict | None) -> dict | None:
     """Validate token_metadata keys and values."""
     if meta is None:
@@ -488,23 +499,7 @@ async def delete_token(
             detail="Access denied",
         )
 
-    # Invalidate cache before deleting
-    try:
-        from app.core.redis import get_redis, RedisCache
-        from app.core.security import hash_token
-        from app.services.token_cache import CachedTokenService
-
-        # Get plain token to calculate hash
-        plain_token = await token_service.get_plain_token(token_uuid)
-        if plain_token:
-            token_hash = hash_token(plain_token)
-            redis_client = await get_redis()
-            cache = RedisCache(redis_client)
-            cached_service = CachedTokenService(token_service.db, cache)
-            await cached_service.invalidate_token_cache(token_hash)
-    except Exception:
-        # Continue even if cache invalidation fails
-        pass
+    await _invalidate_token_cache(token.token_hash)
 
     # Delete token
     await token_service.delete_token(token_uuid)
@@ -549,6 +544,8 @@ async def revoke_token(
             status_code=status.HTTP_403_FORBIDDEN,
             detail="Access denied",
         )
+
+    await _invalidate_token_cache(token.token_hash)
 
     # Revoke token
     await token_service.revoke_token(token_uuid)

--- a/backend/app/api/deps.py
+++ b/backend/app/api/deps.py
@@ -3,6 +3,7 @@ API dependencies for authentication and authorization.
 Provides dependency injection for database sessions, current user, and token validation.
 """
 
+from typing import Optional
 from uuid import UUID
 
 from fastapi import Depends, Header, HTTPException, Request, status
@@ -19,6 +20,22 @@ from app.services.audit_log import AuditLogService
 from app.services.auth import AuthService
 from app.services.refresh_token import RefreshTokenService
 from app.services.token import TokenService
+
+
+async def _validate_token_with_cache(
+    token_service: TokenService, plain_token: str
+) -> Optional[APIToken]:
+    try:
+        from app.core.redis import get_redis, RedisCache
+        from app.services.token_cache import CachedTokenService
+
+        redis_client = await get_redis()
+        cache = RedisCache(redis_client)
+        cached_service = CachedTokenService(token_service, cache)
+        return await cached_service.validate_token_cached(plain_token=plain_token)
+    except Exception:
+        return await token_service.validate_token(plain_token=plain_token)
+
 
 # HTTP Bearer token scheme
 security = HTTPBearer()
@@ -120,24 +137,7 @@ async def get_current_token(
         HTTPException: If token is invalid or access is denied
     """
     plain_token = credentials.credentials
-
-    # Try to use cached validation if Redis is available
-    try:
-        from app.core.redis import get_redis, RedisCache
-        from app.services.token_cache import CachedTokenService
-
-        redis_client = await get_redis()
-        cache = RedisCache(redis_client)
-        cached_service = CachedTokenService(token_service.db, cache)
-
-        token = await cached_service.validate_token_cached(
-            plain_token=plain_token,
-        )
-    except Exception:
-        # Fallback to non-cached validation if Redis unavailable
-        token = await token_service.validate_token(
-            plain_token=plain_token,
-        )
+    token = await _validate_token_with_cache(token_service, plain_token)
 
     if not token:
         raise HTTPException(
@@ -174,17 +174,7 @@ async def get_current_token_flexible(
             detail="Missing API key. Provide via Authorization: Bearer or x-api-key header.",
         )
 
-    # Validate token (same logic as other auth deps)
-    try:
-        from app.core.redis import get_redis, RedisCache
-        from app.services.token_cache import CachedTokenService
-
-        redis_client = await get_redis()
-        cache = RedisCache(redis_client)
-        cached_service = CachedTokenService(token_service.db, cache)
-        token = await cached_service.validate_token_cached(plain_token=api_key)
-    except Exception:
-        token = await token_service.validate_token(plain_token=api_key)
+    token = await _validate_token_with_cache(token_service, api_key)
 
     if not token:
         raise HTTPException(
@@ -216,25 +206,7 @@ async def get_current_token_from_api_key(
     Raises:
         HTTPException: If token is invalid or access is denied
     """
-    plain_token = x_api_key
-
-    # Try to use cached validation if Redis is available
-    try:
-        from app.core.redis import get_redis, RedisCache
-        from app.services.token_cache import CachedTokenService
-
-        redis_client = await get_redis()
-        cache = RedisCache(redis_client)
-        cached_service = CachedTokenService(token_service.db, cache)
-
-        token = await cached_service.validate_token_cached(
-            plain_token=plain_token,
-        )
-    except Exception:
-        # Fallback to non-cached validation if Redis unavailable
-        token = await token_service.validate_token(
-            plain_token=plain_token,
-        )
+    token = await _validate_token_with_cache(token_service, x_api_key)
 
     if not token:
         raise HTTPException(
@@ -280,17 +252,7 @@ async def get_current_token_from_gemini_key(
             detail="Missing API key. Provide via ?key= query parameter or x-goog-api-key header.",
         )
 
-    # Validate (same logic as other auth deps)
-    try:
-        from app.core.redis import get_redis, RedisCache
-        from app.services.token_cache import CachedTokenService
-
-        redis_client = await get_redis()
-        cache = RedisCache(redis_client)
-        cached_service = CachedTokenService(token_service.db, cache)
-        token = await cached_service.validate_token_cached(plain_token=plain_token)
-    except Exception:
-        token = await token_service.validate_token(plain_token=plain_token)
+    token = await _validate_token_with_cache(token_service, plain_token)
 
     if not token:
         raise HTTPException(

--- a/backend/app/core/redis.py
+++ b/backend/app/core/redis.py
@@ -5,8 +5,9 @@ Provides async Redis connection management with graceful degradation
 when Redis is unavailable.
 """
 
+import json
 import logging
-from typing import Optional
+from typing import Any, Optional
 
 import redis.asyncio as aioredis
 
@@ -25,12 +26,7 @@ async def get_redis() -> Optional[aioredis.Redis]:
     global _redis_client
 
     if _redis_client is not None:
-        try:
-            await _redis_client.ping()
-            return _redis_client
-        except Exception:
-            logger.warning("Redis connection lost, attempting reconnect")
-            _redis_client = None
+        return _redis_client
 
     settings = get_settings()
     if not settings.REDIS_URL:
@@ -60,3 +56,28 @@ async def close_redis() -> None:
         await _redis_client.close()
         _redis_client = None
         logger.info("Redis connection closed")
+
+
+class RedisCache:
+    """Thin wrapper over an async Redis client with JSON serialization."""
+
+    def __init__(self, client: Optional[aioredis.Redis]):
+        self._client = client
+
+    async def get(self, key: str) -> Optional[Any]:
+        if self._client is None:
+            return None
+        raw = await self._client.get(key)
+        if raw is None:
+            return None
+        return json.loads(raw)
+
+    async def set(self, key: str, value: Any, expire: int = 300) -> None:
+        if self._client is None:
+            return
+        await self._client.set(key, json.dumps(value), ex=expire)
+
+    async def delete(self, key: str) -> None:
+        if self._client is None:
+            return
+        await self._client.delete(key)

--- a/backend/app/services/token_cache.py
+++ b/backend/app/services/token_cache.py
@@ -4,8 +4,6 @@ import logging
 from typing import Optional
 from uuid import UUID
 
-from sqlalchemy.ext.asyncio import AsyncSession
-
 from app.core.redis import RedisCache
 from app.models.token import APIToken
 from app.services.token import TokenService
@@ -19,10 +17,9 @@ class CachedTokenService:
     CACHE_TTL = 300  # 5 minutes
     CACHE_KEY_PREFIX = "token:"
 
-    def __init__(self, db: AsyncSession, cache: RedisCache):
-        self.db = db
+    def __init__(self, token_service: TokenService, cache: RedisCache):
         self.cache = cache
-        self.token_service = TokenService(db)
+        self.token_service = token_service
 
     def _get_cache_key(self, token_hash: str) -> str:
         """Generate cache key for token."""


### PR DESCRIPTION
## Summary
- Implement `RedisCache` class in `redis.py` with JSON serialization and graceful degradation when client is `None`
- Extract `_validate_token_with_cache()` helper in `deps.py` to deduplicate 4 identical Redis cache blocks
- Extract `_invalidate_token_cache()` helper in `tokens.py`, use `token.token_hash` directly instead of DB read + decrypt + rehash
- Fix missing cache invalidation on `revoke_token` (previously only `delete_token` cleared cache)
- Reuse injected `TokenService` in `CachedTokenService` instead of re-instantiating
- Remove per-request `ping()` from `get_redis()` singleton to reduce hot-path overhead

Net: -23 lines, 4 files changed.

## Test plan
- [ ] Verify token auth works without Redis configured (graceful fallback)
- [ ] Verify token auth works with Redis configured (cache hit/miss)
- [ ] Verify revoked token is immediately rejected (cache invalidated)
- [ ] Verify deleted token is immediately rejected (cache invalidated)
- [ ] Confirm no regression on all 4 auth paths (Bearer, x-api-key, flexible, Gemini key)