### PR TITLE
fix: support Bearer auth in Anthropic messages endpoint

### DIFF
--- a/backend/app/api/anthropic/endpoints/messages.py
+++ b/backend/app/api/anthropic/endpoints/messages.py
@@ -12,7 +12,7 @@ from fastapi import APIRouter, Depends, HTTPException, Request
 from fastapi.responses import StreamingResponse
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.api.deps import get_current_token_from_api_key
+from app.api.deps import get_current_token_flexible
 from app.core.config import get_settings
 from app.core.database import get_db
 from app.models.token import APIToken
@@ -38,7 +38,7 @@ background_tasks = BackgroundTaskManager()
 async def create_message(
     request_data: AnthropicMessagesRequest,
     http_request: Request,
-    token: APIToken = Depends(get_current_token_from_api_key),
+    token: APIToken = Depends(get_current_token_flexible),
     db: AsyncSession = Depends(get_db),
 ):
     """


### PR DESCRIPTION
## Summary
- Switch messages endpoint auth from strict `x-api-key` header to flexible auth (`get_current_token_flexible`)
- Fixes 422 errors from Claude Desktop Gateway which sends `Authorization: Bearer` instead of `x-api-key`
- No impact on existing clients — `x-api-key` is still checked first

## Test plan
- [ ] Verify Claude Desktop Gateway can call `/v1/messages` with Bearer token
- [ ] Verify existing Anthropic SDK clients with `x-api-key` still work
- [ ] Verify requests without any auth return 401

🤖 Generated with [Claude Code](https://claude.com/claude-code)