### PR TITLE
fix: WAF rate limit covers all protocols and reduce KnownBadInputs false positives

### DIFF
--- a/iac/README.md
+++ b/iac/README.md
@@ -92,7 +92,7 @@ No resources.
 | <a name="input_waf_api_alb_name"></a> [waf\_api\_alb\_name](#input\_waf\_api\_alb\_name) | Name of the API ALB for WAF association (auto-discovery) | `string` | `"kolya-br-proxy-api-alb"` | no |
 | <a name="input_waf_frontend_alb_name"></a> [waf\_frontend\_alb\_name](#input\_waf\_frontend\_alb\_name) | Name of the frontend ALB for WAF association (auto-discovery) | `string` | `"kolya-br-proxy-frontend-alb"` | no |
 | <a name="input_waf_rate_limit_auth"></a> [waf\_rate\_limit\_auth](#input\_waf\_rate\_limit\_auth) | WAF rate limit per IP for /admin/auth/* (requests per 5 minutes) | `number` | `20` | no |
-| <a name="input_waf_rate_limit_chat"></a> [waf\_rate\_limit\_chat](#input\_waf\_rate\_limit\_chat) | WAF rate limit per IP for /v1/chat/completions (requests per 5 minutes) | `number` | `300` | no |
+| <a name="input_waf_rate_limit_chat"></a> [waf\_rate\_limit\_chat](#input\_waf\_rate\_limit\_chat) | WAF rate limit per IP for inference endpoints: /v1/chat/completions, /v1/messages, /v1beta/models/ (requests per 5 minutes) | `number` | `300` | no |
 | <a name="input_waf_rate_limit_global"></a> [waf\_rate\_limit\_global](#input\_waf\_rate\_limit\_global) | WAF global rate limit per IP (requests per 5 minutes) | `number` | `2000` | no |
 
 ## Outputs

--- a/iac/modules/waf/README.md
+++ b/iac/modules/waf/README.md
@@ -39,7 +39,7 @@ No modules.
 | <a name="input_frontend_alb_name"></a> [frontend\_alb\_name](#input\_frontend\_alb\_name) | Name of the frontend ALB for auto-discovery | `string` | `"kolya-br-proxy-frontend-alb"` | no |
 | <a name="input_project_name_alias"></a> [project\_name\_alias](#input\_project\_name\_alias) | The short name of the project | `string` | n/a | yes |
 | <a name="input_rate_limit_auth"></a> [rate\_limit\_auth](#input\_rate\_limit\_auth) | Rate limit per IP for /admin/auth/* (requests per 5 minutes) | `number` | `20` | no |
-| <a name="input_rate_limit_chat"></a> [rate\_limit\_chat](#input\_rate\_limit\_chat) | Rate limit per IP for /v1/chat/completions (requests per 5 minutes) | `number` | `300` | no |
+| <a name="input_rate_limit_chat"></a> [rate\_limit\_chat](#input\_rate\_limit\_chat) | Rate limit per IP for inference endpoints: /v1/chat/completions, /v1/messages, /v1beta/models/ (requests per 5 minutes) | `number` | `300` | no |
 | <a name="input_rate_limit_global"></a> [rate\_limit\_global](#input\_rate\_limit\_global) | Global rate limit per IP (requests per 5 minutes) | `number` | `2000` | no |
 | <a name="input_workspace"></a> [workspace](#input\_workspace) | The workspace/environment name | `string` | n/a | yes |
 

--- a/iac/modules/waf/main.tf
+++ b/iac/modules/waf/main.tf
@@ -57,9 +57,10 @@ resource "aws_wafv2_web_acl" "main" {
     }
   }
 
-  # Rule 2: Rate limit on /v1/chat/completions
+  # Rule 2: Rate limit on all inference endpoints
+  # /v1/chat/completions (OpenAI), /v1/messages (Anthropic), /v1beta/models/ (Gemini)
   rule {
-    name     = "rate-limit-chat"
+    name     = "rate-limit-inference"
     priority = 2
 
     action {
@@ -72,17 +73,53 @@ resource "aws_wafv2_web_acl" "main" {
         aggregate_key_type = "IP"
 
         scope_down_statement {
-          byte_match_statement {
-            search_string         = "/v1/chat/completions"
-            positional_constraint = "STARTS_WITH"
+          or_statement {
+            statement {
+              byte_match_statement {
+                search_string         = "/v1/chat/completions"
+                positional_constraint = "STARTS_WITH"
 
-            field_to_match {
-              uri_path {}
+                field_to_match {
+                  uri_path {}
+                }
+
+                text_transformation {
+                  priority = 0
+                  type     = "LOWERCASE"
+                }
+              }
             }
 
-            text_transformation {
-              priority = 0
-              type     = "LOWERCASE"
+            statement {
+              byte_match_statement {
+                search_string         = "/v1/messages"
+                positional_constraint = "STARTS_WITH"
+
+                field_to_match {
+                  uri_path {}
+                }
+
+                text_transformation {
+                  priority = 0
+                  type     = "LOWERCASE"
+                }
+              }
+            }
+
+            statement {
+              byte_match_statement {
+                search_string         = "/v1beta/models/"
+                positional_constraint = "STARTS_WITH"
+
+                field_to_match {
+                  uri_path {}
+                }
+
+                text_transformation {
+                  priority = 0
+                  type     = "LOWERCASE"
+                }
+              }
             }
           }
         }
@@ -91,7 +128,7 @@ resource "aws_wafv2_web_acl" "main" {
 
     visibility_config {
       cloudwatch_metrics_enabled = true
-      metric_name                = "${var.project_name_alias}-rate-limit-chat"
+      metric_name                = "${var.project_name_alias}-rate-limit-inference"
       sampled_requests_enabled   = true
     }
   }
@@ -146,6 +183,8 @@ resource "aws_wafv2_web_acl" "main" {
   }
 
   # Rule 4: AWS Managed - Known Bad Inputs
+  # LLM request bodies contain code snippets and security-related keywords
+  # (e.g. "${jndi:", "FORBIDDEN", "BLOCKED") that trigger false positives.
   rule {
     name     = "aws-managed-known-bad-inputs"
     priority = 4
@@ -158,6 +197,20 @@ resource "aws_wafv2_web_acl" "main" {
       managed_rule_group_statement {
         name        = "AWSManagedRulesKnownBadInputsRuleSet"
         vendor_name = "AWS"
+
+        rule_action_override {
+          name = "Log4JRCE_BODY"
+          action_to_use {
+            count {}
+          }
+        }
+
+        rule_action_override {
+          name = "JavaDeserializationRCE_BODY"
+          action_to_use {
+            count {}
+          }
+        }
       }
     }
 

--- a/iac/modules/waf/variables.tf
+++ b/iac/modules/waf/variables.tf
@@ -47,7 +47,7 @@ variable "rate_limit_auth" {
 }
 
 variable "rate_limit_chat" {
-  description = "Rate limit per IP for /v1/chat/completions (requests per 5 minutes)"
+  description = "Rate limit per IP for inference endpoints: /v1/chat/completions, /v1/messages, /v1beta/models/ (requests per 5 minutes)"
   type        = number
   default     = 300
 }

--- a/iac/variables.tf
+++ b/iac/variables.tf
@@ -141,7 +141,7 @@ variable "waf_rate_limit_auth" {
 }
 
 variable "waf_rate_limit_chat" {
-  description = "WAF rate limit per IP for /v1/chat/completions (requests per 5 minutes)"
+  description = "WAF rate limit per IP for inference endpoints: /v1/chat/completions, /v1/messages, /v1beta/models/ (requests per 5 minutes)"
   type        = number
   default     = 300
 }


### PR DESCRIPTION
## Summary
- **Rate limit covers all inference protocols**: Extend `rate-limit-chat` rule to `rate-limit-inference` using `or_statement` to cover all three inference endpoints: `/v1/chat/completions` (OpenAI), `/v1/messages` (Anthropic), `/v1beta/models/` (Gemini)
- **Fix KnownBadInputsRuleSet false positives**: Add `count` override for `Log4JRCE_BODY` and `JavaDeserializationRCE_BODY` to prevent LLM system prompts containing security-related keywords (e.g. `${jndi:`, `FORBIDDEN`, `BLOCKED`) from triggering WAF 403 blocks
- **Root cause**: Prometheus Agent's ~41K char system prompt contains security instructions and code examples, which `AWSManagedRulesKnownBadInputsRuleSet` misidentifies as attack payloads

## Test plan
- [ ] `terraform plan` confirms expected changes (rule rename + new overrides)
- [ ] After apply, verify OpenCode Prometheus Agent no longer returns 403
- [ ] Verify `rate-limit-inference` CloudWatch metric records correctly
- [ ] Confirm `Log4JRCE_BODY` match events are logged in count mode (not blocked)