### PR TITLE
fix: override GenericLFI_BODY in WAF to unblock LLM agent requests

### DIFF
--- a/iac/modules/waf/main.tf
+++ b/iac/modules/waf/main.tf
@@ -134,9 +134,10 @@ resource "aws_wafv2_web_acl" "main" {
   }
 
   # Rule 3: AWS Managed - Common Rule Set (SQLi, XSS, etc.)
-  # Certain rules are excluded for /v1/chat/completions because:
+  # Certain rules are excluded because LLM agent request bodies contain:
   # - SizeRestrictions_BODY: Agent requests with tools + conversation history exceed 8KB
   # - CrossSiteScripting_BODY: Code snippets in messages trigger XSS false positives
+  # - GenericLFI_BODY: System prompts with file path examples (../../) trigger LFI false positives
   # - NoUserAgent_HEADER: Some SDK clients don't send User-Agent
   # The API path is already protected by Bearer token auth + per-IP rate limiting.
   rule {
@@ -161,6 +162,13 @@ resource "aws_wafv2_web_acl" "main" {
 
         rule_action_override {
           name = "CrossSiteScripting_BODY"
+          action_to_use {
+            count {}
+          }
+        }
+
+        rule_action_override {
+          name = "GenericLFI_BODY"
           action_to_use {
             count {}
           }


### PR DESCRIPTION
## Summary
- Override `GenericLFI_BODY` rule in `AWSManagedRulesCommonRuleSet` to count mode
- Root cause confirmed via `aws wafv2 get-sampled-requests`: OpenCode Prometheus agent requests (~157KB body) were being **BLOCK**ed by `GenericLFI_BODY` because system prompts contain file path patterns like `../../` that trigger LFI detection
- This was the actual cause of the 403 Forbidden from `awselb/2.0` — requests never reached the backend pods

## Evidence from WAF sampled requests
```
07:19:20 | BLOCK | POST /v1/chat/completions | CL=156976 | opencode/1.14.22 | GenericLFI_BODY
07:24:12 | BLOCK | POST /v1/chat/completions | CL=157046 | opencode/1.14.22 | GenericLFI_BODY
```

## Test plan
- [ ] `terraform plan` confirms only the new rule_action_override is added
- [ ] After apply, verify OpenCode Prometheus Agent no longer returns 403
- [ ] Confirm `GenericLFI_BODY` matches are logged as COUNT in CloudWatch (not blocked)