### PR TITLE
fix: exclude GenericLFI_BODY WAF rule for LLM agent requests

### DIFF
--- a/iac/modules/waf/main.tf
+++ b/iac/modules/waf/main.tf
@@ -134,9 +134,10 @@ resource "aws_wafv2_web_acl" "main" {
   }
 
   # Rule 3: AWS Managed - Common Rule Set (SQLi, XSS, etc.)
-  # Certain rules are excluded for /v1/chat/completions because:
+  # Certain rules are excluded because LLM agent request bodies contain:
   # - SizeRestrictions_BODY: Agent requests with tools + conversation history exceed 8KB
   # - CrossSiteScripting_BODY: Code snippets in messages trigger XSS false positives
+  # - GenericLFI_BODY: System prompts with file path examples (../../) trigger LFI false positives
   # - NoUserAgent_HEADER: Some SDK clients don't send User-Agent
   # The API path is already protected by Bearer token auth + per-IP rate limiting.
   rule {
@@ -161,6 +162,13 @@ resource "aws_wafv2_web_acl" "main" {
 
         rule_action_override {
           name = "CrossSiteScripting_BODY"
+          action_to_use {
+            count {}
+          }
+        }
+
+        rule_action_override {
+          name = "GenericLFI_BODY"
           action_to_use {
             count {}
           }


### PR DESCRIPTION
## Summary
- Add `GenericLFI_BODY` rule override (count mode) to `AWSManagedRulesCommonRuleSet` in WAF configuration
- LLM agent system prompts contain file path patterns like `../../` that trigger the Generic Local File Inclusion detection rule, causing legitimate inference requests to be blocked with 403 Forbidden
- Confirmed root cause via `aws wafv2 get-sampled-requests`: OpenCode agent requests (157KB body) were being blocked by `GenericLFI_BODY`

## Test plan
- [x] Confirmed fix via WAF sampled requests analysis
- [x] Verified OpenCode Prometheus agent requests now succeed through proxy
- [ ] Apply Terraform and verify WAF rule change in AWS console