### PR TITLE
fix: resolve 3 GitHub security alerts

### DIFF
--- a/backend/app/api/anthropic/endpoints/messages.py
+++ b/backend/app/api/anthropic/endpoints/messages.py
@@ -249,7 +249,7 @@ async def create_message(
         raise HTTPException(status_code=400, detail="Invalid request")
     except ClientError as e:
         error_code = e.response.get("Error", {}).get("Code", "Unknown")
-        error_message = e.response.get("Error", {}).get("Message", str(e))
+        error_message = e.response.get("Error", {}).get("Message", "")
         logger.error(
             f"Bedrock error: model={request_data.model}, request_id={request_id}, "
             f"code={error_code}, message={error_message}",
@@ -261,10 +261,17 @@ async def create_message(
             "ModelNotReadyException": 529,
             "ServiceUnavailableException": 529,
         }
+        safe_messages = {
+            "ValidationException": "Invalid request parameters",
+            "AccessDeniedException": "Access denied to the requested model",
+            "ThrottlingException": "Rate limit exceeded, please retry later",
+            "ModelNotReadyException": "Model is temporarily unavailable",
+            "ServiceUnavailableException": "Service temporarily unavailable",
+        }
         status_code = status_map.get(error_code, 502)
         raise HTTPException(
             status_code=status_code,
-            detail=error_message,
+            detail=safe_messages.get(error_code, "Upstream service error"),
         )
     except Exception as e:
         logger.error(
@@ -407,7 +414,7 @@ async def stream_anthropic_messages(
 
     except ClientError as e:
         error_code = e.response.get("Error", {}).get("Code", "Unknown")
-        error_message = e.response.get("Error", {}).get("Message", str(e))
+        error_message = e.response.get("Error", {}).get("Message", "")
         logger.error(
             f"Bedrock streaming error: model={model}, request_id={request_id}, "
             f"code={error_code}, message={error_message}",
@@ -421,10 +428,20 @@ async def stream_anthropic_messages(
             "ModelNotReadyException": "overloaded_error",
             "ServiceUnavailableException": "overloaded_error",
         }
+        safe_messages = {
+            "ValidationException": "Invalid request parameters",
+            "AccessDeniedException": "Access denied to the requested model",
+            "ThrottlingException": "Rate limit exceeded, please retry later",
+            "ModelNotReadyException": "Model is temporarily unavailable",
+            "ServiceUnavailableException": "Service temporarily unavailable",
+        }
         error_type = error_type_map.get(error_code, "api_error")
         error_data = {
             "type": "error",
-            "error": {"type": error_type, "message": error_message},
+            "error": {
+                "type": error_type,
+                "message": safe_messages.get(error_code, "Upstream service error"),
+            },
         }
         yield f"event: error\ndata: {_json.dumps(error_data)}\n\n"
     except Exception as e:

--- a/backend/app/api/v1/endpoints/chat.py
+++ b/backend/app/api/v1/endpoints/chat.py
@@ -337,10 +337,10 @@ async def create_chat_completion(
             },
             exc_info=True,
         )
-        raise HTTPException(status_code=400, detail=str(e))
+        raise HTTPException(status_code=400, detail="Invalid request")
     except ClientError as e:
         error_code = e.response.get("Error", {}).get("Code", "Unknown")
-        error_message = e.response.get("Error", {}).get("Message", str(e))
+        error_message = e.response.get("Error", {}).get("Message", "")
         logger.error(
             f"Bedrock error: model={request_data.model}, request_id={request_id}, "
             f"code={error_code}, message={error_message}",
@@ -352,10 +352,17 @@ async def create_chat_completion(
             "ModelNotReadyException": 503,
             "ServiceUnavailableException": 503,
         }
+        safe_messages = {
+            "ValidationException": "Invalid request parameters",
+            "AccessDeniedException": "Access denied to the requested model",
+            "ThrottlingException": "Rate limit exceeded, please retry later",
+            "ModelNotReadyException": "Model is temporarily unavailable",
+            "ServiceUnavailableException": "Service temporarily unavailable",
+        }
         status_code = status_map.get(error_code, 502)
         raise HTTPException(
             status_code=status_code,
-            detail=error_message,
+            detail=safe_messages.get(error_code, "Upstream service error"),
         )
     except Exception as e:
         logger.error(
@@ -407,7 +414,7 @@ async def _handle_gemini_request(
         logger.error(f"Gemini API error: {e}")
         raise HTTPException(
             status_code=e.response.status_code,
-            detail=f"Gemini API error: {str(e)[:200]}",
+            detail=f"Gemini API error: status {e.response.status_code}",
         )
 
     # Extract usage including cached tokens for auto-cache billing
@@ -503,7 +510,7 @@ async def stream_gemini_completion(
         )
         error_response = ErrorResponse(
             error=ErrorDetail(
-                message=f"Gemini API error: {str(e)[:200]}",
+                message=f"Gemini API error: status {e.response.status_code}",
                 type="server_error",
                 code=str(e.response.status_code),
             )
@@ -516,7 +523,7 @@ async def stream_gemini_completion(
         )
         error_response = ErrorResponse(
             error=ErrorDetail(
-                message=str(e),
+                message="Internal server error",
                 type="server_error",
                 code="internal_error",
             )
@@ -795,14 +802,21 @@ async def stream_chat_completion(
 
     except ClientError as e:
         error_code = e.response.get("Error", {}).get("Code", "Unknown")
-        error_message = e.response.get("Error", {}).get("Message", str(e))
+        error_message = e.response.get("Error", {}).get("Message", "")
         logger.error(
             f"Bedrock streaming error: model={model}, request_id={request_id}, "
             f"code={error_code}, message={error_message}",
         )
+        safe_messages = {
+            "ValidationException": "Invalid request parameters",
+            "AccessDeniedException": "Access denied to the requested model",
+            "ThrottlingException": "Rate limit exceeded, please retry later",
+            "ModelNotReadyException": "Model is temporarily unavailable",
+            "ServiceUnavailableException": "Service temporarily unavailable",
+        }
         error_response = ErrorResponse(
             error=ErrorDetail(
-                message=error_message,
+                message=safe_messages.get(error_code, "Upstream service error"),
                 type=error_code,
                 code=error_code,
             )
@@ -813,10 +827,9 @@ async def stream_chat_completion(
             f"Streaming failed: model={model}, request_id={request_id}, error={e}",
             exc_info=True,
         )
-        # Send error in SSE format
         error_response = ErrorResponse(
             error=ErrorDetail(
-                message=str(e),
+                message="Internal server error",
                 type="server_error",
                 code="internal_error",
             )

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -6367,9 +6367,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.8",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
-      "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
+      "version": "8.5.10",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.10.tgz",
+      "integrity": "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==",
       "funding": [
         {
           "type": "opencollective",

--- a/kolya-br-proxy-arch/package.json
+++ b/kolya-br-proxy-arch/package.json
@@ -74,7 +74,7 @@
     "globals": "^16.5.0",
     "parcel": "^2.16.4",
     "parcel-resolver-tspaths": "^0.0.9",
-    "postcss": "^8.5.6",
+    "postcss": "^8.5.10",
     "tailwindcss": "3.4.1",
     "tailwindcss-animate": "^1.0.7",
     "typescript": "~5.9.3",

--- a/kolya-br-proxy-arch/pnpm-lock.yaml
+++ b/kolya-br-proxy-arch/pnpm-lock.yaml
@@ -162,7 +162,7 @@ importers:
         version: 5.1.4(vite@7.3.2(@types/node@24.11.0)(jiti@1.21.7)(lightningcss@1.31.1)(yaml@2.8.2))
       autoprefixer:
         specifier: ^10.4.27
-        version: 10.4.27(postcss@8.5.6)
+        version: 10.4.27(postcss@8.5.10)
       eslint:
         specifier: ^9.39.1
         version: 9.39.3(jiti@1.21.7)
@@ -182,8 +182,8 @@ importers:
         specifier: ^0.0.9
         version: 0.0.9(parcel@2.16.4(@swc/helpers@0.5.19))
       postcss:
-        specifier: ^8.5.6
-        version: 8.5.6
+        specifier: ^8.5.10
+        version: 8.5.10
       tailwindcss:
         specifier: 3.4.1
         version: 3.4.1
@@ -2665,8 +2665,8 @@ packages:
   postcss-value-parser@4.2.0:
     resolution: {integrity: sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==}
 
-  postcss@8.5.6:
-    resolution: {integrity: sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==}
+  postcss@8.5.10:
+    resolution: {integrity: sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==}
     engines: {node: ^10 || ^12 || >=14}
 
   prelude-ls@1.2.1:
@@ -5006,13 +5006,13 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
-  autoprefixer@10.4.27(postcss@8.5.6):
+  autoprefixer@10.4.27(postcss@8.5.10):
     dependencies:
       browserslist: 4.28.1
       caniuse-lite: 1.0.30001775
       fraction.js: 5.3.4
       picocolors: 1.1.1
-      postcss: 8.5.6
+      postcss: 8.5.10
       postcss-value-parser: 4.2.0
 
   balanced-match@1.0.2: {}
@@ -5631,28 +5631,28 @@ snapshots:
 
   pirates@4.0.7: {}
 
-  postcss-import@15.1.0(postcss@8.5.6):
+  postcss-import@15.1.0(postcss@8.5.10):
     dependencies:
-      postcss: 8.5.6
+      postcss: 8.5.10
       postcss-value-parser: 4.2.0
       read-cache: 1.0.0
       resolve: 1.22.11
 
-  postcss-js@4.1.0(postcss@8.5.6):
+  postcss-js@4.1.0(postcss@8.5.10):
     dependencies:
       camelcase-css: 2.0.1
-      postcss: 8.5.6
+      postcss: 8.5.10
 
-  postcss-load-config@4.0.2(postcss@8.5.6):
+  postcss-load-config@4.0.2(postcss@8.5.10):
     dependencies:
       lilconfig: 3.1.3
       yaml: 2.8.2
     optionalDependencies:
-      postcss: 8.5.6
+      postcss: 8.5.10
 
-  postcss-nested@6.2.0(postcss@8.5.6):
+  postcss-nested@6.2.0(postcss@8.5.10):
     dependencies:
-      postcss: 8.5.6
+      postcss: 8.5.10
       postcss-selector-parser: 6.1.2
 
   postcss-selector-parser@6.1.2:
@@ -5662,7 +5662,7 @@ snapshots:
 
   postcss-value-parser@4.2.0: {}
 
-  postcss@8.5.6:
+  postcss@8.5.10:
     dependencies:
       nanoid: 3.3.11
       picocolors: 1.1.1
@@ -5845,11 +5845,11 @@ snapshots:
       normalize-path: 3.0.0
       object-hash: 3.0.0
       picocolors: 1.1.1
-      postcss: 8.5.6
-      postcss-import: 15.1.0(postcss@8.5.6)
-      postcss-js: 4.1.0(postcss@8.5.6)
-      postcss-load-config: 4.0.2(postcss@8.5.6)
-      postcss-nested: 6.2.0(postcss@8.5.6)
+      postcss: 8.5.10
+      postcss-import: 15.1.0(postcss@8.5.10)
+      postcss-js: 4.1.0(postcss@8.5.10)
+      postcss-load-config: 4.0.2(postcss@8.5.10)
+      postcss-nested: 6.2.0(postcss@8.5.10)
       postcss-selector-parser: 6.1.2
       resolve: 1.22.11
       sucrase: 3.35.1
@@ -5951,7 +5951,7 @@ snapshots:
       esbuild: 0.27.7
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
-      postcss: 8.5.6
+      postcss: 8.5.10
       rollup: 4.60.1
       tinyglobby: 0.2.15
     optionalDependencies:


### PR DESCRIPTION
## Summary

Resolves all 3 open alerts on the **Security and quality** tab:

- **Code Scanning #2** (`py/stack-trace-exposure`) — Bedrock `ClientError` and generic exceptions were leaking internal AWS details (Account ID, IAM Role ARN, error messages) to API clients via `str(e)`. Replaced with safe fixed messages in both Anthropic and OpenAI endpoints (streaming + non-streaming).
- **Dependabot #49 & #50** — Upgrade `postcss` to 8.5.10 in both `frontend/` (npm) and `kolya-br-proxy-arch/` (pnpm) to fix XSS via unescaped `</style>` in CSS stringify output.

## Changes

| File | What changed |
|------|-------------|
| `backend/app/api/anthropic/endpoints/messages.py` | Use `safe_messages` dict instead of raw `error_message` / `str(e)` in error responses |
| `backend/app/api/v1/endpoints/chat.py` | Same — 6 places sanitized across non-streaming, streaming, Bedrock, and Gemini paths |
| `frontend/package-lock.json` | postcss 8.5.8 → 8.5.10 |
| `kolya-br-proxy-arch/package.json` | postcss ^8.5.6 → ^8.5.10 |
| `kolya-br-proxy-arch/pnpm-lock.yaml` | postcss 8.5.6 → 8.5.10 |

## Test plan

- [ ] Verify Anthropic `/v1/messages` returns generic error on invalid model (not AWS ARN details)
- [ ] Verify OpenAI `/v1/chat/completions` returns generic error on Bedrock failure
- [ ] Verify streaming errors also use sanitized messages
- [ ] Confirm `npm audit` / `pnpm audit` show no postcss vulnerabilities
- [ ] Check GitHub Security tab shows 0 open alerts after merge