### PR TITLE
feat: teams, monthly quota, Opus 4.7, UI polish

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -101,3 +101,4 @@ npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
 .gitnexus
+kolya-br-proxy-arch/graphify-out/

--- a/backend/alembic/versions/f7g8h9i0j1k2_add_monthly_daily_quota.py
+++ b/backend/alembic/versions/f7g8h9i0j1k2_add_monthly_daily_quota.py
@@ -1,0 +1,36 @@
+"""Add monthly quota, daily limit, reset policy, and quota start to api_tokens.
+
+Revision ID: f7g8h9i0j1k2
+Revises: e6f7g8h9i0j1
+Create Date: 2026-04-30
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "f7g8h9i0j1k2"
+down_revision = "e6f7g8h9i0j1"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "api_tokens",
+        sa.Column("monthly_quota_usd", sa.Numeric(10, 2), nullable=True),
+    )
+    op.add_column(
+        "api_tokens",
+        sa.Column("monthly_reset_policy", sa.String(20), nullable=True),
+    )
+    op.add_column(
+        "api_tokens",
+        sa.Column("monthly_quota_start", sa.DateTime, nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("api_tokens", "monthly_quota_start")
+    op.drop_column("api_tokens", "monthly_reset_policy")
+    op.drop_column("api_tokens", "monthly_quota_usd")

--- a/backend/alembic/versions/g8h9i0j1k2l3_add_record_type_to_usage.py
+++ b/backend/alembic/versions/g8h9i0j1k2l3_add_record_type_to_usage.py
@@ -1,0 +1,36 @@
+"""Add record_type to usage_records for distinguishing adjustments.
+
+Revision ID: g8h9i0j1k2l3
+Revises: f7g8h9i0j1k2
+Create Date: 2026-04-30
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "g8h9i0j1k2l3"
+down_revision = "f7g8h9i0j1k2"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "usage_records",
+        sa.Column(
+            "record_type",
+            sa.String(20),
+            nullable=False,
+            server_default="usage",
+        ),
+    )
+    op.add_column(
+        "usage_records",
+        sa.Column("note", sa.String(500), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("usage_records", "note")
+    op.drop_column("usage_records", "record_type")

--- a/backend/alembic/versions/h9i0j1k2l3m4_add_teams.py
+++ b/backend/alembic/versions/h9i0j1k2l3m4_add_teams.py
@@ -1,0 +1,74 @@
+"""Add teams and team_members tables.
+
+Revision ID: h9i0j1k2l3m4
+Revises: g8h9i0j1k2l3
+Create Date: 2026-05-01
+"""
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects.postgresql import UUID
+
+
+revision = "h9i0j1k2l3m4"
+down_revision = "g8h9i0j1k2l3"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "teams",
+        sa.Column("id", UUID(as_uuid=True), nullable=False),
+        sa.Column("user_id", UUID(as_uuid=True), nullable=False),
+        sa.Column("name", sa.String(255), nullable=False),
+        sa.Column("monthly_budget_usd", sa.Numeric(10, 2), nullable=False),
+        sa.Column(
+            "monthly_reset_policy",
+            sa.String(20),
+            nullable=False,
+            server_default="reset",
+        ),
+        sa.Column("monthly_budget_start", sa.DateTime(), nullable=False),
+        sa.Column("is_active", sa.Boolean(), nullable=False, server_default="true"),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+        sa.Column("updated_at", sa.DateTime(), nullable=False),
+        sa.ForeignKeyConstraint(["user_id"], ["users.id"]),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index("ix_teams_user_id", "teams", ["user_id"])
+
+    op.create_table(
+        "team_members",
+        sa.Column("id", UUID(as_uuid=True), nullable=False),
+        sa.Column("team_id", UUID(as_uuid=True), nullable=False),
+        sa.Column("token_id", UUID(as_uuid=True), nullable=False),
+        sa.Column(
+            "allocated_usd", sa.Numeric(10, 2), nullable=False, server_default="0.00"
+        ),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+        sa.Column("updated_at", sa.DateTime(), nullable=False),
+        sa.ForeignKeyConstraint(["team_id"], ["teams.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["token_id"], ["api_tokens.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index("ix_team_members_team_id", "team_members", ["team_id"])
+    op.create_index(
+        "ix_team_members_token_id", "team_members", ["token_id"], unique=True
+    )
+    op.execute(
+        "ALTER TABLE team_members "
+        "ADD CONSTRAINT ck_allocated_non_negative CHECK (allocated_usd >= 0)"
+    )
+
+
+def downgrade() -> None:
+    op.execute(
+        "ALTER TABLE team_members "
+        "DROP CONSTRAINT IF EXISTS ck_allocated_non_negative"
+    )
+    op.drop_index("ix_team_members_token_id", "team_members")
+    op.drop_index("ix_team_members_team_id", "team_members")
+    op.drop_table("team_members")
+    op.drop_index("ix_teams_user_id", "teams")
+    op.drop_table("teams")

--- a/backend/alembic/versions/h9i0j1k2l3m4_add_teams.py
+++ b/backend/alembic/versions/h9i0j1k2l3m4_add_teams.py
@@ -64,8 +64,7 @@ def upgrade() -> None:
 
 def downgrade() -> None:
     op.execute(
-        "ALTER TABLE team_members "
-        "DROP CONSTRAINT IF EXISTS ck_allocated_non_negative"
+        "ALTER TABLE team_members DROP CONSTRAINT IF EXISTS ck_allocated_non_negative"
     )
     op.drop_index("ix_team_members_token_id", "team_members")
     op.drop_index("ix_team_members_team_id", "team_members")

--- a/backend/alembic/versions/i0j1k2l3m4n5_add_daily_limit_enabled.py
+++ b/backend/alembic/versions/i0j1k2l3m4n5_add_daily_limit_enabled.py
@@ -1,0 +1,31 @@
+"""Add daily_limit_enabled to teams.
+
+Revision ID: i0j1k2l3m4n5
+Revises: h9i0j1k2l3m4
+Create Date: 2026-05-01
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "i0j1k2l3m4n5"
+down_revision = "h9i0j1k2l3m4"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "teams",
+        sa.Column(
+            "daily_limit_enabled",
+            sa.Boolean(),
+            nullable=False,
+            server_default="true",
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("teams", "daily_limit_enabled")

--- a/backend/app/api/admin/endpoints/teams.py
+++ b/backend/app/api/admin/endpoints/teams.py
@@ -1,0 +1,605 @@
+"""Team management endpoints."""
+
+import calendar
+import re
+from datetime import datetime
+from decimal import Decimal
+from typing import List, Optional
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from pydantic import BaseModel
+from sqlalchemy import case, func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import joinedload
+
+from app.api.deps import get_current_user_from_jwt
+from app.core.database import get_db
+from app.models.team import Team, TeamMember
+from app.models.token import APIToken
+from app.models.usage import UsageRecord
+from app.models.user import User
+from app.services.team import TeamService
+
+router = APIRouter()
+
+
+# ---------------------------------------------------------------------------
+# Request / Response models
+# ---------------------------------------------------------------------------
+
+
+class CreateTeamRequest(BaseModel):
+    name: str
+    monthly_budget_usd: Decimal
+    monthly_reset_policy: str = "reset"
+    daily_limit_enabled: bool = True
+
+
+class UpdateTeamRequest(BaseModel):
+    name: str | None = None
+    monthly_budget_usd: Decimal | None = None
+    monthly_reset_policy: str | None = None
+    daily_limit_enabled: bool | None = None
+
+
+class AddMemberRequest(BaseModel):
+    token_id: str
+    allocated_usd: Decimal
+
+
+class AdjustMemberRequest(BaseModel):
+    allocated_usd: Decimal
+
+
+class TransferAllocationRequest(BaseModel):
+    from_token_id: str
+    to_token_id: str
+    amount: Decimal
+
+
+class BatchCreateMembersRequest(BaseModel):
+    names: str
+    per_member_allocation: Decimal
+    expires_at: datetime | None = None
+    quota_usd: Decimal | None = None
+    allowed_ips: List[str] | None = None
+    token_metadata: dict | None = None
+    model_names: List[str] | None = None
+
+    def parsed_names(self) -> List[str]:
+        return [
+            n for n in (s.strip() for s in re.split(r"[,，;；\n]+", self.names)) if n
+        ]
+
+
+class TeamMemberResponse(BaseModel):
+    token_id: str
+    token_name: str
+    allocated_usd: str
+    used_usd: str
+    remaining_usd: str
+    daily_limit_usd: str
+    daily_used_usd: str
+    is_active: bool
+    last_used_at: datetime | None
+
+
+class TeamDashboardResponse(BaseModel):
+    id: str
+    name: str
+    monthly_budget_usd: str
+    monthly_reset_policy: str
+    daily_limit_enabled: bool
+    total_allocated_usd: str
+    total_used_usd: str
+    unallocated_pool_usd: str
+    members: List[TeamMemberResponse]
+
+
+class TeamListItem(BaseModel):
+    id: str
+    name: str
+    monthly_budget_usd: str
+    monthly_reset_policy: str
+    daily_limit_enabled: bool
+    member_count: int
+    total_used_usd: str
+    unallocated_pool_usd: str
+    created_at: datetime
+
+
+class TeamMemberSimpleResponse(BaseModel):
+    token_id: str
+    token_name: str
+    allocated_usd: str
+
+
+class BatchCreateMembersResponse(BaseModel):
+    created: List[dict]
+    total: int
+
+
+# ---------------------------------------------------------------------------
+# Helper
+# ---------------------------------------------------------------------------
+
+
+async def _invalidate_token_cache(token_hash: str) -> None:
+    from app.api.admin.endpoints.tokens import (
+        _invalidate_token_cache as _do_invalidate,
+    )
+
+    await _do_invalidate(token_hash)
+
+
+# ---------------------------------------------------------------------------
+# Team CRUD
+# ---------------------------------------------------------------------------
+
+
+@router.post("", status_code=status.HTTP_201_CREATED)
+async def create_team(
+    request: CreateTeamRequest,
+    current_user: User = Depends(get_current_user_from_jwt),
+    db: AsyncSession = Depends(get_db),
+):
+    if request.monthly_reset_policy not in ("reset", "rollover"):
+        raise HTTPException(
+            status_code=400, detail="monthly_reset_policy must be 'reset' or 'rollover'"
+        )
+    if request.monthly_budget_usd <= 0:
+        raise HTTPException(status_code=400, detail="Budget must be positive")
+
+    service = TeamService(db)
+    team = await service.create_team(
+        user_id=current_user.id,
+        name=request.name,
+        monthly_budget_usd=request.monthly_budget_usd,
+        monthly_reset_policy=request.monthly_reset_policy,
+        daily_limit_enabled=request.daily_limit_enabled,
+    )
+    return {
+        "id": str(team.id),
+        "name": team.name,
+        "monthly_budget_usd": str(team.monthly_budget_usd),
+        "monthly_reset_policy": team.monthly_reset_policy,
+        "daily_limit_enabled": team.daily_limit_enabled,
+        "unallocated_pool_usd": str(team.monthly_budget_usd),
+    }
+
+
+@router.get("", response_model=List[TeamListItem])
+async def list_teams(
+    current_user: User = Depends(get_current_user_from_jwt),
+    db: AsyncSession = Depends(get_db),
+):
+    now = datetime.utcnow()
+    month_start = datetime(now.year, now.month, 1)
+
+    result = await db.execute(
+        select(
+            Team.id,
+            Team.name,
+            Team.monthly_budget_usd,
+            Team.monthly_reset_policy,
+            Team.daily_limit_enabled,
+            Team.monthly_budget_start,
+            Team.created_at,
+            func.count(TeamMember.id).label("member_count"),
+            func.coalesce(func.sum(TeamMember.allocated_usd), Decimal("0.00")).label(
+                "total_allocated"
+            ),
+        )
+        .outerjoin(TeamMember, TeamMember.team_id == Team.id)
+        .where(Team.user_id == current_user.id, Team.is_active)
+        .group_by(Team.id)
+        .order_by(Team.created_at.desc())
+    )
+    rows = result.all()
+
+    # Get total monthly usage per team
+    team_ids = [row.id for row in rows]
+    usage_result = await db.execute(
+        select(
+            TeamMember.team_id,
+            func.coalesce(func.sum(UsageRecord.cost_usd), Decimal("0.00")).label(
+                "total_used"
+            ),
+        )
+        .join(UsageRecord, UsageRecord.token_id == TeamMember.token_id)
+        .where(
+            TeamMember.team_id.in_(team_ids),
+            UsageRecord.created_at >= month_start,
+        )
+        .group_by(TeamMember.team_id)
+    )
+    usage_map = {row.team_id: row.total_used for row in usage_result.all()}
+
+    return [
+        TeamListItem(
+            id=str(row.id),
+            name=row.name,
+            monthly_budget_usd=str(row.monthly_budget_usd),
+            monthly_reset_policy=row.monthly_reset_policy,
+            daily_limit_enabled=row.daily_limit_enabled,
+            member_count=row.member_count,
+            total_used_usd=str(usage_map.get(row.id, Decimal("0.00"))),
+            unallocated_pool_usd=str(row.monthly_budget_usd - row.total_allocated),
+            created_at=row.created_at,
+        )
+        for row in rows
+    ]
+
+
+@router.get("/{team_id}", response_model=TeamDashboardResponse)
+async def get_team_dashboard(
+    team_id: str,
+    current_user: User = Depends(get_current_user_from_jwt),
+    db: AsyncSession = Depends(get_db),
+):
+    try:
+        team_uuid = UUID(team_id)
+    except ValueError:
+        raise HTTPException(status_code=400, detail="Invalid team ID")
+
+    team_result = await db.execute(
+        select(Team).where(Team.id == team_uuid, Team.user_id == current_user.id)
+    )
+    team = team_result.scalar_one_or_none()
+    if not team:
+        raise HTTPException(status_code=404, detail="Team not found")
+
+    now = datetime.utcnow()
+    today = now.date()
+    month_start = datetime(today.year, today.month, 1)
+    day_start = datetime(today.year, today.month, today.day)
+
+    is_rollover = (team.monthly_reset_policy or "reset") == "rollover"
+    monthly_boundary = team.monthly_budget_start if is_rollover else month_start
+
+    result = await db.execute(
+        select(
+            TeamMember.token_id,
+            TeamMember.allocated_usd,
+            APIToken.name.label("token_name"),
+            APIToken.is_active,
+            APIToken.last_used_at,
+            func.coalesce(
+                func.sum(
+                    case(
+                        (
+                            UsageRecord.created_at >= monthly_boundary,
+                            UsageRecord.cost_usd,
+                        ),
+                        else_=Decimal("0.00"),
+                    )
+                ),
+                Decimal("0.00"),
+            ).label("monthly_used"),
+            func.coalesce(
+                func.sum(
+                    case(
+                        (UsageRecord.created_at >= day_start, UsageRecord.cost_usd),
+                        else_=Decimal("0.00"),
+                    )
+                ),
+                Decimal("0.00"),
+            ).label("daily_used"),
+        )
+        .join(APIToken, TeamMember.token_id == APIToken.id)
+        .outerjoin(
+            UsageRecord,
+            (UsageRecord.token_id == TeamMember.token_id)
+            & (UsageRecord.created_at >= monthly_boundary),
+        )
+        .where(TeamMember.team_id == team_uuid)
+        .group_by(
+            TeamMember.token_id,
+            TeamMember.allocated_usd,
+            APIToken.name,
+            APIToken.is_active,
+            APIToken.last_used_at,
+        )
+    )
+    rows = result.all()
+
+    days_in_month = calendar.monthrange(today.year, today.month)[1]
+
+    members = []
+    total_allocated = Decimal("0.00")
+    total_used = Decimal("0.00")
+    for row in rows:
+        daily_limit = row.allocated_usd / Decimal(str(days_in_month))
+        remaining = max(Decimal("0.00"), row.allocated_usd - row.monthly_used)
+        members.append(
+            TeamMemberResponse(
+                token_id=str(row.token_id),
+                token_name=row.token_name,
+                allocated_usd=str(row.allocated_usd),
+                used_usd=str(row.monthly_used),
+                remaining_usd=str(remaining),
+                daily_limit_usd=str(daily_limit),
+                daily_used_usd=str(row.daily_used),
+                is_active=row.is_active,
+                last_used_at=row.last_used_at,
+            )
+        )
+        total_allocated += row.allocated_usd
+        total_used += row.monthly_used
+
+    unallocated = team.monthly_budget_usd - total_allocated
+
+    return TeamDashboardResponse(
+        id=str(team.id),
+        name=team.name,
+        monthly_budget_usd=str(team.monthly_budget_usd),
+        monthly_reset_policy=team.monthly_reset_policy,
+        daily_limit_enabled=team.daily_limit_enabled,
+        total_allocated_usd=str(total_allocated),
+        total_used_usd=str(total_used),
+        unallocated_pool_usd=str(unallocated),
+        members=members,
+    )
+
+
+@router.put("/{team_id}")
+async def update_team(
+    team_id: str,
+    request: UpdateTeamRequest,
+    current_user: User = Depends(get_current_user_from_jwt),
+    db: AsyncSession = Depends(get_db),
+):
+    try:
+        team_uuid = UUID(team_id)
+    except ValueError:
+        raise HTTPException(status_code=400, detail="Invalid team ID")
+
+    if request.monthly_reset_policy and request.monthly_reset_policy not in (
+        "reset",
+        "rollover",
+    ):
+        raise HTTPException(
+            status_code=400, detail="monthly_reset_policy must be 'reset' or 'rollover'"
+        )
+
+    service = TeamService(db)
+    team = await service.update_team(
+        team_id=team_uuid,
+        user_id=current_user.id,
+        name=request.name,
+        monthly_budget_usd=request.monthly_budget_usd,
+        monthly_reset_policy=request.monthly_reset_policy,
+        daily_limit_enabled=request.daily_limit_enabled,
+    )
+    return {"id": str(team.id), "name": team.name, "monthly_budget_usd": str(team.monthly_budget_usd)}
+
+
+@router.delete("/{team_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def delete_team(
+    team_id: str,
+    current_user: User = Depends(get_current_user_from_jwt),
+    db: AsyncSession = Depends(get_db),
+):
+    try:
+        team_uuid = UUID(team_id)
+    except ValueError:
+        raise HTTPException(status_code=400, detail="Invalid team ID")
+
+    service = TeamService(db)
+    await service.delete_team(team_uuid, current_user.id)
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Member management
+# ---------------------------------------------------------------------------
+
+
+@router.post("/{team_id}/members", response_model=TeamMemberSimpleResponse)
+async def add_member(
+    team_id: str,
+    request: AddMemberRequest,
+    current_user: User = Depends(get_current_user_from_jwt),
+    db: AsyncSession = Depends(get_db),
+):
+    try:
+        team_uuid = UUID(team_id)
+        token_uuid = UUID(request.token_id)
+    except ValueError:
+        raise HTTPException(status_code=400, detail="Invalid ID format")
+
+    service = TeamService(db)
+    member = await service.add_member(
+        team_id=team_uuid,
+        token_id=token_uuid,
+        allocated_usd=request.allocated_usd,
+        user_id=current_user.id,
+    )
+
+    # Invalidate token cache
+    token_result = await db.execute(
+        select(APIToken.token_hash).where(APIToken.id == token_uuid)
+    )
+    token_hash = token_result.scalar_one_or_none()
+    if token_hash:
+        await _invalidate_token_cache(token_hash)
+
+    # Get token name
+    token_result = await db.execute(
+        select(APIToken.name).where(APIToken.id == token_uuid)
+    )
+    token_name = token_result.scalar_one_or_none() or ""
+
+    return TeamMemberSimpleResponse(
+        token_id=str(member.token_id),
+        token_name=token_name,
+        allocated_usd=str(member.allocated_usd),
+    )
+
+
+@router.delete(
+    "/{team_id}/members/{token_id}", status_code=status.HTTP_204_NO_CONTENT
+)
+async def remove_member(
+    team_id: str,
+    token_id: str,
+    current_user: User = Depends(get_current_user_from_jwt),
+    db: AsyncSession = Depends(get_db),
+):
+    try:
+        team_uuid = UUID(team_id)
+        token_uuid = UUID(token_id)
+    except ValueError:
+        raise HTTPException(status_code=400, detail="Invalid ID format")
+
+    # Get token hash before removal for cache invalidation
+    token_result = await db.execute(
+        select(APIToken.token_hash).where(APIToken.id == token_uuid)
+    )
+    token_hash = token_result.scalar_one_or_none()
+
+    service = TeamService(db)
+    await service.remove_member(team_uuid, token_uuid, current_user.id)
+
+    if token_hash:
+        await _invalidate_token_cache(token_hash)
+
+    return None
+
+
+@router.put("/{team_id}/members/{token_id}", response_model=TeamMemberSimpleResponse)
+async def adjust_member(
+    team_id: str,
+    token_id: str,
+    request: AdjustMemberRequest,
+    current_user: User = Depends(get_current_user_from_jwt),
+    db: AsyncSession = Depends(get_db),
+):
+    try:
+        team_uuid = UUID(team_id)
+        token_uuid = UUID(token_id)
+    except ValueError:
+        raise HTTPException(status_code=400, detail="Invalid ID format")
+
+    service = TeamService(db)
+    member = await service.adjust_member_allocation(
+        team_id=team_uuid,
+        token_id=token_uuid,
+        new_allocated_usd=request.allocated_usd,
+        user_id=current_user.id,
+    )
+
+    # Invalidate cache
+    token_result = await db.execute(
+        select(APIToken.token_hash).where(APIToken.id == token_uuid)
+    )
+    token_hash = token_result.scalar_one_or_none()
+    if token_hash:
+        await _invalidate_token_cache(token_hash)
+
+    token_result = await db.execute(
+        select(APIToken.name).where(APIToken.id == token_uuid)
+    )
+    token_name = token_result.scalar_one_or_none() or ""
+
+    return TeamMemberSimpleResponse(
+        token_id=str(member.token_id),
+        token_name=token_name,
+        allocated_usd=str(member.allocated_usd),
+    )
+
+
+@router.post("/{team_id}/transfer", status_code=status.HTTP_200_OK)
+async def transfer_allocation(
+    team_id: str,
+    request: TransferAllocationRequest,
+    current_user: User = Depends(get_current_user_from_jwt),
+    db: AsyncSession = Depends(get_db),
+):
+    try:
+        team_uuid = UUID(team_id)
+        from_uuid = UUID(request.from_token_id)
+        to_uuid = UUID(request.to_token_id)
+    except ValueError:
+        raise HTTPException(status_code=400, detail="Invalid ID format")
+
+    service = TeamService(db)
+    await service.transfer_allocation(
+        team_id=team_uuid,
+        from_token_id=from_uuid,
+        to_token_id=to_uuid,
+        amount=request.amount,
+        user_id=current_user.id,
+    )
+
+    # Invalidate caches for both tokens
+    for tid in (from_uuid, to_uuid):
+        result = await db.execute(
+            select(APIToken.token_hash).where(APIToken.id == tid)
+        )
+        token_hash = result.scalar_one_or_none()
+        if token_hash:
+            await _invalidate_token_cache(token_hash)
+
+    return {
+        "from_token_id": request.from_token_id,
+        "to_token_id": request.to_token_id,
+        "amount": str(request.amount),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Batch create members
+# ---------------------------------------------------------------------------
+
+
+@router.post(
+    "/{team_id}/members/batch",
+    response_model=BatchCreateMembersResponse,
+    status_code=status.HTTP_201_CREATED,
+)
+async def batch_create_members(
+    team_id: str,
+    request: BatchCreateMembersRequest,
+    current_user: User = Depends(get_current_user_from_jwt),
+    db: AsyncSession = Depends(get_db),
+):
+    try:
+        team_uuid = UUID(team_id)
+    except ValueError:
+        raise HTTPException(status_code=400, detail="Invalid team ID")
+
+    names = request.parsed_names()
+    if not names:
+        raise HTTPException(status_code=400, detail="No valid names provided")
+    if len(names) > 100:
+        raise HTTPException(
+            status_code=400, detail=f"Too many names ({len(names)}), maximum is 100"
+        )
+
+    service = TeamService(db)
+    results = await service.batch_create_members(
+        team_id=team_uuid,
+        user_id=current_user.id,
+        names=names,
+        per_member_allocation=request.per_member_allocation,
+        expires_at=request.expires_at,
+        quota_usd=request.quota_usd,
+        allowed_ips=request.allowed_ips,
+        token_metadata=request.token_metadata,
+        model_names=request.model_names,
+    )
+
+    created = []
+    for token, plain_token in results:
+        created.append(
+            {
+                "token_id": str(token.id),
+                "token_name": token.name,
+                "token": plain_token,
+                "allocated_usd": str(request.per_member_allocation),
+            }
+        )
+
+    return BatchCreateMembersResponse(created=created, total=len(created))

--- a/backend/app/api/admin/endpoints/teams.py
+++ b/backend/app/api/admin/endpoints/teams.py
@@ -4,14 +4,13 @@ import calendar
 import re
 from datetime import datetime
 from decimal import Decimal
-from typing import List, Optional
+from typing import List
 from uuid import UUID
 
 from fastapi import APIRouter, Depends, HTTPException, status
 from pydantic import BaseModel
 from sqlalchemy import case, func, select
 from sqlalchemy.ext.asyncio import AsyncSession
-from sqlalchemy.orm import joinedload
 
 from app.api.deps import get_current_user_from_jwt
 from app.core.database import get_db

--- a/backend/app/api/admin/endpoints/teams.py
+++ b/backend/app/api/admin/endpoints/teams.py
@@ -371,7 +371,11 @@ async def update_team(
         monthly_reset_policy=request.monthly_reset_policy,
         daily_limit_enabled=request.daily_limit_enabled,
     )
-    return {"id": str(team.id), "name": team.name, "monthly_budget_usd": str(team.monthly_budget_usd)}
+    return {
+        "id": str(team.id),
+        "name": team.name,
+        "monthly_budget_usd": str(team.monthly_budget_usd),
+    }
 
 
 @router.delete("/{team_id}", status_code=status.HTTP_204_NO_CONTENT)
@@ -437,9 +441,7 @@ async def add_member(
     )
 
 
-@router.delete(
-    "/{team_id}/members/{token_id}", status_code=status.HTTP_204_NO_CONTENT
-)
+@router.delete("/{team_id}/members/{token_id}", status_code=status.HTTP_204_NO_CONTENT)
 async def remove_member(
     team_id: str,
     token_id: str,
@@ -534,9 +536,7 @@ async def transfer_allocation(
 
     # Invalidate caches for both tokens
     for tid in (from_uuid, to_uuid):
-        result = await db.execute(
-            select(APIToken.token_hash).where(APIToken.id == tid)
-        )
+        result = await db.execute(select(APIToken.token_hash).where(APIToken.id == tid))
         token_hash = result.scalar_one_or_none()
         if token_hash:
             await _invalidate_token_cache(token_hash)

--- a/backend/app/api/admin/endpoints/tokens.py
+++ b/backend/app/api/admin/endpoints/tokens.py
@@ -2,18 +2,22 @@
 API Token management endpoints.
 """
 
+import calendar
+import uuid as uuid_mod
 from datetime import datetime
 from decimal import Decimal
 from typing import List
+from uuid import UUID
 
 from fastapi import APIRouter, Depends, HTTPException, status
 from pydantic import BaseModel
-from sqlalchemy import func, select
+from sqlalchemy import case, func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.api.deps import get_current_user_from_jwt, get_token_service
 from app.core.database import get_db
 from app.core.security import decrypt_token
+from app.models.team import Team, TeamMember
 from app.models.token import APIToken
 from app.models.usage import UsageRecord
 from app.models.user import User
@@ -64,6 +68,8 @@ class CreateTokenRequest(BaseModel):
     name: str
     expires_at: datetime | None = None
     quota_usd: Decimal | None = None
+    monthly_quota_usd: Decimal | None = None
+    monthly_reset_policy: str | None = None
     allowed_ips: List[str] | None = None
     token_metadata: dict | None = None
 
@@ -78,6 +84,8 @@ class BatchCreateTokenRequest(BaseModel):
     names: str
     expires_at: datetime | None = None
     quota_usd: Decimal | None = None
+    monthly_quota_usd: Decimal | None = None
+    monthly_reset_policy: str | None = None
     allowed_ips: List[str] | None = None
     token_metadata: dict | None = None
     model_names: List[str] | None = None
@@ -97,6 +105,8 @@ class UpdateTokenRequest(BaseModel):
     name: str | None = None
     expires_at: datetime | None = None
     quota_usd: Decimal | None = None
+    monthly_quota_usd: Decimal | None = None
+    monthly_reset_policy: str | None = None
     allowed_ips: List[str] | None = None
     is_active: bool | None = None
     token_metadata: dict | None = None
@@ -110,7 +120,12 @@ class TokenResponse(BaseModel):
     key_prefix: str = "sk-ant-api03"
     expires_at: datetime | None
     quota_usd: str | None
+    monthly_quota_usd: str | None = None
+    daily_limit_usd: str | None = None
+    monthly_reset_policy: str | None = None
     used_usd: str
+    monthly_used_usd: str | None = None
+    daily_used_usd: str | None = None
     remaining_quota: str | None
     allowed_ips: List[str]
     is_active: bool
@@ -119,6 +134,9 @@ class TokenResponse(BaseModel):
     created_at: datetime
     last_used_at: datetime | None
     token_metadata: dict | None = None
+    team_id: str | None = None
+    team_name: str | None = None
+    allocated_usd: str | None = None
 
     class Config:
         from_attributes = True
@@ -138,14 +156,51 @@ class BatchCreateTokenResponse(BaseModel):
 
 
 # Helper functions
-async def calculate_token_used_usd(token: APIToken, db: AsyncSession) -> Decimal:
-    """Calculate total used amount for a token from usage records."""
-    usage_query = select(
-        func.coalesce(func.sum(UsageRecord.cost_usd), Decimal("0.00"))
-    ).where(UsageRecord.token_id == token.id)
+class TokenUsageSummary:
+    """Usage summary for a token across all time windows."""
 
-    result = await db.execute(usage_query)
-    return result.scalar()
+    def __init__(
+        self,
+        total: Decimal,
+        monthly: Decimal = Decimal("0.00"),
+        daily: Decimal = Decimal("0.00"),
+    ):
+        self.total = total
+        self.monthly = monthly
+        self.daily = daily
+
+
+async def calculate_token_usage(token: APIToken, db: AsyncSession) -> TokenUsageSummary:
+    """Calculate total, monthly, and daily used amount for a token."""
+    now = datetime.utcnow()
+    month_start = datetime(now.year, now.month, 1)
+    day_start = datetime(now.year, now.month, now.day)
+
+    result = await db.execute(
+        select(
+            func.coalesce(func.sum(UsageRecord.cost_usd), Decimal("0.00")),
+            func.coalesce(
+                func.sum(
+                    case(
+                        (UsageRecord.created_at >= month_start, UsageRecord.cost_usd),
+                        else_=Decimal("0.00"),
+                    )
+                ),
+                Decimal("0.00"),
+            ),
+            func.coalesce(
+                func.sum(
+                    case(
+                        (UsageRecord.created_at >= day_start, UsageRecord.cost_usd),
+                        else_=Decimal("0.00"),
+                    )
+                ),
+                Decimal("0.00"),
+            ),
+        ).where(UsageRecord.token_id == token.id)
+    )
+    row = result.one()
+    return TokenUsageSummary(total=row[0], monthly=row[1], daily=row[2])
 
 
 def _extract_key_prefix(token: APIToken) -> str:
@@ -160,9 +215,26 @@ def _extract_key_prefix(token: APIToken) -> str:
     return "sk-ant-api03"
 
 
-def build_token_response(token: APIToken, used_usd: Decimal) -> TokenResponse:
-    """Build TokenResponse with calculated used_usd."""
+def build_token_response(
+    token: APIToken,
+    used_usd: Decimal,
+    monthly_used_usd: Decimal | None = None,
+    daily_used_usd: Decimal | None = None,
+    team_id: str | None = None,
+    team_name: str | None = None,
+    allocated_usd: Decimal | None = None,
+) -> TokenResponse:
+    """Build TokenResponse with calculated usage."""
     token.calculate_used_usd(used_usd)
+
+    effective_monthly = (
+        allocated_usd if allocated_usd is not None else token.monthly_quota_usd
+    )
+    daily_limit = None
+    if effective_monthly is not None:
+        today = datetime.utcnow().date()
+        days_in_month = calendar.monthrange(today.year, today.month)[1]
+        daily_limit = effective_monthly / Decimal(str(days_in_month))
 
     return TokenResponse(
         id=str(token.id),
@@ -170,7 +242,16 @@ def build_token_response(token: APIToken, used_usd: Decimal) -> TokenResponse:
         key_prefix=_extract_key_prefix(token),
         expires_at=token.expires_at,
         quota_usd=str(token.quota_usd) if token.quota_usd else None,
+        monthly_quota_usd=(
+            str(effective_monthly) if effective_monthly is not None else None
+        ),
+        daily_limit_usd=str(daily_limit) if daily_limit is not None else None,
+        monthly_reset_policy=token.monthly_reset_policy,
         used_usd=str(used_usd),
+        monthly_used_usd=(
+            str(monthly_used_usd) if monthly_used_usd is not None else None
+        ),
+        daily_used_usd=str(daily_used_usd) if daily_used_usd is not None else None,
         remaining_quota=str(token.remaining_quota) if token.remaining_quota else None,
         allowed_ips=token.allowed_ips or [],
         is_active=token.is_active,
@@ -179,6 +260,9 @@ def build_token_response(token: APIToken, used_usd: Decimal) -> TokenResponse:
         created_at=token.created_at,
         last_used_at=token.last_used_at,
         token_metadata=token.token_metadata,
+        team_id=team_id,
+        team_name=team_name,
+        allocated_usd=str(allocated_usd) if allocated_usd is not None else None,
     )
 
 
@@ -214,6 +298,8 @@ async def create_token(
         name=request.name,
         expires_at=request.expires_at,
         quota_usd=request.quota_usd,
+        monthly_quota_usd=request.monthly_quota_usd,
+        monthly_reset_policy=request.monthly_reset_policy,
         allowed_ips=request.allowed_ips,
         token_metadata=validated_meta,
     )
@@ -264,6 +350,8 @@ async def batch_create_tokens(
         names=names,
         expires_at=request.expires_at,
         quota_usd=request.quota_usd,
+        monthly_quota_usd=request.monthly_quota_usd,
+        monthly_reset_policy=request.monthly_reset_policy,
         allowed_ips=request.allowed_ips,
         token_metadata=validated_meta,
         model_names=request.model_names,
@@ -305,7 +393,11 @@ async def list_tokens(
     if not tokens:
         return []
 
-    # Batch query: get usage for all tokens in one query
+    # Batch query: get total, monthly, daily usage for all tokens in one query
+    now = datetime.utcnow()
+    month_start = datetime(now.year, now.month, 1)
+    day_start = datetime(now.year, now.month, now.day)
+
     token_ids = [token.id for token in tokens]
     usage_query = (
         select(
@@ -313,19 +405,70 @@ async def list_tokens(
             func.coalesce(func.sum(UsageRecord.cost_usd), Decimal("0.00")).label(
                 "total_cost"
             ),
+            func.coalesce(
+                func.sum(
+                    case(
+                        (UsageRecord.created_at >= month_start, UsageRecord.cost_usd),
+                        else_=Decimal("0.00"),
+                    )
+                ),
+                Decimal("0.00"),
+            ).label("monthly_cost"),
+            func.coalesce(
+                func.sum(
+                    case(
+                        (UsageRecord.created_at >= day_start, UsageRecord.cost_usd),
+                        else_=Decimal("0.00"),
+                    )
+                ),
+                Decimal("0.00"),
+            ).label("daily_cost"),
         )
         .where(UsageRecord.token_id.in_(token_ids))
         .group_by(UsageRecord.token_id)
     )
 
     result = await db.execute(usage_query)
-    usage_map = {row.token_id: row.total_cost for row in result}
+    usage_map = {
+        row.token_id: (row.total_cost, row.monthly_cost, row.daily_cost)
+        for row in result
+    }
+
+    # Get team membership info for all tokens in one query
+    team_query = (
+        select(
+            TeamMember.token_id,
+            TeamMember.allocated_usd,
+            Team.id.label("team_id"),
+            Team.name.label("team_name"),
+        )
+        .join(Team, TeamMember.team_id == Team.id)
+        .where(TeamMember.token_id.in_(token_ids))
+    )
+    team_result = await db.execute(team_query)
+    team_map = {
+        row.token_id: (str(row.team_id), row.team_name, row.allocated_usd)
+        for row in team_result
+    }
 
     # Build responses with usage data
     token_responses = []
     for token in tokens:
-        used_usd = usage_map.get(token.id, Decimal("0.00"))
-        token_responses.append(build_token_response(token, used_usd))
+        total, monthly, daily = usage_map.get(
+            token.id, (Decimal("0.00"), Decimal("0.00"), Decimal("0.00"))
+        )
+        team_info = team_map.get(token.id)
+        token_responses.append(
+            build_token_response(
+                token,
+                total,
+                monthly_used_usd=monthly,
+                daily_used_usd=daily,
+                team_id=team_info[0] if team_info else None,
+                team_name=team_info[1] if team_info else None,
+                allocated_usd=team_info[2] if team_info else None,
+            )
+        )
 
     return token_responses
 
@@ -344,7 +487,6 @@ async def get_token(
 
     Returns token details (without plain token key).
     """
-    from uuid import UUID
 
     try:
         token_uuid = UUID(token_id)
@@ -369,8 +511,10 @@ async def get_token(
             detail="Access denied",
         )
 
-    used_usd = await calculate_token_used_usd(token, db)
-    return build_token_response(token, used_usd)
+    usage = await calculate_token_usage(token, db)
+    return build_token_response(
+        token, usage.total, monthly_used_usd=usage.monthly, daily_used_usd=usage.daily
+    )
 
 
 @router.put("/{token_id}", response_model=TokenResponse)
@@ -394,7 +538,6 @@ async def update_token(
 
     Returns updated token details.
     """
-    from uuid import UUID
 
     try:
         token_uuid = UUID(token_id)
@@ -432,6 +575,12 @@ async def update_token(
         token.expires_at = request.expires_at
     if request.quota_usd is not None:
         token.quota_usd = request.quota_usd
+    if request.monthly_quota_usd is not None:
+        token.monthly_quota_usd = request.monthly_quota_usd
+        if token.monthly_quota_start is None:
+            token.monthly_quota_start = datetime.utcnow()
+    if request.monthly_reset_policy is not None:
+        token.monthly_reset_policy = request.monthly_reset_policy
     if request.allowed_ips is not None:
         token.allowed_ips = request.allowed_ips
     if request.is_active is not None:
@@ -442,24 +591,12 @@ async def update_token(
     await db.commit()
     await db.refresh(token)
 
-    # For quota-only updates (like recharge), skip expensive aggregation query
-    # Frontend will refresh to get accurate used_usd
-    if request.quota_usd is not None and all(
-        v is None
-        for v in [
-            request.name,
-            request.expires_at,
-            request.allowed_ips,
-            request.is_active,
-        ]
-    ):
-        # Fast path: only quota changed
-        used_usd = Decimal("0.00")
-    else:
-        # Calculate for other updates
-        used_usd = await calculate_token_used_usd(token, db)
+    await _invalidate_token_cache(token.token_hash)
 
-    return build_token_response(token, used_usd)
+    usage = await calculate_token_usage(token, db)
+    return build_token_response(
+        token, usage.total, monthly_used_usd=usage.monthly, daily_used_usd=usage.daily
+    )
 
 
 @router.delete("/{token_id}", status_code=status.HTTP_204_NO_CONTENT)
@@ -475,7 +612,6 @@ async def delete_token(
 
     Permanently deletes the token. This action cannot be undone.
     """
-    from uuid import UUID
 
     try:
         token_uuid = UUID(token_id)
@@ -521,7 +657,6 @@ async def revoke_token(
 
     Deactivates the token. Can be reactivated later via update endpoint.
     """
-    from uuid import UUID
 
     try:
         token_uuid = UUID(token_id)
@@ -552,8 +687,10 @@ async def revoke_token(
 
     # Return updated token
     token = await token_service.get_token_by_id(token_uuid)
-    used_usd = await calculate_token_used_usd(token, db)
-    return build_token_response(token, used_usd)
+    usage = await calculate_token_usage(token, db)
+    return build_token_response(
+        token, usage.total, monthly_used_usd=usage.monthly, daily_used_usd=usage.daily
+    )
 
 
 @router.get("/{token_id}/plain", response_model=dict)
@@ -569,7 +706,6 @@ async def get_plain_token(
 
     Returns the decrypted token value for copying.
     """
-    from uuid import UUID
 
     try:
         token_uuid = UUID(token_id)
@@ -602,3 +738,97 @@ async def get_plain_token(
         )
 
     return {"token": plain_token}
+
+
+class AdjustBalanceRequest(BaseModel):
+    """Adjust token balance (debit or credit)."""
+
+    amount: Decimal
+    note: str | None = None
+
+
+class AdjustBalanceResponse(BaseModel):
+    """Response after balance adjustment."""
+
+    adjustment_id: str
+    token_id: str
+    amount: str
+    note: str | None
+    used_usd: str
+    monthly_used_usd: str | None
+    daily_used_usd: str | None
+
+
+@router.post("/{token_id}/adjust", response_model=AdjustBalanceResponse)
+async def adjust_token_balance(
+    token_id: str,
+    request: AdjustBalanceRequest,
+    current_user: User = Depends(get_current_user_from_jwt),
+    token_service: TokenService = Depends(get_token_service),
+    db: AsyncSession = Depends(get_db),
+):
+    """
+    Adjust token balance by inserting an adjustment record.
+
+    - **amount**: Positive to debit (reduce balance), negative to credit (increase balance)
+    - **note**: Optional reason for the adjustment
+
+    This inserts a record into usage_records with record_type="adjustment".
+    Positive amount increases "used" (reduces remaining balance).
+    Negative amount decreases "used" (increases remaining balance).
+    """
+    if request.amount == 0:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Amount must be non-zero",
+        )
+
+    try:
+        token_uuid = UUID(token_id)
+    except ValueError:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Invalid token ID format",
+        )
+
+    token = await token_service.get_token_by_id(token_uuid)
+    if not token:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Token not found",
+        )
+
+    if token.user_id != current_user.id:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Access denied",
+        )
+
+    adjustment = UsageRecord(
+        id=uuid_mod.uuid4(),
+        user_id=token.user_id,
+        token_id=token.id,
+        request_id=f"adj-{uuid_mod.uuid4().hex[:16]}",
+        model="adjustment",
+        prompt_tokens=0,
+        completion_tokens=0,
+        total_tokens=0,
+        cost_usd=request.amount,
+        record_type="adjustment",
+        note=request.note,
+    )
+    db.add(adjustment)
+    await db.commit()
+
+    await _invalidate_token_cache(token.token_hash)
+
+    usage = await calculate_token_usage(token, db)
+    return AdjustBalanceResponse(
+        adjustment_id=str(adjustment.id),
+        token_id=str(token.id),
+        amount=str(request.amount),
+        note=request.note,
+        used_usd=str(usage.total),
+        monthly_used_usd=str(usage.monthly),
+        daily_used_usd=str(usage.daily),
+    )

--- a/backend/app/api/admin/endpoints/usage.py
+++ b/backend/app/api/admin/endpoints/usage.py
@@ -334,6 +334,75 @@ class TokensTimeseriesResponse(BaseModel):
     series: List[TokenTimeseriesEntry]
 
 
+class UsageBreakdownItem(BaseModel):
+    """Single row in the token×model breakdown report."""
+
+    time_bucket: str
+    token_id: str
+    token_name: str
+    model: str
+    prompt_tokens: int
+    completion_tokens: int
+    total_tokens: int
+    total_cost: str
+    request_count: int
+
+
+class UsageBreakdownResponse(BaseModel):
+    """Token × model breakdown report."""
+
+    granularity: str
+    start_date: str
+    end_date: str
+    data: List[UsageBreakdownItem]
+
+
+@router.get("/breakdown", response_model=UsageBreakdownResponse)
+async def get_usage_breakdown(
+    start_date: datetime,
+    end_date: datetime,
+    granularity: str = Query("daily", pattern="^(daily|weekly|monthly)$"),
+    token_id: Optional[str] = None,
+    model: Optional[str] = None,
+    tz: str = Query(
+        "UTC", description="IANA timezone for date grouping, e.g. Asia/Shanghai"
+    ),
+    current_user: User = Depends(get_current_user_from_jwt),
+    db: AsyncSession = Depends(get_db),
+):
+    """
+    Get usage breakdown by token × model × time bucket.
+
+    Shows how many tokens and how much cost each key spent on each model,
+    grouped by daily/weekly/monthly granularity.
+
+    - **start_date / end_date**: Time range (max 90 days)
+    - **granularity**: daily, weekly, monthly
+    - **token_id**: Optional filter by single token
+    - **model**: Optional filter by model name
+    - **tz**: Timezone for date grouping
+    """
+    start_date, end_date = _clamp_date_range(start_date, end_date)
+
+    service = UsageStatsService(db)
+    data = await service.get_usage_breakdown(
+        user_id=current_user.id,
+        start_date=start_date,
+        end_date=end_date,
+        granularity=granularity,
+        token_id=UUID(token_id) if token_id else None,
+        model=model,
+        tz=tz,
+    )
+
+    return UsageBreakdownResponse(
+        granularity=granularity,
+        start_date=start_date.isoformat(),
+        end_date=end_date.isoformat(),
+        data=[UsageBreakdownItem(**d) for d in data],
+    )
+
+
 @router.get("/aggregated-stats", response_model=AggregatedStatsResponse)
 async def get_aggregated_stats(
     start_date: datetime,

--- a/backend/app/api/admin/router.py
+++ b/backend/app/api/admin/router.py
@@ -9,6 +9,7 @@ from app.api.admin.endpoints import (
     audit,
     auth,
     models,
+    teams,
     tokens,
     usage,
     pricing,
@@ -20,6 +21,9 @@ admin_router = APIRouter()
 
 # Authentication endpoints (no auth required for login/register)
 admin_router.include_router(auth.router, prefix="/auth", tags=["admin-auth"])
+
+# Team management endpoints (JWT auth required)
+admin_router.include_router(teams.router, prefix="/teams", tags=["admin-teams"])
 
 # Token management endpoints (JWT auth required)
 admin_router.include_router(tokens.router, prefix="/tokens", tags=["admin-tokens"])

--- a/backend/app/api/anthropic/endpoints/messages.py
+++ b/backend/app/api/anthropic/endpoints/messages.py
@@ -57,24 +57,13 @@ async def create_message(
     )
 
     try:
-        # Check token quota
-        from sqlalchemy import select, func
+        from sqlalchemy import select
         from app.models.model import Model
-        from decimal import Decimal
 
-        result = await db.execute(
-            select(func.sum(UsageRecord.cost_usd)).where(
-                UsageRecord.token_id == token.id
-            )
-        )
-        total_used = result.scalar() or Decimal("0.00")
-        token.calculate_used_usd(total_used)
+        # Check all quota tiers (lifetime, monthly, daily)
+        from app.services.quota import enforce_quota
 
-        if token.is_quota_exceeded:
-            raise HTTPException(
-                status_code=429,
-                detail=f"Token quota exceeded. Used: ${total_used:.2f}, Quota: ${token.quota_usd:.2f}",
-            )
+        await enforce_quota(token, db)
 
         # Validate model access
         result = await db.execute(

--- a/backend/app/api/gemini/endpoints/generate.py
+++ b/backend/app/api/gemini/endpoints/generate.py
@@ -10,13 +10,12 @@ import json
 import logging
 import time
 import uuid
-from decimal import Decimal
 from typing import AsyncGenerator, Dict
 
 import httpx
 from fastapi import APIRouter, Depends, HTTPException, Request
 from fastapi.responses import JSONResponse, StreamingResponse
-from sqlalchemy import select, func
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.api.deps import get_current_token_from_gemini_key
@@ -62,18 +61,9 @@ async def _validate_access(
     db: AsyncSession,
 ) -> None:
     """Check quota and model permission.  Raises HTTPException on failure."""
-    # Quota check
-    result = await db.execute(
-        select(func.sum(UsageRecord.cost_usd)).where(UsageRecord.token_id == token.id)
-    )
-    total_used = result.scalar() or Decimal("0.00")
-    token.calculate_used_usd(total_used)
+    from app.services.quota import enforce_quota
 
-    if token.is_quota_exceeded:
-        raise HTTPException(
-            status_code=429,
-            detail=f"Token quota exceeded. Used: ${total_used:.2f}, Quota: ${token.quota_usd:.2f}",
-        )
+    await enforce_quota(token, db)
 
     # Model permission check
     result = await db.execute(

--- a/backend/app/api/v1/endpoints/chat.py
+++ b/backend/app/api/v1/endpoints/chat.py
@@ -179,28 +179,13 @@ async def create_chat_completion(
     logger.debug(f"Full request data: {request_data.model_dump()}")
 
     try:
-        # Check token quota before processing request
-        from sqlalchemy import select, func
+        from sqlalchemy import select
         from app.models.model import Model
-        from decimal import Decimal
 
-        # Calculate total usage for this token
-        result = await db.execute(
-            select(func.sum(UsageRecord.cost_usd)).where(
-                UsageRecord.token_id == token.id
-            )
-        )
-        total_used = result.scalar() or Decimal("0.00")
+        # Check all quota tiers (lifetime, monthly, daily)
+        from app.services.quota import enforce_quota
 
-        # Set cached used amount for quota check
-        token.calculate_used_usd(total_used)
-
-        # Check if quota is exceeded
-        if token.is_quota_exceeded:
-            raise HTTPException(
-                status_code=429,
-                detail=f"Token quota exceeded. Used: ${total_used:.2f}, Quota: ${token.quota_usd:.2f}",
-            )
+        await enforce_quota(token, db)
 
         # Validate model access by querying the models table
         result = await db.execute(

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -10,6 +10,7 @@ from app.models.usage import UsageRecord
 from app.models.user import User
 from app.models.model_pricing import ModelPricing
 from app.models.model import Model
+from app.models.team import Team, TeamMember
 
 __all__ = [
     "User",
@@ -21,4 +22,6 @@ __all__ = [
     "AuditLog",
     "ModelPricing",
     "Model",
+    "Team",
+    "TeamMember",
 ]

--- a/backend/app/models/team.py
+++ b/backend/app/models/team.py
@@ -1,0 +1,77 @@
+"""Team and TeamMember models for team budget management."""
+
+from datetime import datetime
+from decimal import Decimal
+from uuid import uuid4
+
+from sqlalchemy import Boolean, Column, DateTime, ForeignKey, Numeric, String
+from sqlalchemy.dialects.postgresql import UUID as PostgresUUID
+from sqlalchemy.orm import relationship
+
+from app.core.database import Base
+
+
+class Team(Base):
+    """Team model for managing shared monthly budgets."""
+
+    __tablename__ = "teams"
+
+    id = Column(PostgresUUID(as_uuid=True), primary_key=True, default=uuid4)
+    user_id = Column(
+        PostgresUUID(as_uuid=True), ForeignKey("users.id"), nullable=False, index=True
+    )
+    name = Column(String(255), nullable=False)
+    monthly_budget_usd = Column(Numeric(10, 2), nullable=False)
+    monthly_reset_policy = Column(String(20), nullable=False, server_default="reset")
+    daily_limit_enabled = Column(Boolean, default=True, nullable=False)
+    monthly_budget_start = Column(DateTime, nullable=False)
+    is_active = Column(Boolean, default=True, nullable=False)
+    created_at = Column(DateTime, default=datetime.utcnow, nullable=False)
+    updated_at = Column(
+        DateTime, default=datetime.utcnow, onupdate=datetime.utcnow, nullable=False
+    )
+
+    # Relationships
+    user = relationship("User")
+    members = relationship(
+        "TeamMember", back_populates="team", cascade="all, delete-orphan"
+    )
+
+    def __repr__(self) -> str:
+        return f"<Team(id={self.id}, name={self.name})>"
+
+
+class TeamMember(Base):
+    """Join table linking tokens to teams with allocation amounts."""
+
+    __tablename__ = "team_members"
+
+    id = Column(PostgresUUID(as_uuid=True), primary_key=True, default=uuid4)
+    team_id = Column(
+        PostgresUUID(as_uuid=True),
+        ForeignKey("teams.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    token_id = Column(
+        PostgresUUID(as_uuid=True),
+        ForeignKey("api_tokens.id", ondelete="CASCADE"),
+        nullable=False,
+        unique=True,
+        index=True,
+    )
+    allocated_usd = Column(Numeric(10, 2), nullable=False, default=Decimal("0.00"))
+    created_at = Column(DateTime, default=datetime.utcnow, nullable=False)
+    updated_at = Column(
+        DateTime, default=datetime.utcnow, onupdate=datetime.utcnow, nullable=False
+    )
+
+    # Relationships
+    team = relationship("Team", back_populates="members")
+    token = relationship("APIToken", back_populates="team_membership")
+
+    def __repr__(self) -> str:
+        return (
+            f"<TeamMember(team_id={self.team_id}, "
+            f"token_id={self.token_id}, allocated={self.allocated_usd})>"
+        )

--- a/backend/app/models/token.py
+++ b/backend/app/models/token.py
@@ -30,6 +30,9 @@ class APIToken(Base):
     # Expiration and quotas
     expires_at = Column(DateTime, nullable=True)
     quota_usd = Column(Numeric(10, 2), nullable=True)
+    monthly_quota_usd = Column(Numeric(10, 2), nullable=True)
+    monthly_reset_policy = Column(String(20), nullable=True)
+    monthly_quota_start = Column(DateTime, nullable=True)
 
     # Access control
     allowed_ips = Column(ARRAY(String), nullable=True)
@@ -55,6 +58,12 @@ class APIToken(Base):
         "UsageRecord", back_populates="token", cascade="all, delete-orphan"
     )
     models = relationship("Model", back_populates="token", cascade="all, delete-orphan")
+    team_membership = relationship(
+        "TeamMember",
+        back_populates="token",
+        uselist=False,
+        cascade="all, delete-orphan",
+    )
 
     def __repr__(self) -> str:
         return f"<APIToken(id={self.id}, name={self.name}, user_id={self.user_id})>"

--- a/backend/app/models/usage.py
+++ b/backend/app/models/usage.py
@@ -49,6 +49,10 @@ class UsageRecord(Base):
     # Cost information
     cost_usd = Column(Numeric(10, 4), default=Decimal("0.0000"), nullable=False)
 
+    # Record classification: "usage" (real API call) or "adjustment" (admin debit/credit)
+    record_type = Column(String(20), nullable=False, server_default="usage")
+    note = Column(String(500), nullable=True)
+
     # Request metadata (renamed from 'metadata' to avoid SQLAlchemy reserved word)
     request_metadata = Column(JSON, nullable=True)
 

--- a/backend/app/services/bedrock.py
+++ b/backend/app/services/bedrock.py
@@ -528,6 +528,11 @@ class BedrockClient:
                 break
         return base.startswith(cls.ANTHROPIC_BASE_PREFIX)
 
+    @staticmethod
+    def _is_no_sampling_model(model_id: str) -> bool:
+        """Models that don't support temperature/top_p/top_k (e.g. Opus 4.7+)."""
+        return "opus-4-7" in model_id
+
     # Map AWS region prefix to geographic inference profile prefix
     REGION_TO_GEO_PREFIX = {
         "us": "us",
@@ -1097,6 +1102,22 @@ class BedrockClient:
                 )
                 body["max_tokens"] = new_max
 
+        # --- Opus 4.7+ compatibility: remove deprecated sampling params ---
+        if model_id and BedrockClient._is_no_sampling_model(model_id):
+            removed = []
+            for param in ("temperature", "top_p", "top_k"):
+                if param in body:
+                    body.pop(param)
+                    removed.append(param)
+            if removed:
+                logger.info(f"Opus 4.7: stripped deprecated params {removed}")
+            thinking_cfg = body.get("thinking")
+            if isinstance(thinking_cfg, dict) and "budget_tokens" in thinking_cfg:
+                logger.info(
+                    "Opus 4.7: converting thinking.budget_tokens to type=adaptive"
+                )
+                body["thinking"] = {"type": "adaptive"}
+
         # --- fields not supported by invoke_model — warn and skip ---
         if request.prompt_variables:
             logger.warning(
@@ -1230,10 +1251,11 @@ class BedrockClient:
             params["system"] = [{"text": request.system}]
 
         # --- inferenceConfig ---
+        is_opus_47 = model_id and BedrockClient._is_no_sampling_model(model_id)
         inference_config: dict = {"maxTokens": request.max_tokens}
-        if request.temperature is not None:
+        if request.temperature is not None and not is_opus_47:
             inference_config["temperature"] = request.temperature
-        if request.top_p is not None:
+        if request.top_p is not None and not is_opus_47:
             inference_config["topP"] = request.top_p
         if request.stop_sequences:
             inference_config["stopSequences"] = request.stop_sequences

--- a/backend/app/services/quota.py
+++ b/backend/app/services/quota.py
@@ -1,0 +1,142 @@
+"""Centralized quota enforcement for API tokens."""
+
+import calendar
+from datetime import datetime
+from decimal import Decimal
+
+from fastapi import HTTPException
+from sqlalchemy import case, func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.token import APIToken
+from app.models.usage import UsageRecord
+
+
+def _months_elapsed(start: datetime, now: datetime) -> int:
+    """Count calendar months from start to now (inclusive of current month)."""
+    return (now.year - start.year) * 12 + (now.month - start.month) + 1
+
+
+async def enforce_quota(token: APIToken, db: AsyncSession) -> None:
+    """Check all quota tiers for a token. Raises HTTP 429 if any exceeded.
+
+    Checks in order:
+    1. Lifetime quota (quota_usd) - sum of ALL usage
+    2. Monthly quota - either from team allocation or token's own monthly_quota_usd
+    3. Daily limit - auto-calculated from effective monthly quota
+    """
+    from app.services.team import get_team_membership
+
+    has_lifetime = token.quota_usd is not None
+
+    # Determine effective monthly quota source (team or standalone)
+    team_membership = await get_team_membership(token.id, db)
+    daily_limit_enabled = True
+    if team_membership:
+        effective_monthly = team_membership.allocated_usd
+        effective_policy = team_membership.team.monthly_reset_policy
+        effective_start = team_membership.team.monthly_budget_start
+        daily_limit_enabled = team_membership.team.daily_limit_enabled
+    else:
+        effective_monthly = token.monthly_quota_usd
+        effective_policy = token.monthly_reset_policy
+        effective_start = token.monthly_quota_start
+
+    has_monthly = effective_monthly is not None and effective_monthly > 0
+
+    if not has_lifetime and not has_monthly:
+        return
+
+    now = datetime.utcnow()
+    today = now.date()
+    month_start = datetime(today.year, today.month, 1)
+    day_start = datetime(today.year, today.month, today.day)
+
+    is_rollover = (effective_policy or "reset") == "rollover"
+    rollover_start = effective_start or month_start
+
+    # Determine the start boundary for the monthly sum
+    monthly_boundary = rollover_start if is_rollover else month_start
+
+    result = await db.execute(
+        select(
+            func.coalesce(func.sum(UsageRecord.cost_usd), Decimal("0.00")).label(
+                "total"
+            ),
+            func.coalesce(
+                func.sum(
+                    case(
+                        (
+                            UsageRecord.created_at >= monthly_boundary,
+                            UsageRecord.cost_usd,
+                        ),
+                        else_=Decimal("0.00"),
+                    )
+                ),
+                Decimal("0.00"),
+            ).label("monthly"),
+            func.coalesce(
+                func.sum(
+                    case(
+                        (UsageRecord.created_at >= day_start, UsageRecord.cost_usd),
+                        else_=Decimal("0.00"),
+                    )
+                ),
+                Decimal("0.00"),
+            ).label("daily"),
+        ).where(UsageRecord.token_id == token.id)
+    )
+    row = result.one()
+    total_used, monthly_used, daily_used = row.total, row.monthly, row.daily
+
+    token.calculate_used_usd(total_used)
+
+    # 1. Lifetime quota
+    if has_lifetime and total_used >= token.quota_usd:
+        raise HTTPException(
+            status_code=429,
+            detail=(
+                f"Lifetime quota exceeded. "
+                f"Used: ${total_used:.2f}, Limit: ${token.quota_usd:.2f}"
+            ),
+        )
+
+    # 2. Monthly quota
+    if has_monthly:
+        if is_rollover:
+            months = _months_elapsed(rollover_start, now)
+            cumulative_allowance = effective_monthly * Decimal(str(months))
+            if monthly_used >= cumulative_allowance:
+                raise HTTPException(
+                    status_code=429,
+                    detail=(
+                        f"Monthly quota exceeded (rollover). "
+                        f"Used: ${monthly_used:.2f}, "
+                        f"Allowance: ${cumulative_allowance:.2f} "
+                        f"({months} months × ${effective_monthly:.2f})"
+                    ),
+                )
+        else:
+            if monthly_used >= effective_monthly:
+                raise HTTPException(
+                    status_code=429,
+                    detail=(
+                        f"Monthly quota exceeded. "
+                        f"Used: ${monthly_used:.2f}, "
+                        f"Limit: ${effective_monthly:.2f}"
+                    ),
+                )
+
+    # 3. Daily limit (auto-calculated from effective monthly quota)
+    if has_monthly and daily_limit_enabled:
+        days_in_month = calendar.monthrange(today.year, today.month)[1]
+        effective_daily = effective_monthly / Decimal(str(days_in_month))
+
+        if daily_used >= effective_daily:
+            raise HTTPException(
+                status_code=429,
+                detail=(
+                    f"Daily limit exceeded. "
+                    f"Used today: ${daily_used:.2f}, Limit: ${effective_daily:.2f}"
+                ),
+            )

--- a/backend/app/services/team.py
+++ b/backend/app/services/team.py
@@ -1,0 +1,393 @@
+"""Team management service with budget invariant enforcement."""
+
+import logging
+from datetime import datetime
+from decimal import Decimal
+from typing import List, Optional
+from uuid import UUID
+
+from fastapi import HTTPException
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import joinedload
+
+from app.models.team import Team, TeamMember
+from app.models.token import APIToken
+
+logger = logging.getLogger(__name__)
+
+
+class TeamService:
+    """Service for team CRUD and budget allocation with invariant enforcement."""
+
+    def __init__(self, db: AsyncSession):
+        self.db = db
+
+    # ------------------------------------------------------------------
+    # Locking helper
+    # ------------------------------------------------------------------
+
+    async def _lock_team_and_members(
+        self, team_id: UUID
+    ) -> tuple[Team, list[TeamMember], Decimal]:
+        """Lock team + all members FOR UPDATE. Returns (team, members, total_allocated)."""
+        result = await self.db.execute(
+            select(Team).where(Team.id == team_id).with_for_update()
+        )
+        team = result.scalar_one_or_none()
+        if not team:
+            raise HTTPException(status_code=404, detail="Team not found")
+
+        members_result = await self.db.execute(
+            select(TeamMember).where(TeamMember.team_id == team_id).with_for_update()
+        )
+        members = list(members_result.scalars().all())
+        total_allocated = sum((m.allocated_usd for m in members), Decimal("0.00"))
+
+        return team, members, total_allocated
+
+    # ------------------------------------------------------------------
+    # CRUD
+    # ------------------------------------------------------------------
+
+    async def create_team(
+        self,
+        user_id: UUID,
+        name: str,
+        monthly_budget_usd: Decimal,
+        monthly_reset_policy: str = "reset",
+        daily_limit_enabled: bool = True,
+    ) -> Team:
+        team = Team(
+            user_id=user_id,
+            name=name,
+            monthly_budget_usd=monthly_budget_usd,
+            monthly_reset_policy=monthly_reset_policy,
+            daily_limit_enabled=daily_limit_enabled,
+            monthly_budget_start=datetime.utcnow(),
+        )
+        self.db.add(team)
+        await self.db.commit()
+        await self.db.refresh(team)
+        return team
+
+    async def get_team(self, team_id: UUID, user_id: UUID) -> Team:
+        result = await self.db.execute(
+            select(Team).where(Team.id == team_id, Team.user_id == user_id)
+        )
+        team = result.scalar_one_or_none()
+        if not team:
+            raise HTTPException(status_code=404, detail="Team not found")
+        return team
+
+    async def list_teams(self, user_id: UUID) -> list[Team]:
+        result = await self.db.execute(
+            select(Team)
+            .where(Team.user_id == user_id, Team.is_active)
+            .order_by(Team.created_at.desc())
+        )
+        return list(result.scalars().all())
+
+    async def update_team(
+        self,
+        team_id: UUID,
+        user_id: UUID,
+        name: Optional[str] = None,
+        monthly_budget_usd: Optional[Decimal] = None,
+        monthly_reset_policy: Optional[str] = None,
+        daily_limit_enabled: Optional[bool] = None,
+    ) -> Team:
+        team, members, total_allocated = await self._lock_team_and_members(team_id)
+
+        if team.user_id != user_id:
+            raise HTTPException(status_code=403, detail="Access denied")
+
+        if monthly_budget_usd is not None:
+            if monthly_budget_usd < total_allocated:
+                raise HTTPException(
+                    status_code=400,
+                    detail=(
+                        f"Cannot reduce budget below total allocated "
+                        f"(${total_allocated:.2f}). Free up allocations first."
+                    ),
+                )
+            team.monthly_budget_usd = monthly_budget_usd
+
+        if name is not None:
+            team.name = name
+        if monthly_reset_policy is not None:
+            team.monthly_reset_policy = monthly_reset_policy
+        if daily_limit_enabled is not None:
+            team.daily_limit_enabled = daily_limit_enabled
+
+        await self.db.commit()
+        await self.db.refresh(team)
+        return team
+
+    async def delete_team(self, team_id: UUID, user_id: UUID) -> None:
+        team = await self.get_team(team_id, user_id)
+
+        # Clear monthly quota from member tokens (they become standalone)
+        members_result = await self.db.execute(
+            select(TeamMember)
+            .where(TeamMember.team_id == team.id)
+            .options(joinedload(TeamMember.token))
+        )
+        for member in members_result.scalars().all():
+            if member.token:
+                member.token.monthly_quota_usd = None
+                member.token.monthly_reset_policy = None
+                member.token.monthly_quota_start = None
+
+        await self.db.delete(team)
+        await self.db.commit()
+
+    # ------------------------------------------------------------------
+    # Member management
+    # ------------------------------------------------------------------
+
+    async def add_member(
+        self,
+        team_id: UUID,
+        token_id: UUID,
+        allocated_usd: Decimal,
+        user_id: UUID,
+    ) -> TeamMember:
+        team, members, total_allocated = await self._lock_team_and_members(team_id)
+
+        if team.user_id != user_id:
+            raise HTTPException(status_code=403, detail="Access denied")
+
+        if allocated_usd < 0:
+            raise HTTPException(status_code=400, detail="Allocation must be >= 0")
+
+        if total_allocated + allocated_usd > team.monthly_budget_usd:
+            pool = team.monthly_budget_usd - total_allocated
+            raise HTTPException(
+                status_code=400,
+                detail=(
+                    f"Insufficient unallocated pool. "
+                    f"Available: ${pool:.2f}, requested: ${allocated_usd:.2f}"
+                ),
+            )
+
+        # Verify token exists, belongs to same user, not already in a team
+        token_result = await self.db.execute(
+            select(APIToken).where(APIToken.id == token_id)
+        )
+        token = token_result.scalar_one_or_none()
+        if not token:
+            raise HTTPException(status_code=404, detail="Token not found")
+        if token.user_id != user_id:
+            raise HTTPException(status_code=403, detail="Token does not belong to you")
+
+        existing = await self.db.execute(
+            select(TeamMember).where(TeamMember.token_id == token_id)
+        )
+        if existing.scalar_one_or_none():
+            raise HTTPException(
+                status_code=400, detail="Token is already a member of a team"
+            )
+
+        # Clear token standalone monthly quota (team takes over)
+        token.monthly_quota_usd = None
+        token.monthly_reset_policy = None
+        token.monthly_quota_start = None
+
+        member = TeamMember(
+            team_id=team_id,
+            token_id=token_id,
+            allocated_usd=allocated_usd,
+        )
+        self.db.add(member)
+        await self.db.commit()
+        await self.db.refresh(member)
+        return member
+
+    async def remove_member(
+        self, team_id: UUID, token_id: UUID, user_id: UUID
+    ) -> None:
+        team = await self.get_team(team_id, user_id)
+
+        result = await self.db.execute(
+            select(TeamMember).where(
+                TeamMember.team_id == team.id, TeamMember.token_id == token_id
+            )
+        )
+        member = result.scalar_one_or_none()
+        if not member:
+            raise HTTPException(status_code=404, detail="Member not found in this team")
+
+        # Soft-delete the associated token
+        token_result = await self.db.execute(
+            select(APIToken).where(APIToken.id == token_id)
+        )
+        token = token_result.scalar_one_or_none()
+        if token:
+            token.is_active = False
+            token.is_deleted = True
+            token.deleted_at = datetime.utcnow()
+
+        await self.db.delete(member)
+        await self.db.commit()
+
+    async def adjust_member_allocation(
+        self,
+        team_id: UUID,
+        token_id: UUID,
+        new_allocated_usd: Decimal,
+        user_id: UUID,
+    ) -> TeamMember:
+        team, members, total_allocated = await self._lock_team_and_members(team_id)
+
+        if team.user_id != user_id:
+            raise HTTPException(status_code=403, detail="Access denied")
+
+        if new_allocated_usd < 0:
+            raise HTTPException(status_code=400, detail="Allocation must be >= 0")
+
+        target = None
+        for m in members:
+            if m.token_id == token_id:
+                target = m
+                break
+
+        if not target:
+            raise HTTPException(status_code=404, detail="Member not found in this team")
+
+        total_others = total_allocated - target.allocated_usd
+        if total_others + new_allocated_usd > team.monthly_budget_usd:
+            pool = team.monthly_budget_usd - total_others
+            raise HTTPException(
+                status_code=400,
+                detail=(
+                    f"Exceeds budget. Max allocation for this member: ${pool:.2f}"
+                ),
+            )
+
+        target.allocated_usd = new_allocated_usd
+        await self.db.commit()
+        await self.db.refresh(target)
+        return target
+
+    async def transfer_allocation(
+        self,
+        team_id: UUID,
+        from_token_id: UUID,
+        to_token_id: UUID,
+        amount: Decimal,
+        user_id: UUID,
+    ) -> None:
+        team, members, _ = await self._lock_team_and_members(team_id)
+
+        if team.user_id != user_id:
+            raise HTTPException(status_code=403, detail="Access denied")
+
+        if amount <= 0:
+            raise HTTPException(status_code=400, detail="Amount must be positive")
+
+        from_member = None
+        to_member = None
+        for m in members:
+            if m.token_id == from_token_id:
+                from_member = m
+            if m.token_id == to_token_id:
+                to_member = m
+
+        if not from_member or not to_member:
+            raise HTTPException(
+                status_code=404, detail="One or both members not found in this team"
+            )
+
+        if from_member.allocated_usd < amount:
+            raise HTTPException(
+                status_code=400,
+                detail=(
+                    f"Insufficient allocation. "
+                    f"Source has: ${from_member.allocated_usd:.2f}, "
+                    f"requested: ${amount:.2f}"
+                ),
+            )
+
+        from_member.allocated_usd -= amount
+        to_member.allocated_usd += amount
+        await self.db.commit()
+
+    # ------------------------------------------------------------------
+    # Batch create members
+    # ------------------------------------------------------------------
+
+    async def batch_create_members(
+        self,
+        team_id: UUID,
+        user_id: UUID,
+        names: List[str],
+        per_member_allocation: Decimal,
+        expires_at=None,
+        quota_usd=None,
+        allowed_ips=None,
+        token_metadata=None,
+        model_names=None,
+    ) -> list[tuple[APIToken, str]]:
+        """Create new tokens and add them as team members atomically."""
+        from app.services.token import TokenService
+
+        team, members, total_allocated = await self._lock_team_and_members(team_id)
+
+        if team.user_id != user_id:
+            raise HTTPException(status_code=403, detail="Access denied")
+
+        if per_member_allocation < 0:
+            raise HTTPException(status_code=400, detail="Allocation must be >= 0")
+
+        needed = per_member_allocation * len(names)
+        if total_allocated + needed > team.monthly_budget_usd:
+            pool = team.monthly_budget_usd - total_allocated
+            raise HTTPException(
+                status_code=400,
+                detail=(
+                    f"Insufficient budget. "
+                    f"Available: ${pool:.2f}, needed: ${needed:.2f} "
+                    f"({len(names)} × ${per_member_allocation:.2f})"
+                ),
+            )
+
+        token_service = TokenService(self.db)
+        results = await token_service.create_tokens_batch(
+            user_id=user_id,
+            names=names,
+            expires_at=expires_at,
+            quota_usd=quota_usd,
+            allowed_ips=allowed_ips,
+            token_metadata=token_metadata,
+            model_names=model_names,
+            auto_commit=False,
+        )
+
+        for token, _ in results:
+            member = TeamMember(
+                team_id=team_id,
+                token_id=token.id,
+                allocated_usd=per_member_allocation,
+            )
+            self.db.add(member)
+
+        await self.db.commit()
+
+        # Refresh tokens
+        token_ids = [t.id for t, _ in results]
+        refresh_result = await self.db.execute(
+            select(APIToken).where(APIToken.id.in_(token_ids))
+        )
+        refreshed = {t.id: t for t in refresh_result.scalars().all()}
+        return [(refreshed[t.id], pk) for t, pk in results]
+
+
+async def get_team_membership(token_id: UUID, db: AsyncSession) -> Optional[TeamMember]:
+    """Get team membership with team data for a token. Returns None if not in a team."""
+    result = await db.execute(
+        select(TeamMember)
+        .options(joinedload(TeamMember.team))
+        .where(TeamMember.token_id == token_id)
+    )
+    return result.scalar_one_or_none()

--- a/backend/app/services/team.py
+++ b/backend/app/services/team.py
@@ -7,7 +7,7 @@ from typing import List, Optional
 from uuid import UUID
 
 from fastapi import HTTPException
-from sqlalchemy import func, select
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import joinedload
 

--- a/backend/app/services/team.py
+++ b/backend/app/services/team.py
@@ -204,9 +204,7 @@ class TeamService:
         await self.db.refresh(member)
         return member
 
-    async def remove_member(
-        self, team_id: UUID, token_id: UUID, user_id: UUID
-    ) -> None:
+    async def remove_member(self, team_id: UUID, token_id: UUID, user_id: UUID) -> None:
         team = await self.get_team(team_id, user_id)
 
         result = await self.db.execute(
@@ -260,9 +258,7 @@ class TeamService:
             pool = team.monthly_budget_usd - total_others
             raise HTTPException(
                 status_code=400,
-                detail=(
-                    f"Exceeds budget. Max allocation for this member: ${pool:.2f}"
-                ),
+                detail=(f"Exceeds budget. Max allocation for this member: ${pool:.2f}"),
             )
 
         target.allocated_usd = new_allocated_usd

--- a/backend/app/services/token.py
+++ b/backend/app/services/token.py
@@ -42,6 +42,8 @@ class TokenService:
         name: str,
         expires_at: Optional[datetime] = None,
         quota_usd: Optional[Decimal] = None,
+        monthly_quota_usd: Optional[Decimal] = None,
+        monthly_reset_policy: Optional[str] = None,
         allowed_ips: Optional[List[str]] = None,
         token_metadata: Optional[dict] = None,
     ) -> tuple[APIToken, str]:
@@ -52,7 +54,9 @@ class TokenService:
             user_id: User UUID
             name: Token name/description
             expires_at: Optional expiration datetime
-            quota_usd: Optional usage quota in USD
+            quota_usd: Optional lifetime usage quota in USD
+            monthly_quota_usd: Optional monthly budget in USD
+            monthly_reset_policy: "reset" (clear each month) or "rollover" (accumulate)
             allowed_ips: Optional list of allowed IP addresses/ranges
             token_metadata: Optional metadata dict for per-key configuration
 
@@ -73,6 +77,9 @@ class TokenService:
             encrypted_token=encrypted,
             expires_at=expires_at,
             quota_usd=quota_usd,
+            monthly_quota_usd=monthly_quota_usd,
+            monthly_reset_policy=monthly_reset_policy,
+            monthly_quota_start=datetime.utcnow() if monthly_quota_usd else None,
             allowed_ips=allowed_ips or [],
             token_metadata=token_metadata,
             is_active=True,
@@ -90,14 +97,18 @@ class TokenService:
         names: List[str],
         expires_at: Optional[datetime] = None,
         quota_usd: Optional[Decimal] = None,
+        monthly_quota_usd: Optional[Decimal] = None,
+        monthly_reset_policy: Optional[str] = None,
         allowed_ips: Optional[List[str]] = None,
         token_metadata: Optional[dict] = None,
         model_names: Optional[List[str]] = None,
+        auto_commit: bool = True,
     ) -> List[tuple[APIToken, str]]:
         """
         Batch create API tokens with explicit names and optional shared model list.
 
         All tokens are inserted in a single transaction (atomic).
+        Set auto_commit=False to defer commit (caller must commit).
 
         Returns:
             List of (APIToken, plain_token) tuples
@@ -116,6 +127,9 @@ class TokenService:
                 encrypted_token=encrypted,
                 expires_at=expires_at,
                 quota_usd=quota_usd,
+                monthly_quota_usd=monthly_quota_usd,
+                monthly_reset_policy=monthly_reset_policy,
+                monthly_quota_start=datetime.utcnow() if monthly_quota_usd else None,
                 allowed_ips=allowed_ips or [],
                 token_metadata=token_metadata,
                 is_active=True,
@@ -136,15 +150,17 @@ class TokenService:
                     )
                     self.db.add(model)
 
-        await self.db.commit()
+        if auto_commit:
+            await self.db.commit()
+            # Refresh all tokens in a single query instead of N round-trips
+            token_ids = [t.id for t, _ in tokens_and_keys]
+            result = await self.db.execute(
+                select(APIToken).where(APIToken.id.in_(token_ids))
+            )
+            refreshed = {t.id: t for t in result.scalars().all()}
+            return [(refreshed[t.id], pk) for t, pk in tokens_and_keys]
 
-        # Refresh all tokens in a single query instead of N round-trips
-        token_ids = [t.id for t, _ in tokens_and_keys]
-        result = await self.db.execute(
-            select(APIToken).where(APIToken.id.in_(token_ids))
-        )
-        refreshed = {t.id: t for t in result.scalars().all()}
-        return [(refreshed[t.id], pk) for t, pk in tokens_and_keys]
+        return tokens_and_keys
 
     async def get_token_by_id(self, token_id: UUID) -> Optional[APIToken]:
         """

--- a/backend/app/services/token_cache.py
+++ b/backend/app/services/token_cache.py
@@ -86,6 +86,15 @@ class CachedTokenService:
             "name": token.name,
             "expires_at": token.expires_at.isoformat() if token.expires_at else None,
             "quota_usd": str(token.quota_usd) if token.quota_usd else None,
+            "monthly_quota_usd": (
+                str(token.monthly_quota_usd) if token.monthly_quota_usd else None
+            ),
+            "monthly_reset_policy": token.monthly_reset_policy,
+            "monthly_quota_start": (
+                token.monthly_quota_start.isoformat()
+                if token.monthly_quota_start
+                else None
+            ),
             "allowed_ips": token.allowed_ips,
             "is_active": token.is_active,
         }
@@ -97,8 +106,6 @@ class CachedTokenService:
             from datetime import datetime
             from decimal import Decimal
 
-            # Create a minimal token object for validation
-            # Note: This is not a full ORM object, just for validation
             token = APIToken()
             token.id = UUID(cached_data["id"])
             token.user_id = UUID(cached_data["user_id"])
@@ -110,6 +117,17 @@ class CachedTokenService:
             )
             token.quota_usd = (
                 Decimal(cached_data["quota_usd"]) if cached_data["quota_usd"] else None
+            )
+            token.monthly_quota_usd = (
+                Decimal(cached_data["monthly_quota_usd"])
+                if cached_data.get("monthly_quota_usd")
+                else None
+            )
+            token.monthly_reset_policy = cached_data.get("monthly_reset_policy")
+            token.monthly_quota_start = (
+                datetime.fromisoformat(cached_data["monthly_quota_start"])
+                if cached_data.get("monthly_quota_start")
+                else None
             )
             token.allowed_ips = cached_data["allowed_ips"]
             token.is_active = cached_data["is_active"]

--- a/backend/app/services/usage_stats.py
+++ b/backend/app/services/usage_stats.py
@@ -94,6 +94,82 @@ class UsageStatsService:
             for row in rows
         ]
 
+    async def get_usage_breakdown(
+        self,
+        user_id: UUID,
+        start_date: datetime,
+        end_date: datetime,
+        granularity: str = "daily",
+        token_id: Optional[UUID] = None,
+        model: Optional[str] = None,
+        tz: str = "UTC",
+    ) -> List[dict]:
+        """
+        Get usage breakdown by token × model × time bucket.
+
+        Returns rows of (time_bucket, token_id, token_name, model,
+        prompt_tokens, completion_tokens, total_tokens, total_cost, request_count).
+        """
+        trunc_field = self._granularity_to_trunc(granularity)
+        time_expr = self._localized_time(UsageRecord.created_at, tz)
+        time_bucket = func.date_trunc(trunc_field, time_expr).label("time_bucket")
+
+        query = (
+            select(
+                time_bucket,
+                UsageRecord.token_id,
+                APIToken.name.label("token_name"),
+                UsageRecord.model,
+                func.coalesce(func.sum(UsageRecord.prompt_tokens), 0).label(
+                    "prompt_tokens"
+                ),
+                func.coalesce(func.sum(UsageRecord.completion_tokens), 0).label(
+                    "completion_tokens"
+                ),
+                func.coalesce(func.sum(UsageRecord.total_tokens), 0).label(
+                    "total_tokens"
+                ),
+                func.coalesce(func.sum(UsageRecord.cost_usd), Decimal("0.0000")).label(
+                    "total_cost"
+                ),
+                func.count(UsageRecord.id).label("request_count"),
+            )
+            .join(APIToken, UsageRecord.token_id == APIToken.id)
+            .where(
+                UsageRecord.user_id == user_id,
+                UsageRecord.created_at >= start_date,
+                UsageRecord.created_at <= end_date,
+                UsageRecord.record_type == "usage",
+            )
+            .group_by(
+                time_bucket, UsageRecord.token_id, APIToken.name, UsageRecord.model
+            )
+            .order_by(time_bucket, APIToken.name, UsageRecord.model)
+        )
+
+        if token_id is not None:
+            query = query.where(UsageRecord.token_id == token_id)
+        if model is not None:
+            query = query.where(UsageRecord.model == model)
+
+        result = await self.db.execute(query)
+        rows = result.all()
+
+        return [
+            {
+                "time_bucket": row.time_bucket.isoformat(),
+                "token_id": str(row.token_id),
+                "token_name": row.token_name,
+                "model": row.model,
+                "prompt_tokens": row.prompt_tokens,
+                "completion_tokens": row.completion_tokens,
+                "total_tokens": row.total_tokens,
+                "total_cost": str(row.total_cost),
+                "request_count": row.request_count,
+            }
+            for row in rows
+        ]
+
     async def get_usage_by_token(
         self,
         user_id: UUID,

--- a/frontend/src/layouts/MainLayout.vue
+++ b/frontend/src/layouts/MainLayout.vue
@@ -102,6 +102,12 @@ const menuLinks = [
     to: '/',
   },
   {
+    title: 'Teams',
+    caption: 'Team budget management',
+    icon: 'groups',
+    to: '/teams',
+  },
+  {
     title: 'API Keys',
     caption: 'API Key management',
     icon: 'vpn_key',

--- a/frontend/src/pages/DashboardPage.vue
+++ b/frontend/src/pages/DashboardPage.vue
@@ -21,73 +21,84 @@
     <!-- Usage Statistics -->
     <q-card>
       <q-card-section>
-        <div class="row items-center justify-between q-mb-md">
-          <div class="text-h6">Usage Statistics</div>
-          <div class="row q-gutter-sm">
-            <div v-if="groupBy === 'token'" class="row items-center q-gutter-sm">
-              <span class="text-caption">Show Active:</span>
-              <q-toggle
-                v-model="showActiveTokens"
-                dark
-                color="primary"
-              />
-            </div>
-            <q-input
-              v-model="startDate"
-              label="Start Date"
-              outlined
-              dense
+        <div class="row items-center no-wrap q-gutter-sm q-mb-md">
+          <div class="text-h6 q-mr-sm">Usage Statistics</div>
+          <div v-if="groupBy === 'token'" class="row items-center no-wrap q-gutter-xs">
+            <span class="text-caption">Active:</span>
+            <q-toggle
+              v-model="showActiveTokens"
               dark
-              type="date"
-              :min="minAllowedDate"
-              style="width: 160px"
-            />
-            <q-input
-              v-model="endDate"
-              label="End Date"
-              outlined
+              color="primary"
               dense
-              dark
-              type="date"
-              :min="minAllowedDate"
-              style="width: 160px"
-            />
-            <q-select
-              v-model="groupBy"
-              :options="groupByOptions"
-              label="Group By"
-              outlined
-              dense
-              dark
-              style="width: 150px"
-              emit-value
-              map-options
-            />
-            <q-select
-              v-if="groupBy === 'token'"
-              v-model="selectedToken"
-              :options="tokenOptions"
-              label="Filter API Key"
-              outlined
-              dense
-              dark
-              clearable
-              style="width: 200px"
-              emit-value
-              map-options
-            />
-            <q-select
-              v-if="groupBy === 'model'"
-              v-model="selectedModel"
-              :options="modelOptions"
-              label="Filter Model"
-              outlined
-              dense
-              dark
-              clearable
-              style="width: 200px"
             />
           </div>
+          <q-input
+            v-model="startDate"
+            label="Start"
+            outlined
+            dense
+            dark
+            type="date"
+            :min="minAllowedDate"
+            style="width: 150px"
+          />
+          <q-input
+            v-model="endDate"
+            label="End"
+            outlined
+            dense
+            dark
+            type="date"
+            :min="minAllowedDate"
+            style="width: 150px"
+          />
+          <q-select
+            v-model="groupBy"
+            :options="groupByOptions"
+            label="Group By"
+            outlined
+            dense
+            dark
+            style="width: 140px"
+            emit-value
+            map-options
+          />
+          <q-select
+            v-if="groupBy === 'token'"
+            v-model="selectedToken"
+            :options="tokenOptions"
+            label="API Key"
+            outlined
+            dense
+            dark
+            clearable
+            style="width: 180px"
+            emit-value
+            map-options
+          />
+          <q-select
+            v-if="groupBy === 'model'"
+            v-model="selectedModel"
+            :options="modelOptions"
+            label="Model"
+            outlined
+            dense
+            dark
+            clearable
+            style="width: 180px"
+          />
+          <q-btn
+            icon="download"
+            flat
+            dense
+            round
+            size="xs"
+            color="grey-7"
+            :loading="exporting"
+            @click="exportCsv"
+          >
+            <q-tooltip>Export CSV</q-tooltip>
+          </q-btn>
         </div>
 
         <q-table
@@ -133,9 +144,11 @@
 import { ref, computed, onMounted, watch } from 'vue';
 import { useTokensStore } from 'src/stores/tokens';
 import { useDashboardStore } from 'src/stores/dashboard';
+import { api } from 'src/boot/axios';
 
 const tokensStore = useTokensStore();
 const dashboardStore = useDashboardStore();
+const exporting = ref(false);
 
 const groupBy = ref<'token' | 'model'>('token');
 const selectedToken = ref<string | null>(null);
@@ -169,7 +182,7 @@ const totalBalance = computed(() => {
     return sum + used;
   }, 0);
 
-  return (totalQuota - totalUsed).toFixed(8);
+  return (totalQuota - totalUsed).toFixed(2);
 });
 
 const tokenOptions = computed(() => [
@@ -332,8 +345,65 @@ watch([startDate, endDate], async () => {
   }
 });
 
+async function exportCsv() {
+  exporting.value = true;
+  try {
+    const params: Record<string, string> = {
+      granularity: 'daily',
+      tz: Intl.DateTimeFormat().resolvedOptions().timeZone,
+    };
+    if (startDate.value) {
+      const start = new Date(startDate.value);
+      start.setHours(0, 0, 0, 0);
+      params.start_date = start.toISOString();
+    } else {
+      const d = new Date();
+      d.setDate(d.getDate() - 30);
+      params.start_date = d.toISOString();
+    }
+    if (endDate.value) {
+      const end = new Date(endDate.value);
+      end.setHours(23, 59, 59, 999);
+      params.end_date = end.toISOString();
+    } else {
+      params.end_date = new Date().toISOString();
+    }
+    if (selectedToken.value && groupBy.value === 'token') {
+      params.token_id = selectedToken.value;
+    }
+    if (selectedModel.value && groupBy.value === 'model' && selectedModel.value !== 'All') {
+      params.model = selectedModel.value;
+    }
+
+    const response = await api.get('/admin/usage/breakdown', { params });
+    const rows = response.data.data as Array<Record<string, unknown>>;
+
+    const headers = ['Date', 'API Key', 'Model', 'Prompt Tokens', 'Completion Tokens', 'Total Tokens', 'Requests', 'Cost (USD)'];
+    const csvRows = rows.map(r => [
+      r.time_bucket,
+      r.token_name,
+      r.model,
+      r.prompt_tokens,
+      r.completion_tokens,
+      r.total_tokens,
+      r.request_count,
+      r.total_cost,
+    ].map(v => `"${String(v).replace(/"/g, '""')}"`).join(','));
+
+    const csv = [headers.join(','), ...csvRows].join('\n');
+    const blob = new Blob([csv], { type: 'text/csv;charset=utf-8;' });
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement('a');
+    link.href = url;
+    link.download = `usage_${params.start_date.slice(0, 10)}_${params.end_date.slice(0, 10)}.csv`;
+    link.click();
+    URL.revokeObjectURL(url);
+  } finally {
+    exporting.value = false;
+  }
+}
+
 onMounted(async () => {
-  // 并行加载所有数据以提高性能
   await Promise.all([
     tokensStore.fetchTokens(),
     fetchUsageByToken(),

--- a/frontend/src/pages/DashboardPage.vue
+++ b/frontend/src/pages/DashboardPage.vue
@@ -22,7 +22,8 @@
     <q-card>
       <q-card-section>
         <div class="row items-center no-wrap q-gutter-sm q-mb-md">
-          <div class="text-h6 q-mr-sm">Usage Statistics</div>
+          <div class="text-h6">Usage Statistics</div>
+          <q-space />
           <div v-if="groupBy === 'token'" class="row items-center no-wrap q-gutter-xs">
             <span class="text-caption">Active:</span>
             <q-toggle

--- a/frontend/src/pages/PlaygroundPage.vue
+++ b/frontend/src/pages/PlaygroundPage.vue
@@ -56,6 +56,7 @@
             </div>
 
             <q-input
+              v-if="supportsTemperature"
               v-model.number="temperature"
               label="Temperature"
               outlined
@@ -280,6 +281,11 @@ const modelOptions = computed(() => {
     }));
 });
 
+const supportsTemperature = computed(() => {
+  const model = selectedModel.value || '';
+  return !model.includes('opus-4-7');
+});
+
 /** Image generation models don't support streaming */
 function isImageModel(modelId: string | null): boolean {
   if (!modelId) return false;
@@ -462,7 +468,7 @@ async function sendViaOpenAI(plainToken: string, assistantMsgIndex: number) {
       model: selectedModel.value,
       messages: getOpenAIMessages(),
       stream: useStream,
-      ...(temperature.value !== null && { temperature: temperature.value }),
+      ...(supportsTemperature.value && temperature.value !== null && { temperature: temperature.value }),
       ...(maxTokens.value !== null && { max_tokens: maxTokens.value }),
     }),
   });
@@ -532,7 +538,7 @@ async function sendViaAnthropic(plainToken: string, assistantMsgIndex: number) {
       messages: getAnthropicMessages(),
       stream: true,
       max_tokens: maxTokens.value || 2048,
-      ...(temperature.value !== null && { temperature: temperature.value }),
+      ...(supportsTemperature.value && temperature.value !== null && { temperature: temperature.value }),
     }),
   });
 

--- a/frontend/src/pages/TeamsPage.vue
+++ b/frontend/src/pages/TeamsPage.vue
@@ -1,0 +1,859 @@
+<template>
+  <q-page class="q-pa-md">
+    <!-- Team List View -->
+    <template v-if="!selectedTeam">
+      <div class="row items-center justify-between q-mb-md">
+        <div class="text-h4">Teams</div>
+        <q-btn
+          color="grey-8"
+          icon="add"
+          label="Create Team"
+          @click="showCreateDialog = true"
+          unelevated
+        />
+      </div>
+
+      <q-card>
+        <q-card-section>
+          <q-table
+            :rows="teams"
+            :columns="teamColumns"
+            row-key="id"
+            :loading="loading"
+            flat
+            bordered
+          >
+            <template v-slot:body-cell-name="props">
+              <q-td :props="props">
+                <a
+                  class="text-weight-bold cursor-pointer text-primary"
+                  @click="selectTeam(props.row.id)"
+                >
+                  {{ props.row.name }}
+                </a>
+              </q-td>
+            </template>
+
+            <template v-slot:body-cell-budget="props">
+              <q-td :props="props">
+                ${{ props.row.monthly_budget_usd }}
+              </q-td>
+            </template>
+
+            <template v-slot:body-cell-used="props">
+              <q-td :props="props">
+                <div>${{ props.row.total_used_usd }}</div>
+                <q-linear-progress
+                  :value="getBudgetProgress(props.row)"
+                  :color="getBudgetColor(props.row)"
+                  class="q-mt-xs"
+                  style="max-width: 120px"
+                />
+              </q-td>
+            </template>
+
+            <template v-slot:body-cell-unallocated="props">
+              <q-td :props="props">
+                ${{ props.row.unallocated_pool_usd }}
+              </q-td>
+            </template>
+
+            <template v-slot:body-cell-policy="props">
+              <q-td :props="props">
+                <q-badge
+                  :color="props.row.monthly_reset_policy === 'reset' ? 'blue-7' : 'teal-7'"
+                  :label="props.row.monthly_reset_policy"
+                />
+              </q-td>
+            </template>
+
+            <template v-slot:body-cell-actions="props">
+              <q-td :props="props">
+                <q-btn
+                  flat
+                  dense
+                  round
+                  size="xs"
+                  icon="edit"
+                  color="grey-7"
+                  @click.stop="editTeam(props.row)"
+                  class="q-mr-xs"
+                >
+                  <q-tooltip>Edit Team</q-tooltip>
+                </q-btn>
+                <q-btn
+                  flat
+                  dense
+                  round
+                  size="xs"
+                  icon="delete"
+                  color="negative"
+                  @click.stop="confirmDeleteTeam(props.row)"
+                >
+                  <q-tooltip>Delete Team</q-tooltip>
+                </q-btn>
+              </q-td>
+            </template>
+          </q-table>
+        </q-card-section>
+      </q-card>
+    </template>
+
+    <!-- Team Dashboard View -->
+    <template v-else>
+      <div class="row items-center q-mb-md">
+        <q-btn
+          flat
+          round
+          icon="arrow_back"
+          @click="teamsStore.currentTeam = null"
+          class="q-mr-sm"
+        />
+        <div class="text-h4">{{ selectedTeam.name }}</div>
+        <q-space />
+        <q-btn
+          color="grey-8"
+          icon="playlist_add"
+          label="Batch Create"
+          @click="showBatchDialog = true"
+          unelevated
+          class="q-mr-sm"
+        />
+        <q-btn
+          color="grey-8"
+          icon="swap_horiz"
+          label="Transfer"
+          @click="showTransferDialog = true"
+          unelevated
+          :disable="selectedTeam.members.length < 2"
+        />
+      </div>
+
+      <!-- Budget Summary -->
+      <div class="row q-gutter-md q-mb-md">
+        <q-card class="col">
+          <q-card-section>
+            <div class="text-caption text-grey-7">Monthly Budget</div>
+            <div class="text-h5">${{ selectedTeam.monthly_budget_usd }}</div>
+          </q-card-section>
+        </q-card>
+        <q-card class="col">
+          <q-card-section>
+            <div class="text-caption text-grey-7">Total Used</div>
+            <div class="text-h5">${{ selectedTeam.total_used_usd }}</div>
+          </q-card-section>
+        </q-card>
+        <q-card class="col">
+          <q-card-section>
+            <div class="text-caption text-grey-7">Unallocated Pool</div>
+            <div class="text-h5">${{ selectedTeam.unallocated_pool_usd }}</div>
+          </q-card-section>
+        </q-card>
+        <q-card v-if="selectedTeam.daily_limit_enabled" class="col">
+          <q-card-section>
+            <div class="text-caption text-grey-7">Daily Budget (team)</div>
+            <div class="text-h5">${{ teamDailyBudget }}</div>
+            <div class="text-caption text-grey-7">= monthly / {{ daysInMonth }} days</div>
+          </q-card-section>
+        </q-card>
+        <q-card class="col">
+          <q-card-section>
+            <div class="text-caption text-grey-7">Reset Policy</div>
+            <div class="text-h5">
+              <q-badge
+                :color="selectedTeam.monthly_reset_policy === 'reset' ? 'blue-7' : 'teal-7'"
+                :label="selectedTeam.monthly_reset_policy"
+                class="text-body1"
+              />
+            </div>
+          </q-card-section>
+        </q-card>
+      </div>
+
+      <!-- Members Table -->
+      <q-card>
+        <q-card-section>
+          <div class="text-h6 q-mb-sm">Members</div>
+          <q-table
+            :rows="selectedTeam.members"
+            :columns="memberColumns"
+            row-key="token_id"
+            :loading="loading"
+            flat
+            bordered
+          >
+            <template v-slot:body-cell-name="props">
+              <q-td :props="props">
+                <div class="text-weight-bold">{{ props.row.token_name }}</div>
+              </q-td>
+            </template>
+
+            <template v-slot:body-cell-allocation="props">
+              <q-td :props="props">
+                ${{ Number(props.row.allocated_usd).toFixed(2) }}
+              </q-td>
+            </template>
+
+            <template v-slot:body-cell-used="props">
+              <q-td :props="props">
+                <div>${{ Number(props.row.used_usd).toFixed(2) }} / ${{ Number(props.row.allocated_usd).toFixed(2) }}</div>
+                <q-linear-progress
+                  :value="getMemberProgress(props.row)"
+                  :color="getMemberColor(props.row)"
+                  class="q-mt-xs"
+                  style="max-width: 120px"
+                />
+              </q-td>
+            </template>
+
+            <template v-slot:body-cell-remaining="props">
+              <q-td :props="props">
+                ${{ Number(props.row.remaining_usd).toFixed(2) }}
+              </q-td>
+            </template>
+
+            <template v-slot:body-cell-daily="props">
+              <q-td :props="props">
+                <div>${{ Number(props.row.daily_used_usd).toFixed(2) }} / ${{ Number(props.row.daily_limit_usd).toFixed(2) }}</div>
+              </q-td>
+            </template>
+
+            <template v-slot:body-cell-status="props">
+              <q-td :props="props">
+                <q-badge
+                  :color="props.row.is_active ? 'positive' : 'grey'"
+                  :label="props.row.is_active ? 'Active' : 'Inactive'"
+                />
+              </q-td>
+            </template>
+
+            <template v-slot:body-cell-actions="props">
+              <q-td :props="props">
+                <q-btn
+                  flat
+                  dense
+                  round
+                  size="xs"
+                  icon="tune"
+                  color="grey-7"
+                  @click="openAdjustDialog(props.row)"
+                  class="q-mr-xs"
+                >
+                  <q-tooltip>Adjust Allocation</q-tooltip>
+                </q-btn>
+                <q-btn
+                  flat
+                  dense
+                  round
+                  size="xs"
+                  icon="person_remove"
+                  color="negative"
+                  @click="confirmRemoveMember(props.row)"
+                >
+                  <q-tooltip>Remove Member</q-tooltip>
+                </q-btn>
+              </q-td>
+            </template>
+          </q-table>
+        </q-card-section>
+      </q-card>
+    </template>
+
+    <!-- Create Team Dialog -->
+    <q-dialog v-model="showCreateDialog">
+      <q-card dark style="min-width: 450px">
+        <q-card-section>
+          <div class="text-h6">Create Team</div>
+        </q-card-section>
+        <q-card-section class="q-pt-none">
+          <q-form @submit="handleCreateTeam">
+            <q-input
+              v-model="createForm.name"
+              label="Team Name"
+              outlined
+              rounded
+              dark
+              :rules="[(val) => !!val || 'Required']"
+              class="q-mb-md"
+            />
+            <q-input
+              v-model="createForm.monthly_budget_usd"
+              label="Monthly Budget (USD)"
+              outlined
+              rounded
+              dark
+              type="text"
+              :rules="[(val) => !!val || 'Required']"
+              class="q-mb-md"
+            />
+            <q-select
+              v-model="createForm.monthly_reset_policy"
+              :options="policyOptions"
+              label="Reset Policy"
+              outlined
+              rounded
+              dark
+              emit-value
+              map-options
+              class="q-mb-md"
+            />
+            <q-item dark dense class="q-mb-md">
+              <q-item-section>
+                <q-item-label>Daily Use Limitation</q-item-label>
+                <q-item-label caption>Limit each member's daily spending (allocation / days in month)</q-item-label>
+              </q-item-section>
+              <q-item-section side>
+                <q-toggle v-model="createForm.daily_limit_enabled" dark />
+              </q-item-section>
+            </q-item>
+            <div class="row justify-end q-gutter-sm">
+              <q-btn label="Cancel" flat v-close-popup />
+              <q-btn
+                label="Create"
+                type="submit"
+                color="grey-8"
+                :loading="creating"
+                unelevated
+              />
+            </div>
+          </q-form>
+        </q-card-section>
+      </q-card>
+    </q-dialog>
+
+    <!-- Edit Team Dialog -->
+    <q-dialog v-model="showEditDialog">
+      <q-card dark style="min-width: 450px">
+        <q-card-section>
+          <div class="text-h6">Edit Team</div>
+        </q-card-section>
+        <q-card-section class="q-pt-none">
+          <q-form @submit="handleUpdateTeam">
+            <q-input
+              v-model="editForm.name"
+              label="Team Name"
+              outlined
+              rounded
+              dark
+              class="q-mb-md"
+            />
+            <q-input
+              v-model="editForm.monthly_budget_usd"
+              label="Monthly Budget (USD)"
+              outlined
+              rounded
+              dark
+              type="text"
+              class="q-mb-md"
+            />
+            <q-select
+              v-model="editForm.monthly_reset_policy"
+              :options="policyOptions"
+              label="Reset Policy"
+              outlined
+              rounded
+              dark
+              emit-value
+              map-options
+              class="q-mb-md"
+            />
+            <q-item dark dense class="q-mb-md">
+              <q-item-section>
+                <q-item-label>Daily Use Limitation</q-item-label>
+                <q-item-label caption>Limit each member's daily spending (allocation / days in month)</q-item-label>
+              </q-item-section>
+              <q-item-section side>
+                <q-toggle v-model="editForm.daily_limit_enabled" dark />
+              </q-item-section>
+            </q-item>
+            <div class="row justify-end q-gutter-sm">
+              <q-btn label="Cancel" flat v-close-popup />
+              <q-btn
+                label="Save"
+                type="submit"
+                color="grey-8"
+                :loading="updating"
+                unelevated
+              />
+            </div>
+          </q-form>
+        </q-card-section>
+      </q-card>
+    </q-dialog>
+
+
+    <!-- Adjust Allocation Dialog -->
+    <q-dialog v-model="showAdjustDialog">
+      <q-card dark style="min-width: 400px">
+        <q-card-section>
+          <div class="text-h6">Adjust Allocation</div>
+          <div class="text-caption text-grey-7 q-mt-xs">
+            Member: {{ adjustForm.token_name }}
+          </div>
+        </q-card-section>
+        <q-card-section class="q-pt-none">
+          <div class="q-mb-md">
+            <div class="text-caption text-grey-7">Current Allocation</div>
+            <div class="text-h6 text-primary">${{ adjustForm.current }}</div>
+          </div>
+          <div class="q-mb-md">
+            <div class="text-caption text-grey-7">Unallocated Pool</div>
+            <div class="text-body1">${{ selectedTeam?.unallocated_pool_usd }}</div>
+          </div>
+          <q-input
+            v-model="adjustForm.new_amount"
+            label="New Allocation (USD)"
+            outlined
+            rounded
+            dark
+            type="text"
+          />
+        </q-card-section>
+        <q-card-actions align="right">
+          <q-btn label="Cancel" flat v-close-popup />
+          <q-btn
+            label="Save"
+            color="grey-8"
+            @click="handleAdjust"
+            :loading="adjusting"
+            unelevated
+          />
+        </q-card-actions>
+      </q-card>
+    </q-dialog>
+
+    <!-- Transfer Dialog -->
+    <q-dialog v-model="showTransferDialog">
+      <q-card dark style="min-width: 450px">
+        <q-card-section>
+          <div class="text-h6">Transfer Allocation</div>
+        </q-card-section>
+        <q-card-section class="q-pt-none">
+          <q-form @submit="handleTransfer">
+            <q-select
+              v-model="transferForm.from_token_id"
+              :options="memberOptions"
+              label="From"
+              outlined
+              rounded
+              dark
+              emit-value
+              map-options
+              option-label="label"
+              option-value="value"
+              :rules="[(val) => !!val || 'Required']"
+              class="q-mb-md"
+            />
+            <q-select
+              v-model="transferForm.to_token_id"
+              :options="memberOptions"
+              label="To"
+              outlined
+              rounded
+              dark
+              emit-value
+              map-options
+              option-label="label"
+              option-value="value"
+              :rules="[(val) => !!val || 'Required', (val) => val !== transferForm.from_token_id || 'Must differ from source']"
+              class="q-mb-md"
+            />
+            <q-input
+              v-model="transferForm.amount"
+              label="Amount (USD)"
+              outlined
+              rounded
+              dark
+              type="text"
+              :rules="[(val) => !!val || 'Required']"
+              class="q-mb-md"
+            />
+            <div class="row justify-end q-gutter-sm">
+              <q-btn label="Cancel" flat v-close-popup />
+              <q-btn
+                label="Transfer"
+                type="submit"
+                color="grey-8"
+                :loading="transferring"
+                unelevated
+              />
+            </div>
+          </q-form>
+        </q-card-section>
+      </q-card>
+    </q-dialog>
+
+    <!-- Batch Create Members Dialog -->
+    <q-dialog v-model="showBatchDialog">
+      <q-card dark style="min-width: 500px">
+        <q-card-section>
+          <div class="text-h6">Batch Create Members</div>
+          <div class="text-caption text-grey-7 q-mt-xs">
+            Unallocated pool: ${{ selectedTeam?.unallocated_pool_usd }}
+          </div>
+        </q-card-section>
+        <q-card-section class="q-pt-none">
+          <q-form @submit="handleBatchCreate">
+            <q-input
+              v-model="batchForm.names"
+              label="Names"
+              outlined
+              rounded
+              dark
+              type="textarea"
+              autogrow
+              :rules="[(val) => !!val?.trim() || 'Required']"
+              hint="Separate with comma or newline"
+              class="q-mb-md"
+            />
+            <q-input
+              :model-value="computedPerMemberAllocation"
+              label="Allocation per Member (USD)"
+              outlined
+              rounded
+              dark
+              readonly
+              hint="Auto-calculated: unallocated pool / member count"
+              class="q-mb-md"
+            />
+            <q-input
+              v-if="selectedTeam?.daily_limit_enabled"
+              :model-value="computedPerMemberDaily"
+              label="Daily Limit per Member (USD)"
+              outlined
+              rounded
+              dark
+              readonly
+              :hint="`= ${computedPerMemberAllocation} / ${daysInMonth} days`"
+              class="q-mb-md"
+            />
+            <q-select
+              v-model="batchForm.model_names"
+              :options="availableModelOptions"
+              label="Models (optional)"
+              outlined
+              rounded
+              dark
+              multiple
+              use-chips
+              option-label="label"
+              option-value="value"
+              emit-value
+              map-options
+              :loading="modelsLoading"
+              class="q-mb-md"
+            />
+            <div class="row justify-end q-gutter-sm">
+              <q-btn label="Cancel" flat v-close-popup />
+              <q-btn
+                label="Create"
+                type="submit"
+                color="grey-8"
+                :loading="batchCreating"
+                unelevated
+              />
+            </div>
+          </q-form>
+        </q-card-section>
+      </q-card>
+    </q-dialog>
+  </q-page>
+</template>
+
+<script setup lang="ts">
+import { ref, computed, onMounted } from 'vue';
+import { useTeamsStore } from 'src/stores/teams';
+import { useTokensStore } from 'src/stores/tokens';
+import { useModelsStore } from 'src/stores/models';
+import { Dialog } from 'quasar';
+import type { TeamListItem, TeamMember } from 'src/stores/teams';
+
+const teamsStore = useTeamsStore();
+const tokensStore = useTokensStore();
+const modelsStore = useModelsStore();
+
+const selectedTeam = computed(() => teamsStore.currentTeam);
+const teams = computed(() => teamsStore.teams);
+const loading = computed(() => teamsStore.loading);
+const modelsLoading = computed(() => modelsStore.loading);
+
+const showCreateDialog = ref(false);
+const showEditDialog = ref(false);
+const showAdjustDialog = ref(false);
+const showTransferDialog = ref(false);
+const showBatchDialog = ref(false);
+
+const creating = ref(false);
+const updating = ref(false);
+const adjusting = ref(false);
+const transferring = ref(false);
+const batchCreating = ref(false);
+
+const editingTeamId = ref('');
+
+const createForm = ref({
+  name: '',
+  monthly_budget_usd: '',
+  monthly_reset_policy: 'reset',
+  daily_limit_enabled: true,
+});
+
+const editForm = ref({
+  name: '',
+  monthly_budget_usd: '',
+  monthly_reset_policy: 'reset',
+  daily_limit_enabled: true,
+});
+
+
+const adjustForm = ref({
+  token_id: '',
+  token_name: '',
+  current: '',
+  new_amount: '',
+});
+
+const transferForm = ref({
+  from_token_id: '',
+  to_token_id: '',
+  amount: '',
+});
+
+const batchForm = ref({
+  names: '',
+  model_names: [] as string[],
+});
+
+const policyOptions = [
+  { label: 'Reset (clear each month)', value: 'reset' },
+  { label: 'Rollover (accumulate unused)', value: 'rollover' },
+];
+
+const teamColumns = [
+  { name: 'name', label: 'Name', field: 'name', align: 'left' as const },
+  { name: 'budget', label: 'Monthly Budget', field: 'monthly_budget_usd', align: 'left' as const },
+  { name: 'used', label: 'Used', field: 'total_used_usd', align: 'left' as const },
+  { name: 'unallocated', label: 'Unallocated', field: 'unallocated_pool_usd', align: 'left' as const },
+  { name: 'policy', label: 'Policy', field: 'monthly_reset_policy', align: 'center' as const },
+  { name: 'actions', label: 'Actions', field: 'id', align: 'center' as const },
+];
+
+const memberColumns = computed(() => {
+  const cols: { name: string; label: string; field: string; align: 'left' | 'center' | 'right' }[] = [
+    { name: 'name', label: 'Name', field: 'token_name', align: 'left' },
+    { name: 'allocation', label: 'Allocation', field: 'allocated_usd', align: 'left' },
+    { name: 'used', label: 'Used / Allocation', field: 'used_usd', align: 'left' },
+    { name: 'remaining', label: 'Remaining', field: 'remaining_usd', align: 'left' },
+  ];
+  if (selectedTeam.value?.daily_limit_enabled) {
+    cols.push({ name: 'daily', label: 'Daily', field: 'daily_limit_usd', align: 'left' });
+  }
+  cols.push(
+    { name: 'status', label: 'Status', field: 'is_active', align: 'center' },
+    { name: 'actions', label: 'Actions', field: 'token_id', align: 'center' },
+  );
+  return cols;
+});
+
+const memberOptions = computed(() => {
+  return (selectedTeam.value?.members || []).map((m) => ({
+    label: `${m.token_name} ($${m.allocated_usd})`,
+    value: m.token_id,
+  }));
+});
+
+const availableModelOptions = computed(() =>
+  modelsStore.availableModels.map((m) => ({
+    label: `${m.friendly_name} (${m.model_id})`,
+    value: m.model_id,
+  }))
+);
+
+const computedPerMemberAllocation = computed(() => {
+  const pool = parseFloat(selectedTeam.value?.unallocated_pool_usd || '0');
+  const names = batchForm.value.names.trim();
+  if (!names) return '--';
+  const count = names.split(/[,\n]+/).filter((n) => n.trim()).length;
+  if (count === 0) return '--';
+  return (pool / count).toFixed(2);
+});
+
+const computedPerMemberDaily = computed(() => {
+  if (computedPerMemberAllocation.value === '--') return '--';
+  const allocation = parseFloat(computedPerMemberAllocation.value);
+  if (allocation <= 0) return '--';
+  return (allocation / daysInMonth.value).toFixed(2);
+});
+
+const daysInMonth = computed(() => {
+  const now = new Date();
+  return new Date(now.getFullYear(), now.getMonth() + 1, 0).getDate();
+});
+
+const teamDailyBudget = computed(() => {
+  if (!selectedTeam.value) return '0.00';
+  const monthly = parseFloat(selectedTeam.value.monthly_budget_usd);
+  return (monthly / daysInMonth.value).toFixed(2);
+});
+
+function getBudgetProgress(team: TeamListItem) {
+  const used = parseFloat(team.total_used_usd);
+  const budget = parseFloat(team.monthly_budget_usd);
+  return budget > 0 ? used / budget : 0;
+}
+
+function getBudgetColor(team: TeamListItem) {
+  const p = getBudgetProgress(team);
+  if (p >= 0.9) return 'negative';
+  if (p >= 0.7) return 'warning';
+  return 'positive';
+}
+
+function getMemberProgress(member: TeamMember) {
+  const used = parseFloat(member.used_usd);
+  const allocated = parseFloat(member.allocated_usd);
+  return allocated > 0 ? used / allocated : 0;
+}
+
+function getMemberColor(member: TeamMember) {
+  const p = getMemberProgress(member);
+  if (p >= 0.9) return 'negative';
+  if (p >= 0.7) return 'warning';
+  return 'positive';
+}
+
+async function selectTeam(teamId: string) {
+  await teamsStore.fetchTeamDashboard(teamId);
+}
+
+function editTeam(team: TeamListItem) {
+  editingTeamId.value = team.id;
+  editForm.value = {
+    name: team.name,
+    monthly_budget_usd: team.monthly_budget_usd,
+    monthly_reset_policy: team.monthly_reset_policy,
+    daily_limit_enabled: team.daily_limit_enabled,
+  };
+  showEditDialog.value = true;
+}
+
+function confirmDeleteTeam(team: TeamListItem) {
+  Dialog.create({
+    title: 'Delete Team',
+    message: `Are you sure you want to delete team "${team.name}"? Members will become standalone tokens.`,
+    cancel: { label: 'Cancel', color: 'grey-7', flat: true },
+    ok: { label: 'Delete', color: 'negative', unelevated: true },
+    persistent: true,
+    dark: true,
+  }).onOk(() => {
+    void teamsStore.deleteTeam(team.id);
+  });
+}
+
+function openAdjustDialog(member: TeamMember) {
+  adjustForm.value = {
+    token_id: member.token_id,
+    token_name: member.token_name,
+    current: member.allocated_usd,
+    new_amount: member.allocated_usd,
+  };
+  showAdjustDialog.value = true;
+}
+
+function confirmRemoveMember(member: TeamMember) {
+  Dialog.create({
+    title: 'Remove Member',
+    message: `Remove "${member.token_name}" from this team? Allocation will return to the pool.`,
+    cancel: { label: 'Cancel', color: 'grey-7', flat: true },
+    ok: { label: 'Remove', color: 'negative', unelevated: true },
+    persistent: true,
+    dark: true,
+  }).onOk(() => {
+    if (selectedTeam.value) {
+      void teamsStore.removeMember(selectedTeam.value.id, member.token_id).then(() => {
+        void tokensStore.fetchTokens(false, true);
+      });
+    }
+  });
+}
+
+async function handleCreateTeam() {
+  creating.value = true;
+  try {
+    await teamsStore.createTeam(createForm.value);
+    showCreateDialog.value = false;
+    createForm.value = { name: '', monthly_budget_usd: '', monthly_reset_policy: 'reset', daily_limit_enabled: true };
+  } finally {
+    creating.value = false;
+  }
+}
+
+async function handleUpdateTeam() {
+  updating.value = true;
+  try {
+    await teamsStore.updateTeam(editingTeamId.value, editForm.value);
+    showEditDialog.value = false;
+  } finally {
+    updating.value = false;
+  }
+}
+
+
+
+async function handleAdjust() {
+  if (!selectedTeam.value) return;
+  adjusting.value = true;
+  try {
+    await teamsStore.adjustMember(
+      selectedTeam.value.id,
+      adjustForm.value.token_id,
+      adjustForm.value.new_amount,
+    );
+    showAdjustDialog.value = false;
+  } finally {
+    adjusting.value = false;
+  }
+}
+
+async function handleTransfer() {
+  if (!selectedTeam.value) return;
+  transferring.value = true;
+  try {
+    await teamsStore.transferAllocation(
+      selectedTeam.value.id,
+      transferForm.value.from_token_id,
+      transferForm.value.to_token_id,
+      transferForm.value.amount,
+    );
+    showTransferDialog.value = false;
+    transferForm.value = { from_token_id: '', to_token_id: '', amount: '' };
+  } finally {
+    transferring.value = false;
+  }
+}
+
+async function handleBatchCreate() {
+  if (!selectedTeam.value) return;
+  batchCreating.value = true;
+  try {
+    const batchData: { names: string; per_member_allocation: string; model_names?: string[] } = {
+      names: batchForm.value.names,
+      per_member_allocation: computedPerMemberAllocation.value,
+    };
+    if (batchForm.value.model_names.length > 0) {
+      batchData.model_names = batchForm.value.model_names;
+    }
+    await teamsStore.batchCreateMembers(selectedTeam.value.id, batchData);
+    void tokensStore.fetchTokens(false, true);
+    showBatchDialog.value = false;
+    batchForm.value = { names: '', model_names: [] };
+  } finally {
+    batchCreating.value = false;
+  }
+}
+
+onMounted(async () => {
+  await teamsStore.fetchTeams();
+  void modelsStore.fetchAvailableModels();
+});
+</script>

--- a/frontend/src/pages/TeamsPage.vue
+++ b/frontend/src/pages/TeamsPage.vue
@@ -630,7 +630,7 @@ const policyOptions = [
 ];
 
 const teamColumns = [
-  { name: 'name', label: 'Name', field: 'name', align: 'left' as const },
+  { name: 'name', label: 'Name', field: 'name', align: 'left' as const, sortable: true },
   { name: 'budget', label: 'Monthly Budget', field: 'monthly_budget_usd', align: 'left' as const },
   { name: 'used', label: 'Used', field: 'total_used_usd', align: 'left' as const },
   { name: 'unallocated', label: 'Unallocated', field: 'unallocated_pool_usd', align: 'left' as const },
@@ -639,8 +639,8 @@ const teamColumns = [
 ];
 
 const memberColumns = computed(() => {
-  const cols: { name: string; label: string; field: string; align: 'left' | 'center' | 'right' }[] = [
-    { name: 'name', label: 'Name', field: 'token_name', align: 'left' },
+  const cols: { name: string; label: string; field: string; align: 'left' | 'center' | 'right'; sortable?: boolean }[] = [
+    { name: 'name', label: 'Name', field: 'token_name', align: 'left', sortable: true },
     { name: 'allocation', label: 'Allocation', field: 'allocated_usd', align: 'left' },
     { name: 'used', label: 'Used / Allocation', field: 'used_usd', align: 'left' },
     { name: 'remaining', label: 'Remaining', field: 'remaining_usd', align: 'left' },

--- a/frontend/src/pages/TokensPage.vue
+++ b/frontend/src/pages/TokensPage.vue
@@ -67,7 +67,7 @@
                   flat
                   dense
                   round
-                  size="sm"
+                  size="xs"
                   icon="content_copy"
                   color="grey-7"
                   @click="copyTokenKey(props.row)"
@@ -92,7 +92,16 @@
           <template v-slot:body-cell-quota="props">
             <q-td :props="props">
               <div v-if="props.row.quota_usd">
-                ${{ props.row.used_usd }} / ${{ props.row.quota_usd }}
+                ${{ Number(props.row.used_usd).toFixed(2) }} / ${{ Number(props.row.quota_usd).toFixed(2) }}
+                <q-linear-progress
+                  :value="getQuotaProgress(props.row)"
+                  :color="getQuotaColor(props.row)"
+                  class="q-mt-xs"
+                />
+              </div>
+              <div v-else-if="props.row.allocated_usd">
+                ${{ Number(props.row.used_usd).toFixed(2) }} / ${{ Number(props.row.allocated_usd).toFixed(2) }}
+                <span class="text-caption text-grey-6 q-ml-xs">(team)</span>
                 <q-linear-progress
                   :value="getQuotaProgress(props.row)"
                   :color="getQuotaColor(props.row)"
@@ -127,6 +136,7 @@
                 flat
                 dense
                 round
+                size="xs"
                 icon="settings"
                 color="grey-7"
                 @click="openSettings(props.row)"
@@ -138,6 +148,7 @@
                 flat
                 dense
                 round
+                size="xs"
                 icon="account_balance_wallet"
                 color="positive"
                 @click="rechargeToken(props.row)"
@@ -149,6 +160,7 @@
                 flat
                 dense
                 round
+                size="xs"
                 icon="delete"
                 color="negative"
                 @click="deleteToken(props.row)"
@@ -684,8 +696,9 @@ function getStatusLabel(token: APIToken) {
 }
 
 function getQuotaProgress(token: APIToken) {
-  if (!token.quota_usd) return 0;
-  return parseFloat(token.used_usd) / parseFloat(token.quota_usd);
+  const limit = token.quota_usd || token.allocated_usd;
+  if (!limit) return 0;
+  return parseFloat(token.used_usd) / parseFloat(limit);
 }
 
 function getQuotaColor(token: APIToken) {

--- a/frontend/src/pages/TokensPage.vue
+++ b/frontend/src/pages/TokensPage.vue
@@ -47,12 +47,6 @@
           flat
           bordered
         >
-          <template v-slot:body-cell-id="props">
-            <q-td :props="props">
-              <div class="text-mono text-caption">{{ props.row.id }}</div>
-            </q-td>
-          </template>
-
           <template v-slot:body-cell-name="props">
             <q-td :props="props">
               <div class="text-weight-bold">{{ props.row.name }}</div>
@@ -621,16 +615,11 @@ const newToken = ref({
 
 const columns = [
   {
-    name: 'id',
-    label: 'ID',
-    field: 'id',
-    align: 'left' as const,
-  },
-  {
     name: 'name',
     label: 'Name',
     field: 'name',
     align: 'left' as const,
+    sortable: true,
   },
   {
     name: 'key',

--- a/frontend/src/router/routes.ts
+++ b/frontend/src/router/routes.ts
@@ -30,6 +30,11 @@ const routes: RouteRecordRaw[] = [
         component: () => import('pages/DashboardPage.vue'),
       },
       {
+        path: 'teams',
+        name: 'teams',
+        component: () => import('pages/TeamsPage.vue'),
+      },
+      {
         path: 'tokens',
         name: 'tokens',
         component: () => import('pages/TokensPage.vue'),

--- a/frontend/src/stores/teams.ts
+++ b/frontend/src/stores/teams.ts
@@ -1,0 +1,140 @@
+import { defineStore } from 'pinia';
+import { api } from 'src/boot/axios';
+import { Notify } from 'quasar';
+
+export interface TeamMember {
+  token_id: string;
+  token_name: string;
+  allocated_usd: string;
+  used_usd: string;
+  remaining_usd: string;
+  daily_limit_usd: string;
+  daily_used_usd: string;
+  is_active: boolean;
+  last_used_at: string | null;
+}
+
+export interface TeamDashboard {
+  id: string;
+  name: string;
+  monthly_budget_usd: string;
+  monthly_reset_policy: string;
+  daily_limit_enabled: boolean;
+  total_allocated_usd: string;
+  total_used_usd: string;
+  unallocated_pool_usd: string;
+  members: TeamMember[];
+}
+
+export interface TeamListItem {
+  id: string;
+  name: string;
+  monthly_budget_usd: string;
+  monthly_reset_policy: string;
+  daily_limit_enabled: boolean;
+  member_count: number;
+  total_used_usd: string;
+  unallocated_pool_usd: string;
+  created_at: string;
+}
+
+export const useTeamsStore = defineStore('teams', {
+  state: () => ({
+    teams: [] as TeamListItem[],
+    currentTeam: null as TeamDashboard | null,
+    loading: false,
+  }),
+
+  actions: {
+    async fetchTeams() {
+      this.loading = true;
+      try {
+        const response = await api.get<TeamListItem[]>('/admin/teams');
+        this.teams = response.data;
+      } catch {
+        Notify.create({ type: 'negative', message: 'Failed to load teams' });
+      } finally {
+        this.loading = false;
+      }
+    },
+
+    async fetchTeamDashboard(teamId: string) {
+      this.loading = true;
+      try {
+        const response = await api.get<TeamDashboard>(`/admin/teams/${teamId}`);
+        this.currentTeam = response.data;
+      } catch {
+        Notify.create({ type: 'negative', message: 'Failed to load team details' });
+      } finally {
+        this.loading = false;
+      }
+    },
+
+    async createTeam(data: { name: string; monthly_budget_usd: string; monthly_reset_policy: string; daily_limit_enabled?: boolean }) {
+      const response = await api.post('/admin/teams', data);
+      await this.fetchTeams();
+      Notify.create({ type: 'positive', message: 'Team created' });
+      return response.data;
+    },
+
+    async updateTeam(teamId: string, data: { name?: string; monthly_budget_usd?: string; monthly_reset_policy?: string; daily_limit_enabled?: boolean }) {
+      await api.put(`/admin/teams/${teamId}`, data);
+      await this.fetchTeams();
+      if (this.currentTeam?.id === teamId) {
+        await this.fetchTeamDashboard(teamId);
+      }
+      Notify.create({ type: 'positive', message: 'Team updated' });
+    },
+
+    async deleteTeam(teamId: string) {
+      await api.delete(`/admin/teams/${teamId}`);
+      this.currentTeam = null;
+      await this.fetchTeams();
+      Notify.create({ type: 'positive', message: 'Team deleted' });
+    },
+
+    async addMember(teamId: string, tokenId: string, allocatedUsd: string) {
+      await api.post(`/admin/teams/${teamId}/members`, {
+        token_id: tokenId,
+        allocated_usd: allocatedUsd,
+      });
+      await this.fetchTeamDashboard(teamId);
+      Notify.create({ type: 'positive', message: 'Member added' });
+    },
+
+    async removeMember(teamId: string, tokenId: string) {
+      await api.delete(`/admin/teams/${teamId}/members/${tokenId}`);
+      await this.fetchTeamDashboard(teamId);
+      Notify.create({ type: 'positive', message: 'Member removed' });
+    },
+
+    async adjustMember(teamId: string, tokenId: string, allocatedUsd: string) {
+      await api.put(`/admin/teams/${teamId}/members/${tokenId}`, {
+        allocated_usd: allocatedUsd,
+      });
+      await this.fetchTeamDashboard(teamId);
+      Notify.create({ type: 'positive', message: 'Allocation updated' });
+    },
+
+    async transferAllocation(teamId: string, fromTokenId: string, toTokenId: string, amount: string) {
+      await api.post(`/admin/teams/${teamId}/transfer`, {
+        from_token_id: fromTokenId,
+        to_token_id: toTokenId,
+        amount,
+      });
+      await this.fetchTeamDashboard(teamId);
+      Notify.create({ type: 'positive', message: 'Transfer complete' });
+    },
+
+    async batchCreateMembers(teamId: string, data: {
+      names: string;
+      per_member_allocation: string;
+      model_names?: string[];
+    }) {
+      const response = await api.post(`/admin/teams/${teamId}/members/batch`, data);
+      await this.fetchTeamDashboard(teamId);
+      Notify.create({ type: 'positive', message: `${response.data.total} members created` });
+      return response.data;
+    },
+  },
+});

--- a/frontend/src/stores/tokens.ts
+++ b/frontend/src/stores/tokens.ts
@@ -23,6 +23,9 @@ export interface APIToken {
   created_at: string;
   last_used_at: string | null;
   token_metadata?: TokenMetadata | null;
+  team_id?: string | null;
+  team_name?: string | null;
+  allocated_usd?: string | null;
 }
 
 export interface APITokenWithKey extends APIToken {


### PR DESCRIPTION
## Summary

- **Teams module**: team budget pool with member allocation, batch create members, transfer between members, daily spending limits with toggle
- **Monthly/daily quota**: per-token monthly quota with reset/rollover policies, centralized `enforce_quota()` check across all API paths
- **Opus 4.7 support**: strip deprecated `temperature`/`top_p`/`top_k` params, convert `thinking.budget_tokens` to adaptive mode
- **Dashboard**: export CSV (date, API key, model, tokens, requests, cost), compact single-row toolbar
- **UI improvements**: smaller action icons (`size="xs"`), 2-decimal money formatting, hide temperature in Playground for Opus 4.7
- **Token page**: display team allocation quota with progress bar and "(team)" label

## Test plan

- [ ] Create a team with monthly budget, add members via batch create
- [ ] Verify allocation invariant (sum of allocations ≤ budget)
- [ ] Transfer allocation between members
- [ ] Send request with Opus 4.7 model — verify no temperature error
- [ ] Export CSV from Dashboard — verify file downloads with correct columns
- [ ] Check action icons are compact across Teams/Tokens pages
- [ ] Verify money values show 2 decimal places