### PR TITLE
fix: team members list shows deleted tokens

### DIFF
--- a/backend/app/api/admin/endpoints/teams.py
+++ b/backend/app/api/admin/endpoints/teams.py
@@ -293,6 +293,7 @@ async def get_team_dashboard(
             & (UsageRecord.created_at >= monthly_boundary),
         )
         .where(TeamMember.team_id == team_uuid)
+        .where(APIToken.is_deleted.is_(False))
         .group_by(
             TeamMember.token_id,
             TeamMember.allocated_usd,

--- a/frontend/src/pages/TeamsPage.vue
+++ b/frontend/src/pages/TeamsPage.vue
@@ -854,6 +854,9 @@ async function handleBatchCreate() {
 
 onMounted(async () => {
   await teamsStore.fetchTeams();
+  if (teamsStore.currentTeam) {
+    await teamsStore.fetchTeamDashboard(teamsStore.currentTeam.id);
+  }
   void modelsStore.fetchAvailableModels();
 });
 </script>

--- a/frontend/src/pages/TokensPage.vue
+++ b/frontend/src/pages/TokensPage.vue
@@ -553,12 +553,14 @@
 <script setup lang="ts">
 import { ref, computed, onMounted } from 'vue';
 import { useTokensStore } from 'src/stores/tokens';
+import { useTeamsStore } from 'src/stores/teams';
 import { useModelsStore } from 'src/stores/models';
 import { Notify, Dialog, copyToClipboard } from 'quasar';
 import { getApiBaseUrl } from 'src/utils/api';
 import type { APIToken, APITokenWithKey, CreateTokenRequest, TokenMetadata, BatchCreateTokenRequest } from 'src/stores/tokens';
 
 const tokensStore = useTokensStore();
+const teamsStore = useTeamsStore();
 const modelsStore = useModelsStore();
 
 const searchQuery = ref('');
@@ -896,7 +898,11 @@ function deleteToken(token: APIToken) {
     class: 'flat-dialog',
   }).onOk(() => {
     deletingTokenId.value = token.id;
-    void tokensStore.deleteToken(token.id).finally(() => {
+    void tokensStore.deleteToken(token.id).then(() => {
+      if (token.team_id) {
+        void teamsStore.fetchTeams();
+      }
+    }).finally(() => {
       deletingTokenId.value = null;
     });
   });


### PR DESCRIPTION
## Summary

- Filter out soft-deleted tokens (`is_deleted=True`) from team dashboard members query
- Refresh teams store when a team member token is deleted from API Keys page
- Re-fetch team dashboard on TeamsPage mount if a team is already selected

## Test plan

- [ ] Delete a token that belongs to a team from API Keys page
- [ ] Navigate to Teams → select that team — deleted token should not appear
- [ ] Hard refresh the page — deleted token still hidden