### PR TITLE
fix: code quality cleanup — async fetch, dead code, usage filters

### DIFF
--- a/backend/app/api/admin/endpoints/teams.py
+++ b/backend/app/api/admin/endpoints/teams.py
@@ -421,23 +421,16 @@ async def add_member(
         user_id=current_user.id,
     )
 
-    # Invalidate token cache
     token_result = await db.execute(
-        select(APIToken.token_hash).where(APIToken.id == token_uuid)
+        select(APIToken.token_hash, APIToken.name).where(APIToken.id == token_uuid)
     )
-    token_hash = token_result.scalar_one_or_none()
-    if token_hash:
-        await _invalidate_token_cache(token_hash)
-
-    # Get token name
-    token_result = await db.execute(
-        select(APIToken.name).where(APIToken.id == token_uuid)
-    )
-    token_name = token_result.scalar_one_or_none() or ""
+    token_row = token_result.one_or_none()
+    if token_row and token_row.token_hash:
+        await _invalidate_token_cache(token_row.token_hash)
 
     return TeamMemberSimpleResponse(
         token_id=str(member.token_id),
-        token_name=token_name,
+        token_name=token_row.name if token_row else "",
         allocated_usd=str(member.allocated_usd),
     )
 
@@ -492,22 +485,16 @@ async def adjust_member(
         user_id=current_user.id,
     )
 
-    # Invalidate cache
     token_result = await db.execute(
-        select(APIToken.token_hash).where(APIToken.id == token_uuid)
+        select(APIToken.token_hash, APIToken.name).where(APIToken.id == token_uuid)
     )
-    token_hash = token_result.scalar_one_or_none()
-    if token_hash:
-        await _invalidate_token_cache(token_hash)
-
-    token_result = await db.execute(
-        select(APIToken.name).where(APIToken.id == token_uuid)
-    )
-    token_name = token_result.scalar_one_or_none() or ""
+    token_row = token_result.one_or_none()
+    if token_row and token_row.token_hash:
+        await _invalidate_token_cache(token_row.token_hash)
 
     return TeamMemberSimpleResponse(
         token_id=str(member.token_id),
-        token_name=token_name,
+        token_name=token_row.name if token_row else "",
         allocated_usd=str(member.allocated_usd),
     )
 

--- a/backend/app/api/admin/endpoints/tokens.py
+++ b/backend/app/api/admin/endpoints/tokens.py
@@ -37,8 +37,12 @@ async def _invalidate_token_cache(token_hash: str) -> None:
         redis_client = await get_redis()
         cache = RedisCache(redis_client)
         await cache.delete(f"token:{token_hash}")
-    except Exception:
-        pass
+    except Exception as e:
+        import logging
+
+        logging.getLogger(__name__).warning(
+            "Failed to invalidate token cache for %s: %s", token_hash[:8], e
+        )
 
 
 def validate_token_metadata(meta: dict | None) -> dict | None:

--- a/backend/app/api/admin/endpoints/usage.py
+++ b/backend/app/api/admin/endpoints/usage.py
@@ -125,6 +125,7 @@ async def get_usage_stats(
         UsageRecord.user_id == current_user.id,
         UsageRecord.created_at >= current_month_start,
         UsageRecord.created_at <= current_month_end,
+        UsageRecord.record_type == "usage",
     )
     current_month_result = await db.execute(current_month_query)
     current_month = current_month_result.first()
@@ -136,6 +137,7 @@ async def get_usage_stats(
     ).where(
         UsageRecord.user_id == current_user.id,
         UsageRecord.created_at >= last_30_days_start,
+        UsageRecord.record_type == "usage",
     )
     last_30_days_result = await db.execute(last_30_days_query)
     last_30_days = last_30_days_result.first()
@@ -144,7 +146,10 @@ async def get_usage_stats(
     all_time_query = select(
         func.coalesce(func.sum(UsageRecord.cost_usd), Decimal("0.00")).label("cost"),
         func.count(UsageRecord.id).label("requests"),
-    ).where(UsageRecord.user_id == current_user.id)
+    ).where(
+        UsageRecord.user_id == current_user.id,
+        UsageRecord.record_type == "usage",
+    )
     all_time_result = await db.execute(all_time_query)
     all_time = all_time_result.first()
 
@@ -194,6 +199,7 @@ async def get_usage_by_token(
             UsageRecord.user_id == current_user.id,
             UsageRecord.created_at >= start_date,
             UsageRecord.created_at <= end_date,
+            UsageRecord.record_type == "usage",
         )
         .group_by(
             UsageRecord.token_id,
@@ -205,7 +211,11 @@ async def get_usage_by_token(
     )
 
     if token_id:
-        query = query.where(UsageRecord.token_id == token_id)
+        try:
+            token_uuid = UUID(token_id)
+        except ValueError:
+            raise HTTPException(status_code=400, detail="Invalid token_id format")
+        query = query.where(UsageRecord.token_id == token_uuid)
 
     result = await db.execute(query)
     rows = result.all()
@@ -256,6 +266,7 @@ async def get_usage_by_model(
             UsageRecord.user_id == current_user.id,
             UsageRecord.created_at >= start_date,
             UsageRecord.created_at <= end_date,
+            UsageRecord.record_type == "usage",
         )
         .group_by(UsageRecord.model)
         .order_by(func.sum(UsageRecord.cost_usd).desc())

--- a/backend/app/api/v1/endpoints/chat.py
+++ b/backend/app/api/v1/endpoints/chat.py
@@ -226,7 +226,7 @@ async def create_chat_completion(
         bedrock_client = BedrockClient.get_instance()
 
         # Translate request
-        bedrock_request = RequestTranslator.openai_to_bedrock(request_data)
+        bedrock_request = await RequestTranslator.openai_to_bedrock(request_data)
 
         # Handle streaming
         if request_data.stream:
@@ -716,8 +716,10 @@ async def stream_chat_completion(
                     stop_reason = "tool_calls"
 
             elif event.type == "message_stop":
-                # Send final chunk with finish reason
-                finish_reason = "tool_calls" if tool_use_blocks else "stop"
+                if stop_reason:
+                    finish_reason = stop_reason
+                else:
+                    finish_reason = "tool_calls" if tool_use_blocks else "stop"
                 chunk = ResponseTranslator.create_stream_chunk(
                     request_id=request_id,
                     model=model,

--- a/backend/app/services/quota.py
+++ b/backend/app/services/quota.py
@@ -29,8 +29,15 @@ async def enforce_quota(token: APIToken, db: AsyncSession) -> None:
 
     has_lifetime = token.quota_usd is not None
 
-    # Determine effective monthly quota source (team or standalone)
     team_membership = await get_team_membership(token.id, db)
+
+    # Early exit: no quota of any kind
+    has_own_monthly = (
+        token.monthly_quota_usd is not None and token.monthly_quota_usd > 0
+    )
+    if not has_lifetime and not has_own_monthly and not team_membership:
+        return
+
     daily_limit_enabled = True
     if team_membership:
         effective_monthly = team_membership.allocated_usd
@@ -58,8 +65,9 @@ async def enforce_quota(token: APIToken, db: AsyncSession) -> None:
     # Determine the start boundary for the monthly sum
     monthly_boundary = rollover_start if is_rollover else month_start
 
-    result = await db.execute(
-        select(
+    if has_lifetime:
+        # Need full history for lifetime check
+        query = select(
             func.coalesce(func.sum(UsageRecord.cost_usd), Decimal("0.00")).label(
                 "total"
             ),
@@ -85,11 +93,37 @@ async def enforce_quota(token: APIToken, db: AsyncSession) -> None:
                 Decimal("0.00"),
             ).label("daily"),
         ).where(UsageRecord.token_id == token.id)
-    )
-    row = result.one()
-    total_used, monthly_used, daily_used = row.total, row.monthly, row.daily
+    else:
+        # Only monthly/daily needed — scope to monthly_boundary for efficiency
+        query = select(
+            func.coalesce(func.sum(UsageRecord.cost_usd), Decimal("0.00")).label(
+                "monthly"
+            ),
+            func.coalesce(
+                func.sum(
+                    case(
+                        (UsageRecord.created_at >= day_start, UsageRecord.cost_usd),
+                        else_=Decimal("0.00"),
+                    )
+                ),
+                Decimal("0.00"),
+            ).label("daily"),
+        ).where(
+            UsageRecord.token_id == token.id,
+            UsageRecord.created_at >= monthly_boundary,
+        )
 
-    token.calculate_used_usd(total_used)
+    result = await db.execute(query)
+    row = result.one()
+
+    if has_lifetime:
+        total_used, monthly_used, daily_used = row.total, row.monthly, row.daily
+    else:
+        total_used = Decimal("0.00")
+        monthly_used, daily_used = row.monthly, row.daily
+
+    if has_lifetime:
+        token.calculate_used_usd(total_used)
 
     # 1. Lifetime quota
     if has_lifetime and total_used >= token.quota_usd:

--- a/backend/app/services/token.py
+++ b/backend/app/services/token.py
@@ -364,29 +364,6 @@ class TokenService:
         await self.db.commit()
         return True
 
-    async def record_usage(
-        self,
-        token_id: UUID,
-        cost_usd: Decimal,
-    ) -> bool:
-        """
-        Record token usage and update used amount.
-
-        Args:
-            token_id: Token UUID
-            cost_usd: Cost in USD to add
-
-        Returns:
-            True if successful, False if token not found
-        """
-        token = await self.get_token_by_id(token_id)
-        if not token:
-            return False
-
-        token.used_usd += cost_usd
-        await self.db.commit()
-        return True
-
     def _is_ip_allowed(self, client_ip: str, allowed_ips: List[str]) -> bool:
         """
         Check if client IP is in allowed list.

--- a/backend/app/services/translator.py
+++ b/backend/app/services/translator.py
@@ -44,7 +44,7 @@ class RequestTranslator:
         )
 
     @staticmethod
-    def _fetch_and_encode_image(image_url: str):
+    async def _fetch_and_encode_image(image_url: str):
         """
         Fetch image from URL and encode as base64.
 
@@ -55,17 +55,15 @@ class RequestTranslator:
             BedrockContentPart with image data
         """
         import base64
-        import requests
+        import httpx
         from app.schemas.bedrock import BedrockContentPart
 
         try:
-            response = requests.get(image_url, timeout=10)
-            response.raise_for_status()
+            async with httpx.AsyncClient(timeout=10) as client:
+                response = await client.get(image_url)
+                response.raise_for_status()
 
-            # Determine media type from content-type header
             media_type = response.headers.get("content-type", "image/jpeg")
-
-            # Encode to base64
             image_data = base64.b64encode(response.content).decode("utf-8")
 
             return BedrockContentPart(
@@ -76,7 +74,7 @@ class RequestTranslator:
             raise ValueError(f"Failed to fetch image from URL: {str(e)}")
 
     @staticmethod
-    def openai_to_bedrock(request: ChatCompletionRequest) -> BedrockRequest:
+    async def openai_to_bedrock(request: ChatCompletionRequest) -> BedrockRequest:
         """
         Convert OpenAI chat completion request to Bedrock format.
 
@@ -242,7 +240,9 @@ class RequestTranslator:
                         else:
                             # URL-based image - fetch and convert to base64
                             content_parts.append(
-                                RequestTranslator._fetch_and_encode_image(image_url)
+                                await RequestTranslator._fetch_and_encode_image(
+                                    image_url
+                                )
                             )
 
                 if msg.role == "system":

--- a/backend/app/services/usage_stats.py
+++ b/backend/app/services/usage_stats.py
@@ -69,6 +69,7 @@ class UsageStatsService:
                 UsageRecord.user_id == user_id,
                 UsageRecord.created_at >= start_date,
                 UsageRecord.created_at <= end_date,
+                UsageRecord.record_type == "usage",
             )
             .group_by(time_bucket)
             .order_by(time_bucket)


### PR DESCRIPTION
## Summary

- Replace blocking `requests.get` with async `httpx` for image URL fetching
- Remove dead `TokenService.record_usage` (referenced non-existent column)
- Use captured `stop_reason` in stream instead of hardcoded `finish_reason`
- Add `record_type="usage"` filter to all usage stats queries (exclude adjustments)
- Validate `token_id` as UUID before DB query in usage endpoint
- Only call `calculate_used_usd` when lifetime quota exists (avoid zeroing cache)
- Log cache invalidation failures instead of silently swallowing
- Merge duplicate token queries in teams add/adjust member endpoints

## Test plan

- [ ] Send image URL in chat request — verify async fetch works
- [ ] Check usage stats exclude adjustment records
- [ ] Stream response with tool_use — verify correct finish_reason
- [ ] Pass invalid token_id to usage endpoint — expect 400 not 500