### PR TITLE
feat: expandable token rows with models and description

### DIFF
--- a/backend/alembic/versions/j1k2l3m4n5o6_add_description_to_api_tokens.py
+++ b/backend/alembic/versions/j1k2l3m4n5o6_add_description_to_api_tokens.py
@@ -1,0 +1,22 @@
+"""add description to api_tokens
+
+Revision ID: j1k2l3m4n5o6
+Revises: i0j1k2l3m4n5
+Create Date: 2026-05-09
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "j1k2l3m4n5o6"
+down_revision = "i0j1k2l3m4n5"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("api_tokens", sa.Column("description", sa.String(500), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("api_tokens", "description")

--- a/backend/app/api/admin/endpoints/tokens.py
+++ b/backend/app/api/admin/endpoints/tokens.py
@@ -17,6 +17,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.api.deps import get_current_user_from_jwt, get_token_service
 from app.core.database import get_db
 from app.core.security import decrypt_token
+from app.models.model import Model
 from app.models.team import Team, TeamMember
 from app.models.token import APIToken
 from app.models.usage import UsageRecord
@@ -70,6 +71,7 @@ class CreateTokenRequest(BaseModel):
     """Create token request."""
 
     name: str
+    description: str | None = None
     expires_at: datetime | None = None
     quota_usd: Decimal | None = None
     monthly_quota_usd: Decimal | None = None
@@ -107,6 +109,7 @@ class UpdateTokenRequest(BaseModel):
     """Update token request."""
 
     name: str | None = None
+    description: str | None = None
     expires_at: datetime | None = None
     quota_usd: Decimal | None = None
     monthly_quota_usd: Decimal | None = None
@@ -121,6 +124,7 @@ class TokenResponse(BaseModel):
 
     id: str
     name: str
+    description: str | None = None
     key_prefix: str = "sk-ant-api03"
     expires_at: datetime | None
     quota_usd: str | None
@@ -141,6 +145,7 @@ class TokenResponse(BaseModel):
     team_id: str | None = None
     team_name: str | None = None
     allocated_usd: str | None = None
+    allowed_models: List[str] = []
 
     class Config:
         from_attributes = True
@@ -227,6 +232,7 @@ def build_token_response(
     team_id: str | None = None,
     team_name: str | None = None,
     allocated_usd: Decimal | None = None,
+    allowed_models: List[str] | None = None,
 ) -> TokenResponse:
     """Build TokenResponse with calculated usage."""
     token.calculate_used_usd(used_usd)
@@ -243,6 +249,7 @@ def build_token_response(
     return TokenResponse(
         id=str(token.id),
         name=token.name,
+        description=token.description,
         key_prefix=_extract_key_prefix(token),
         expires_at=token.expires_at,
         quota_usd=str(token.quota_usd) if token.quota_usd else None,
@@ -267,6 +274,7 @@ def build_token_response(
         team_id=team_id,
         team_name=team_name,
         allocated_usd=str(allocated_usd) if allocated_usd is not None else None,
+        allowed_models=allowed_models or [],
     )
 
 
@@ -300,6 +308,7 @@ async def create_token(
     token, plain_token = await token_service.create_token(
         user_id=current_user.id,
         name=request.name,
+        description=request.description,
         expires_at=request.expires_at,
         quota_usd=request.quota_usd,
         monthly_quota_usd=request.monthly_quota_usd,
@@ -455,6 +464,17 @@ async def list_tokens(
         for row in team_result
     }
 
+    # Get allowed models for all tokens in one query
+    models_query = select(Model.token_id, Model.model_name).where(
+        Model.token_id.in_(token_ids),
+        Model.is_active.is_(True),
+        Model.is_deleted.is_(False),
+    )
+    models_result = await db.execute(models_query)
+    models_map: dict[UUID, list[str]] = {}
+    for row in models_result:
+        models_map.setdefault(row.token_id, []).append(row.model_name)
+
     # Build responses with usage data
     token_responses = []
     for token in tokens:
@@ -471,6 +491,7 @@ async def list_tokens(
                 team_id=team_info[0] if team_info else None,
                 team_name=team_info[1] if team_info else None,
                 allocated_usd=team_info[2] if team_info else None,
+                allowed_models=models_map.get(token.id),
             )
         )
 
@@ -575,6 +596,8 @@ async def update_token(
     # Update token fields directly (avoid redundant query)
     if request.name is not None:
         token.name = request.name
+    if request.description is not None:
+        token.description = request.description
     if request.expires_at is not None:
         token.expires_at = request.expires_at
     if request.quota_usd is not None:

--- a/backend/app/models/token.py
+++ b/backend/app/models/token.py
@@ -22,6 +22,7 @@ class APIToken(Base):
 
     # Token information
     name = Column(String(255), nullable=False)
+    description = Column(String(500), nullable=True)
     token_hash = Column(String(255), unique=True, nullable=False, index=True)
     encrypted_token = Column(
         String(512), nullable=True

--- a/backend/app/services/token.py
+++ b/backend/app/services/token.py
@@ -40,6 +40,7 @@ class TokenService:
         self,
         user_id: UUID,
         name: str,
+        description: Optional[str] = None,
         expires_at: Optional[datetime] = None,
         quota_usd: Optional[Decimal] = None,
         monthly_quota_usd: Optional[Decimal] = None,
@@ -73,6 +74,7 @@ class TokenService:
         token = APIToken(
             user_id=user_id,
             name=name,
+            description=description,
             token_hash=token_hash,
             encrypted_token=encrypted,
             expires_at=expires_at,

--- a/frontend/src/pages/TokensPage.vue
+++ b/frontend/src/pages/TokensPage.vue
@@ -47,122 +47,132 @@
           flat
           bordered
         >
-          <template v-slot:body-cell-name="props">
-            <q-td :props="props">
-              <div class="text-weight-bold">{{ props.row.name }}</div>
-            </q-td>
-          </template>
-
-          <template v-slot:body-cell-key="props">
-            <q-td :props="props">
-              <div class="row items-center no-wrap">
-                <span class="text-mono">{{ props.row.key_prefix }}_••••••••</span>
-                <q-btn
-                  flat
-                  dense
-                  round
-                  size="xs"
-                  icon="content_copy"
-                  color="grey-7"
-                  @click="copyTokenKey(props.row)"
-                  :loading="copyingTokenId === props.row.id"
-                  class="q-ml-xs"
-                >
-                  <q-tooltip>Copy Key</q-tooltip>
-                </q-btn>
-              </div>
-            </q-td>
-          </template>
-
-          <template v-slot:body-cell-status="props">
-            <q-td :props="props">
-              <q-badge
-                :color="getStatusColor(props.row)"
-                :label="getStatusLabel(props.row)"
-              />
-            </q-td>
-          </template>
-
-          <template v-slot:body-cell-quota="props">
-            <q-td :props="props">
-              <div v-if="props.row.quota_usd">
-                ${{ Number(props.row.used_usd).toFixed(2) }} / ${{ Number(props.row.quota_usd).toFixed(2) }}
-                <q-linear-progress
-                  :value="getQuotaProgress(props.row)"
-                  :color="getQuotaColor(props.row)"
-                  class="q-mt-xs"
-                />
-              </div>
-              <div v-else-if="props.row.allocated_usd">
-                ${{ Number(props.row.used_usd).toFixed(2) }} / ${{ Number(props.row.allocated_usd).toFixed(2) }}
-                <span class="text-caption text-grey-6 q-ml-xs">(team)</span>
-                <q-linear-progress
-                  :value="getQuotaProgress(props.row)"
-                  :color="getQuotaColor(props.row)"
-                  class="q-mt-xs"
-                />
-              </div>
-              <div v-else class="text-grey-7">Unlimited</div>
-            </q-td>
-          </template>
-
-          <template v-slot:body-cell-expires_at="props">
-            <q-td :props="props">
-              <div v-if="props.row.expires_at">
-                {{ formatDate(props.row.expires_at) }}
-              </div>
-              <div v-else class="text-grey-7">Never expires</div>
-            </q-td>
-          </template>
-
-          <template v-slot:body-cell-cache="props">
-            <q-td :props="props">
-              <q-badge
-                :color="getCacheBadge(props.row).color"
-                :label="getCacheBadge(props.row).label"
-              />
-            </q-td>
-          </template>
-
-          <template v-slot:body-cell-actions="props">
-            <q-td :props="props">
-              <q-btn
-                flat
-                dense
-                round
-                size="xs"
-                icon="settings"
-                color="grey-7"
-                @click="openSettings(props.row)"
-                class="q-mr-xs"
-              >
-                <q-tooltip>Cache Settings</q-tooltip>
-              </q-btn>
-              <q-btn
-                flat
-                dense
-                round
-                size="xs"
-                icon="account_balance_wallet"
-                color="positive"
-                @click="rechargeToken(props.row)"
-                class="q-mr-xs"
-              >
-                <q-tooltip>Recharge</q-tooltip>
-              </q-btn>
-              <q-btn
-                flat
-                dense
-                round
-                size="xs"
-                icon="delete"
-                color="negative"
-                @click="deleteToken(props.row)"
-                :loading="deletingTokenId === props.row.id"
-              >
-                <q-tooltip>Delete</q-tooltip>
-              </q-btn>
-            </q-td>
+          <template v-slot:body="props">
+            <q-tr :props="props" @click="props.expand = !props.expand" class="cursor-pointer">
+              <q-td v-for="col in props.cols" :key="col.name" :props="props">
+                <template v-if="col.name === 'name'">
+                  <div class="text-weight-bold">{{ props.row.name }}</div>
+                </template>
+                <template v-else-if="col.name === 'key'">
+                  <div class="row items-center no-wrap">
+                    <span class="text-mono">{{ props.row.key_prefix }}_••••••••</span>
+                    <q-btn
+                      flat
+                      dense
+                      round
+                      size="xs"
+                      icon="content_copy"
+                      color="grey-7"
+                      @click.stop="copyTokenKey(props.row)"
+                      :loading="copyingTokenId === props.row.id"
+                      class="q-ml-xs"
+                    >
+                      <q-tooltip>Copy Key</q-tooltip>
+                    </q-btn>
+                  </div>
+                </template>
+                <template v-else-if="col.name === 'status'">
+                  <q-badge
+                    :color="getStatusColor(props.row)"
+                    :label="getStatusLabel(props.row)"
+                  />
+                </template>
+                <template v-else-if="col.name === 'quota'">
+                  <div v-if="props.row.quota_usd">
+                    ${{ Number(props.row.used_usd).toFixed(2) }} / ${{ Number(props.row.quota_usd).toFixed(2) }}
+                    <q-linear-progress
+                      :value="getQuotaProgress(props.row)"
+                      :color="getQuotaColor(props.row)"
+                      class="q-mt-xs"
+                    />
+                  </div>
+                  <div v-else-if="props.row.allocated_usd">
+                    ${{ Number(props.row.used_usd).toFixed(2) }} / ${{ Number(props.row.allocated_usd).toFixed(2) }}
+                    <span class="text-caption text-grey-6 q-ml-xs">(team)</span>
+                    <q-linear-progress
+                      :value="getQuotaProgress(props.row)"
+                      :color="getQuotaColor(props.row)"
+                      class="q-mt-xs"
+                    />
+                  </div>
+                  <div v-else class="text-grey-7">Unlimited</div>
+                </template>
+                <template v-else-if="col.name === 'expires_at'">
+                  <div v-if="props.row.expires_at">
+                    {{ formatDate(props.row.expires_at) }}
+                  </div>
+                  <div v-else class="text-grey-7">Never expires</div>
+                </template>
+                <template v-else-if="col.name === 'cache'">
+                  <q-badge
+                    :color="getCacheBadge(props.row).color"
+                    :label="getCacheBadge(props.row).label"
+                  />
+                </template>
+                <template v-else-if="col.name === 'actions'">
+                  <q-btn
+                    flat
+                    dense
+                    round
+                    size="xs"
+                    icon="settings"
+                    color="grey-7"
+                    @click.stop="openSettings(props.row)"
+                    class="q-mr-xs"
+                  >
+                    <q-tooltip>Cache Settings</q-tooltip>
+                  </q-btn>
+                  <q-btn
+                    flat
+                    dense
+                    round
+                    size="xs"
+                    icon="account_balance_wallet"
+                    color="positive"
+                    @click.stop="rechargeToken(props.row)"
+                    class="q-mr-xs"
+                  >
+                    <q-tooltip>Recharge</q-tooltip>
+                  </q-btn>
+                  <q-btn
+                    flat
+                    dense
+                    round
+                    size="xs"
+                    icon="delete"
+                    color="negative"
+                    @click.stop="deleteToken(props.row)"
+                    :loading="deletingTokenId === props.row.id"
+                  >
+                    <q-tooltip>Delete</q-tooltip>
+                  </q-btn>
+                </template>
+                <template v-else>
+                  {{ col.value }}
+                </template>
+              </q-td>
+            </q-tr>
+            <q-tr v-show="props.expand" :props="props">
+              <q-td colspan="100%">
+                <div class="q-pa-sm">
+                  <span class="text-caption text-grey-5">Models: </span>
+                  <template v-if="props.row.allowed_models && props.row.allowed_models.length > 0">
+                    <q-chip
+                      v-for="model in props.row.allowed_models"
+                      :key="model"
+                      size="sm"
+                      color="grey-9"
+                      text-color="grey-3"
+                      dense
+                      class="q-mr-xs"
+                    >
+                      {{ model }}
+                    </q-chip>
+                  </template>
+                  <span v-else class="text-grey-7 text-caption">All models (no restriction)</span>
+                </div>
+              </q-td>
+            </q-tr>
           </template>
         </q-table>
       </q-card-section>
@@ -232,6 +242,15 @@
               rounded
               dark
               :rules="[(val) => !!val || 'Please enter name']"
+              class="q-mb-md"
+            />
+
+            <q-input
+              v-model="newToken.description"
+              label="Description (optional)"
+              outlined
+              rounded
+              dark
               class="q-mb-md"
             />
 
@@ -609,6 +628,7 @@ const cacheTtlOptions = [
 
 const newToken = ref({
   name: '',
+  description: '',
   quota_usd: undefined as number | undefined,
   expires_at: '',
   cacheEnabled: false,
@@ -622,6 +642,12 @@ const columns = [
     field: 'name',
     align: 'left' as const,
     sortable: true,
+  },
+  {
+    name: 'description',
+    label: 'Description',
+    field: 'description',
+    align: 'left' as const,
   },
   {
     name: 'key',
@@ -745,6 +771,9 @@ async function handleCreateToken() {
       name: newToken.value.name,
     };
 
+    if (newToken.value.description) {
+      tokenData.description = newToken.value.description;
+    }
     if (newToken.value.quota_usd !== undefined) {
       tokenData.quota_usd = newToken.value.quota_usd;
     }
@@ -768,6 +797,7 @@ async function handleCreateToken() {
       // Reset form
       newToken.value = {
         name: '',
+        description: '',
         quota_usd: undefined,
         expires_at: '',
         cacheEnabled: false,

--- a/frontend/src/stores/tokens.ts
+++ b/frontend/src/stores/tokens.ts
@@ -10,6 +10,7 @@ export interface TokenMetadata {
 export interface APIToken {
   id: string;
   name: string;
+  description: string | null;
   key_prefix: string;
   expires_at: string | null;
   quota_usd: string | null;
@@ -34,6 +35,7 @@ export interface APITokenWithKey extends APIToken {
 
 export interface CreateTokenRequest {
   name: string;
+  description?: string;
   expires_at?: string;
   quota_usd?: number;
   allowed_ips?: string[];


### PR DESCRIPTION
## Summary

- API Keys 表格点击行可展开，显示该 key 绑定的 models
- 新增 Description 列，支持创建/编辑时填写 key 描述
- 后端 `list_tokens` 批量查询 models（单次 SQL，无 N+1）
- Alembic migration 添加 `description` 字段

## Test plan

- [ ] 创建 key 时填写 description，确认列表中显示
- [ ] 点击表格行展开，确认 models 正确展示
- [ ] 无 models 的 key 显示 "All models (no restriction)"
- [ ] 编辑 key 更新 description，确认生效

🤖 Generated with [Claude Code](https://claude.com/claude-code)