### PR TITLE
feat: RBAC with resource-level permissions for admin users

### DIFF
--- a/backend/alembic/versions/k2l3m4n5o6p7_add_rbac_fields.py
+++ b/backend/alembic/versions/k2l3m4n5o6p7_add_rbac_fields.py
@@ -1,0 +1,55 @@
+"""add rbac role and permissions to users
+
+Revision ID: k2l3m4n5o6p7
+Revises: j1k2l3m4n5o6
+Create Date: 2026-05-09
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "k2l3m4n5o6p7"
+down_revision = "j1k2l3m4n5o6"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # Create enum type
+    userrole = sa.Enum("super_admin", "admin", name="userrole")
+    userrole.create(op.get_bind(), checkfirst=True)
+
+    # Add role column with default 'admin'
+    op.add_column(
+        "users",
+        sa.Column("role", userrole, nullable=False, server_default="admin"),
+    )
+    op.create_index("ix_users_role", "users", ["role"])
+
+    # Add permissions JSON column
+    op.add_column(
+        "users",
+        sa.Column("permissions", sa.JSON(), nullable=True),
+    )
+
+    # Migrate existing super admins
+    op.execute("UPDATE users SET role = 'super_admin' WHERE is_admin = true")
+
+    # Add new audit action enum values
+    op.execute("ALTER TYPE auditaction ADD VALUE IF NOT EXISTS 'admin_created'")
+    op.execute("ALTER TYPE auditaction ADD VALUE IF NOT EXISTS 'admin_updated'")
+    op.execute("ALTER TYPE auditaction ADD VALUE IF NOT EXISTS 'admin_deleted'")
+    op.execute("ALTER TYPE auditaction ADD VALUE IF NOT EXISTS 'token_created'")
+    op.execute("ALTER TYPE auditaction ADD VALUE IF NOT EXISTS 'token_updated'")
+    op.execute("ALTER TYPE auditaction ADD VALUE IF NOT EXISTS 'token_deleted'")
+    op.execute("ALTER TYPE auditaction ADD VALUE IF NOT EXISTS 'team_created'")
+    op.execute("ALTER TYPE auditaction ADD VALUE IF NOT EXISTS 'team_updated'")
+    op.execute("ALTER TYPE auditaction ADD VALUE IF NOT EXISTS 'team_deleted'")
+    op.execute("ALTER TYPE auditaction ADD VALUE IF NOT EXISTS 'model_updated'")
+
+
+def downgrade() -> None:
+    op.drop_index("ix_users_role", table_name="users")
+    op.drop_column("users", "permissions")
+    op.drop_column("users", "role")
+    sa.Enum(name="userrole").drop(op.get_bind(), checkfirst=True)

--- a/backend/alembic/versions/l3m4n5o6p7q8_set_superadmin.py
+++ b/backend/alembic/versions/l3m4n5o6p7q8_set_superadmin.py
@@ -1,0 +1,23 @@
+"""set kolya@amazon.com as super_admin
+
+Revision ID: l3m4n5o6p7q8
+Revises: k2l3m4n5o6p7
+Create Date: 2026-05-09
+"""
+
+from alembic import op
+
+revision = "l3m4n5o6p7q8"
+down_revision = "k2l3m4n5o6p7"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute(
+        "UPDATE users SET role = 'super_admin', is_admin = true WHERE email = 'kolya@amazon.com'"
+    )
+
+
+def downgrade() -> None:
+    pass

--- a/backend/alembic/versions/m4n5o6p7q8r9_fix_audit_enum_values.py
+++ b/backend/alembic/versions/m4n5o6p7q8r9_fix_audit_enum_values.py
@@ -1,0 +1,33 @@
+"""fix auditaction enum - add uppercase values matching SQLAlchemy names
+
+Revision ID: m4n5o6p7q8r9
+Revises: l3m4n5o6p7q8
+Create Date: 2026-05-09
+"""
+
+from alembic import op
+
+revision = "m4n5o6p7q8r9"
+down_revision = "l3m4n5o6p7q8"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # The initial migration created auditaction enum with uppercase names (LOGIN_SUCCESS etc).
+    # The RBAC migration incorrectly added lowercase values. SQLAlchemy uses enum NAMES
+    # (uppercase) by default, so we need uppercase values in the DB.
+    op.execute("ALTER TYPE auditaction ADD VALUE IF NOT EXISTS 'ADMIN_CREATED'")
+    op.execute("ALTER TYPE auditaction ADD VALUE IF NOT EXISTS 'ADMIN_UPDATED'")
+    op.execute("ALTER TYPE auditaction ADD VALUE IF NOT EXISTS 'ADMIN_DELETED'")
+    op.execute("ALTER TYPE auditaction ADD VALUE IF NOT EXISTS 'TOKEN_CREATED'")
+    op.execute("ALTER TYPE auditaction ADD VALUE IF NOT EXISTS 'TOKEN_UPDATED'")
+    op.execute("ALTER TYPE auditaction ADD VALUE IF NOT EXISTS 'TOKEN_DELETED'")
+    op.execute("ALTER TYPE auditaction ADD VALUE IF NOT EXISTS 'TEAM_CREATED'")
+    op.execute("ALTER TYPE auditaction ADD VALUE IF NOT EXISTS 'TEAM_UPDATED'")
+    op.execute("ALTER TYPE auditaction ADD VALUE IF NOT EXISTS 'TEAM_DELETED'")
+    op.execute("ALTER TYPE auditaction ADD VALUE IF NOT EXISTS 'MODEL_UPDATED'")
+
+
+def downgrade() -> None:
+    pass

--- a/backend/app/api/admin/endpoints/audit.py
+++ b/backend/app/api/admin/endpoints/audit.py
@@ -1,13 +1,21 @@
 """Audit log viewing endpoints."""
 
-from datetime import datetime
+from datetime import datetime, timedelta
 from typing import List
 from uuid import UUID
 
 from fastapi import APIRouter, Depends, Query
 from pydantic import BaseModel
 
-from app.api.deps import get_audit_log_service, get_current_user_from_jwt
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.api.deps import (
+    get_audit_log_service,
+    get_current_superadmin,
+    get_current_user_from_jwt,
+)
+from app.core.database import get_db
 from app.models.audit_log import AuditAction
 from app.models.user import User
 from app.services.audit_log import AuditLogService
@@ -55,7 +63,7 @@ class AuditSummaryResponse(BaseModel):
 
 @router.get("", response_model=PaginatedAuditLogsResponse)
 async def list_audit_logs(
-    current_user: User = Depends(get_current_user_from_jwt),
+    current_user: User = Depends(get_current_superadmin),
     audit_service: AuditLogService = Depends(get_audit_log_service),
     page: int = Query(1, ge=1),
     page_size: int = Query(50, ge=1, le=200),
@@ -116,7 +124,7 @@ async def list_audit_logs(
 
 @router.get("/summary", response_model=AuditSummaryResponse)
 async def get_audit_summary(
-    current_user: User = Depends(get_current_user_from_jwt),
+    current_user: User = Depends(get_current_superadmin),
     audit_service: AuditLogService = Depends(get_audit_log_service),
     start_date: datetime | None = None,
     end_date: datetime | None = None,
@@ -133,3 +141,82 @@ async def get_audit_summary(
     )
 
     return AuditSummaryResponse(**summary)
+
+
+class ActivityItem(BaseModel):
+    """Simplified activity entry visible to all admins."""
+
+    id: str
+    user_id: str | None
+    user_email: str | None
+    action: str
+    resource_type: str | None
+    resource_id: str | None
+    details: str | None
+    created_at: datetime
+
+
+class PaginatedActivityResponse(BaseModel):
+    """Paginated activity feed response."""
+
+    items: List[ActivityItem]
+    total: int
+    page: int
+    page_size: int
+    total_pages: int
+
+
+@router.get("/activity", response_model=PaginatedActivityResponse)
+async def list_activity(
+    current_user: User = Depends(get_current_user_from_jwt),
+    audit_service: AuditLogService = Depends(get_audit_log_service),
+    db: AsyncSession = Depends(get_db),
+    page: int = Query(1, ge=1),
+    page_size: int = Query(50, ge=1, le=100),
+    days: int = Query(7, ge=1, le=30),
+):
+    """
+    Activity feed visible to all admins.
+    Shows recent operations (last N days) without sensitive fields (IP, user-agent).
+    """
+    start_date = datetime.utcnow() - timedelta(days=days)
+
+    logs, total = await audit_service.get_audit_logs(
+        page=page,
+        page_size=page_size,
+        start_date=start_date,
+        success=True,
+    )
+
+    total_pages = (total + page_size - 1) // page_size if total > 0 else 0
+
+    # Batch load user emails
+    user_ids = {log.user_id for log in logs if log.user_id}
+    email_map: dict[str, str] = {}
+    if user_ids:
+        result = await db.execute(
+            select(User.id, User.email).where(User.id.in_(user_ids))
+        )
+        email_map = {str(row.id): row.email for row in result}
+
+    items = [
+        ActivityItem(
+            id=str(log.id),
+            user_id=str(log.user_id) if log.user_id else None,
+            user_email=email_map.get(str(log.user_id)) if log.user_id else None,
+            action=log.action.value,
+            resource_type=log.resource_type,
+            resource_id=log.resource_id,
+            details=log.details,
+            created_at=log.created_at,
+        )
+        for log in logs
+    ]
+
+    return PaginatedActivityResponse(
+        items=items,
+        total=total,
+        page=page,
+        page_size=page_size,
+        total_pages=total_pages,
+    )

--- a/backend/app/api/admin/endpoints/audit.py
+++ b/backend/app/api/admin/endpoints/audit.py
@@ -1,5 +1,6 @@
 """Audit log viewing endpoints."""
 
+import time
 from datetime import datetime, timedelta
 from typing import List
 from uuid import UUID
@@ -32,6 +33,21 @@ ACTIVITY_ACTIONS = [
     AuditAction.TEAM_DELETED,
     AuditAction.MODEL_UPDATED,
 ]
+
+_super_admin_cache: tuple[float, list] = (0.0, [])
+_SUPER_ADMIN_CACHE_TTL = 60
+
+
+async def _get_super_admin_ids(db: AsyncSession) -> list:
+    global _super_admin_cache
+    now = time.time()
+    if now - _super_admin_cache[0] < _SUPER_ADMIN_CACHE_TTL:
+        return _super_admin_cache[1]
+    result = await db.execute(select(User.id).where(User.role == UserRole.SUPER_ADMIN))
+    ids = [row.id for row in result]
+    _super_admin_cache = (now, ids)
+    return ids
+
 
 router = APIRouter()
 
@@ -198,12 +214,8 @@ async def list_activity(
         AuditLog.created_at >= start_date,
     ]
 
-    # Non-super_admin users cannot see super_admin operations
     if current_user.role != UserRole.SUPER_ADMIN:
-        super_admin_result = await db.execute(
-            select(User.id).where(User.role == UserRole.SUPER_ADMIN)
-        )
-        super_admin_ids = [row.id for row in super_admin_result]
+        super_admin_ids = await _get_super_admin_ids(db)
         if super_admin_ids:
             filters.append(AuditLog.user_id.notin_(super_admin_ids))
 

--- a/backend/app/api/admin/endpoints/audit.py
+++ b/backend/app/api/admin/endpoints/audit.py
@@ -17,7 +17,7 @@ from app.api.deps import (
 )
 from app.core.database import get_db
 from app.models.audit_log import AuditAction, AuditLog
-from app.models.user import User
+from app.models.user import User, UserRole
 from app.services.audit_log import AuditLogService
 
 ACTIVITY_ACTIONS = [
@@ -193,10 +193,21 @@ async def list_activity(
     """
     start_date = datetime.utcnow() - timedelta(days=days)
 
-    base_filter = (
+    filters = [
         AuditLog.action.in_(ACTIVITY_ACTIONS),
         AuditLog.created_at >= start_date,
-    )
+    ]
+
+    # Non-super_admin users cannot see super_admin operations
+    if current_user.role != UserRole.SUPER_ADMIN:
+        super_admin_result = await db.execute(
+            select(User.id).where(User.role == UserRole.SUPER_ADMIN)
+        )
+        super_admin_ids = [row.id for row in super_admin_result]
+        if super_admin_ids:
+            filters.append(AuditLog.user_id.notin_(super_admin_ids))
+
+    base_filter = tuple(filters)
 
     total_result = await db.execute(select(func.count(AuditLog.id)).where(*base_filter))
     total = total_result.scalar() or 0

--- a/backend/app/api/admin/endpoints/audit.py
+++ b/backend/app/api/admin/endpoints/audit.py
@@ -7,7 +7,7 @@ from uuid import UUID
 from fastapi import APIRouter, Depends, Query
 from pydantic import BaseModel
 
-from sqlalchemy import select
+from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.api.deps import (
@@ -16,9 +16,22 @@ from app.api.deps import (
     get_current_user_from_jwt,
 )
 from app.core.database import get_db
-from app.models.audit_log import AuditAction
+from app.models.audit_log import AuditAction, AuditLog
 from app.models.user import User
 from app.services.audit_log import AuditLogService
+
+ACTIVITY_ACTIONS = [
+    AuditAction.ADMIN_CREATED,
+    AuditAction.ADMIN_UPDATED,
+    AuditAction.ADMIN_DELETED,
+    AuditAction.TOKEN_CREATED,
+    AuditAction.TOKEN_UPDATED,
+    AuditAction.TOKEN_DELETED,
+    AuditAction.TEAM_CREATED,
+    AuditAction.TEAM_UPDATED,
+    AuditAction.TEAM_DELETED,
+    AuditAction.MODEL_UPDATED,
+]
 
 router = APIRouter()
 
@@ -169,7 +182,6 @@ class PaginatedActivityResponse(BaseModel):
 @router.get("/activity", response_model=PaginatedActivityResponse)
 async def list_activity(
     current_user: User = Depends(get_current_user_from_jwt),
-    audit_service: AuditLogService = Depends(get_audit_log_service),
     db: AsyncSession = Depends(get_db),
     page: int = Query(1, ge=1),
     page_size: int = Query(50, ge=1, le=100),
@@ -177,16 +189,27 @@ async def list_activity(
 ):
     """
     Activity feed visible to all admins.
-    Shows recent operations (last N days) without sensitive fields (IP, user-agent).
+    Shows only management operations (token/team/model/admin CRUD).
     """
     start_date = datetime.utcnow() - timedelta(days=days)
 
-    logs, total = await audit_service.get_audit_logs(
-        page=page,
-        page_size=page_size,
-        start_date=start_date,
-        success=True,
+    base_filter = (
+        AuditLog.action.in_(ACTIVITY_ACTIONS),
+        AuditLog.created_at >= start_date,
     )
+
+    total_result = await db.execute(select(func.count(AuditLog.id)).where(*base_filter))
+    total = total_result.scalar() or 0
+
+    offset = (page - 1) * page_size
+    result = await db.execute(
+        select(AuditLog)
+        .where(*base_filter)
+        .order_by(AuditLog.created_at.desc())
+        .offset(offset)
+        .limit(page_size)
+    )
+    logs = list(result.scalars().all())
 
     total_pages = (total + page_size - 1) // page_size if total > 0 else 0
 

--- a/backend/app/api/admin/endpoints/auth.py
+++ b/backend/app/api/admin/endpoints/auth.py
@@ -22,7 +22,7 @@ from app.core.cookies import (
 )
 from app.core.database import get_db
 from app.core.security import create_access_token, decode_jwt_token
-from app.models.user import User
+from app.models.user import User, UserRole
 from app.services.audit_log import AuditLogService
 from app.services.auth import AuthService
 from app.services.cognito_oauth import get_cognito_oauth_service
@@ -46,6 +46,21 @@ class UserResponse(BaseModel):
     permissions: dict | None
     email_verified: bool
     current_balance: str
+
+    @classmethod
+    def from_user(cls, user: User) -> "UserResponse":
+        return cls(
+            id=str(user.id),
+            email=user.email,
+            first_name=user.first_name,
+            last_name=user.last_name,
+            is_active=user.is_active,
+            is_admin=user.is_admin,
+            role=user.role.value if user.role else "admin",
+            permissions=user.permissions,
+            email_verified=user.email_verified,
+            current_balance=str(user.current_balance),
+        )
 
     class Config:
         from_attributes = True
@@ -156,18 +171,7 @@ async def refresh_access_token(
         return LoginResponse(
             access_token=access_token,
             token_type="bearer",
-            user=UserResponse(
-                id=str(user.id),
-                email=user.email,
-                first_name=user.first_name,
-                last_name=user.last_name,
-                is_active=user.is_active,
-                is_admin=user.is_admin,
-                role=user.role.value if user.role else "admin",
-                permissions=user.permissions,
-                email_verified=user.email_verified,
-                current_balance=str(user.current_balance),
-            ),
+            user=UserResponse.from_user(user),
         )
 
     except HTTPException:
@@ -285,18 +289,7 @@ async def get_current_user_info(
 
     Requires valid JWT access token in Authorization header.
     """
-    return UserResponse(
-        id=str(current_user.id),
-        email=current_user.email,
-        first_name=current_user.first_name,
-        last_name=current_user.last_name,
-        is_active=current_user.is_active,
-        is_admin=current_user.is_admin,
-        role=current_user.role.value if current_user.role else "admin",
-        permissions=current_user.permissions,
-        email_verified=current_user.email_verified,
-        current_balance=str(current_user.current_balance),
-    )
+    return UserResponse.from_user(current_user)
 
 
 class UpdateProfileRequest(BaseModel):
@@ -329,18 +322,7 @@ async def update_profile(
     await db.commit()
     await db.refresh(current_user)
 
-    return UserResponse(
-        id=str(current_user.id),
-        email=current_user.email,
-        first_name=current_user.first_name,
-        last_name=current_user.last_name,
-        is_active=current_user.is_active,
-        is_admin=current_user.is_admin,
-        role=current_user.role.value if current_user.role else "admin",
-        permissions=current_user.permissions,
-        email_verified=current_user.email_verified,
-        current_balance=str(current_user.current_balance),
-    )
+    return UserResponse.from_user(current_user)
 
 
 @router.get("/microsoft/login")
@@ -514,8 +496,6 @@ async def microsoft_callback(
 
             settings = get_settings()
 
-            from app.models.user import UserRole
-
             user = User(
                 email=email,
                 password_hash=None,  # No password for OAuth users
@@ -572,18 +552,7 @@ async def microsoft_callback(
     return LoginResponse(
         access_token=access_token_jwt,
         token_type="bearer",
-        user=UserResponse(
-            id=str(user.id),
-            email=user.email,
-            first_name=user.first_name,
-            last_name=user.last_name,
-            is_active=user.is_active,
-            is_admin=user.is_admin,
-            role=user.role.value if user.role else "admin",
-            permissions=user.permissions,
-            email_verified=user.email_verified,
-            current_balance=str(user.current_balance),
-        ),
+        user=UserResponse.from_user(user),
     )
 
 
@@ -759,8 +728,6 @@ async def cognito_callback(
 
         settings = get_settings()
 
-        from app.models.user import UserRole
-
         user = User(
             email=email,
             password_hash=None,  # No password for OAuth users
@@ -816,16 +783,5 @@ async def cognito_callback(
     return LoginResponse(
         access_token=access_token_jwt,
         token_type="bearer",
-        user=UserResponse(
-            id=str(user.id),
-            email=user.email,
-            first_name=user.first_name,
-            last_name=user.last_name,
-            is_active=user.is_active,
-            is_admin=user.is_admin,
-            role=user.role.value if user.role else "admin",
-            permissions=user.permissions,
-            email_verified=user.email_verified,
-            current_balance=str(user.current_balance),
-        ),
+        user=UserResponse.from_user(user),
     )

--- a/backend/app/api/admin/endpoints/auth.py
+++ b/backend/app/api/admin/endpoints/auth.py
@@ -42,6 +42,8 @@ class UserResponse(BaseModel):
     last_name: str | None
     is_active: bool
     is_admin: bool
+    role: str
+    permissions: dict | None
     email_verified: bool
     current_balance: str
 
@@ -161,6 +163,8 @@ async def refresh_access_token(
                 last_name=user.last_name,
                 is_active=user.is_active,
                 is_admin=user.is_admin,
+                role=user.role.value if user.role else "admin",
+                permissions=user.permissions,
                 email_verified=user.email_verified,
                 current_balance=str(user.current_balance),
             ),
@@ -288,6 +292,8 @@ async def get_current_user_info(
         last_name=current_user.last_name,
         is_active=current_user.is_active,
         is_admin=current_user.is_admin,
+        role=current_user.role.value if current_user.role else "admin",
+        permissions=current_user.permissions,
         email_verified=current_user.email_verified,
         current_balance=str(current_user.current_balance),
     )
@@ -330,6 +336,8 @@ async def update_profile(
         last_name=current_user.last_name,
         is_active=current_user.is_active,
         is_admin=current_user.is_admin,
+        role=current_user.role.value if current_user.role else "admin",
+        permissions=current_user.permissions,
         email_verified=current_user.email_verified,
         current_balance=str(current_user.current_balance),
     )
@@ -506,6 +514,8 @@ async def microsoft_callback(
 
             settings = get_settings()
 
+            from app.models.user import UserRole
+
             user = User(
                 email=email,
                 password_hash=None,  # No password for OAuth users
@@ -515,6 +525,8 @@ async def microsoft_callback(
                 last_name=last_name,
                 current_balance=Decimal(str(settings.INITIAL_USER_BALANCE_USD)),
                 is_active=True,
+                is_admin=True,
+                role=UserRole.ADMIN,
                 email_verified=True,  # Microsoft accounts are pre-verified
             )
             db.add(user)
@@ -567,6 +579,8 @@ async def microsoft_callback(
             last_name=user.last_name,
             is_active=user.is_active,
             is_admin=user.is_admin,
+            role=user.role.value if user.role else "admin",
+            permissions=user.permissions,
             email_verified=user.email_verified,
             current_balance=str(user.current_balance),
         ),
@@ -745,6 +759,8 @@ async def cognito_callback(
 
         settings = get_settings()
 
+        from app.models.user import UserRole
+
         user = User(
             email=email,
             password_hash=None,  # No password for OAuth users
@@ -753,6 +769,8 @@ async def cognito_callback(
             last_name=last_name,
             current_balance=Decimal(str(settings.INITIAL_USER_BALANCE_USD)),
             is_active=True,
+            is_admin=True,
+            role=UserRole.ADMIN,
             email_verified=True,  # Cognito accounts are pre-verified
         )
         db.add(user)
@@ -805,6 +823,8 @@ async def cognito_callback(
             last_name=user.last_name,
             is_active=user.is_active,
             is_admin=user.is_admin,
+            role=user.role.value if user.role else "admin",
+            permissions=user.permissions,
             email_verified=user.email_verified,
             current_balance=str(user.current_balance),
         ),

--- a/backend/app/api/admin/endpoints/models.py
+++ b/backend/app/api/admin/endpoints/models.py
@@ -12,7 +12,7 @@ from pydantic import BaseModel
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.api.deps import get_current_user_from_jwt
+from app.api.deps import require_permission
 from app.core.config import get_settings
 from app.core.database import get_db
 from app.models.model import Model
@@ -96,7 +96,7 @@ def _get_model_id_from_cache(model_name: str) -> Optional[str]:
 
 @router.get("/aws-available")
 async def list_aws_available_models(
-    _current_user=Depends(get_current_user_from_jwt),
+    _current_user=Depends(require_permission("manage_models")),
 ):
     """
     Get list of available Bedrock models from AWS (for selection).
@@ -181,7 +181,7 @@ async def list_aws_available_models(
 async def list_enabled_models(
     token_id: Optional[str] = None,
     db: AsyncSession = Depends(get_db),
-    _current_user=Depends(get_current_user_from_jwt),
+    _current_user=Depends(require_permission("manage_models")),
 ):
     """
     Get list of enabled models from PostgreSQL.
@@ -269,7 +269,7 @@ async def list_enabled_models(
 async def add_model(
     request: AddModelRequest,
     db: AsyncSession = Depends(get_db),
-    _current_user=Depends(get_current_user_from_jwt),
+    _current_user=Depends(require_permission("manage_models")),
 ):
     """
     Add a model to enabled list for a specific token.
@@ -338,7 +338,7 @@ async def add_model(
 async def delete_model(
     model_id: UUID,
     db: AsyncSession = Depends(get_db),
-    _current_user=Depends(get_current_user_from_jwt),
+    _current_user=Depends(require_permission("manage_models")),
 ):
     """
     Delete (deactivate) a model from enabled list.

--- a/backend/app/api/admin/endpoints/monitor.py
+++ b/backend/app/api/admin/endpoints/monitor.py
@@ -6,7 +6,7 @@ from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy import select
 from app.core.database import get_db
-from app.api.deps import get_current_user_from_jwt
+from app.api.deps import require_permission
 from app.models.user import User
 from app.models.model_pricing import ModelPricing as ModelPricingModel
 from typing import List, Dict, Any, Optional
@@ -65,7 +65,7 @@ async def _fetch_pricing_table(db: AsyncSession) -> List[Dict[str, Any]]:
 async def get_pricing_table(
     force_refresh: bool = False,
     db: AsyncSession = Depends(get_db),
-    current_user: User = Depends(get_current_user_from_jwt),
+    current_user: User = Depends(require_permission("view_monitor")),
 ):
     """
     Get complete pricing table for all models and regions.
@@ -118,7 +118,7 @@ async def get_pricing_table(
 @router.get("/pricing-summary")
 async def get_pricing_summary(
     db: AsyncSession = Depends(get_db),
-    current_user: User = Depends(get_current_user_from_jwt),
+    current_user: User = Depends(require_permission("view_monitor")),
 ):
     """
     Get pricing summary statistics.
@@ -160,7 +160,7 @@ async def get_pricing_summary(
 
 @router.post("/clear-cache")
 async def clear_pricing_cache(
-    current_user: User = Depends(get_current_user_from_jwt),
+    current_user: User = Depends(require_permission("view_monitor")),
 ):
     """
     Clear the pricing table cache.

--- a/backend/app/api/admin/endpoints/observability.py
+++ b/backend/app/api/admin/endpoints/observability.py
@@ -12,7 +12,7 @@ from typing import Optional
 from fastapi import APIRouter, Depends
 from pydantic import BaseModel, Field
 
-from app.api.deps import get_current_user_from_jwt
+from app.api.deps import get_current_superadmin
 from app.core.config import get_settings
 from app.core.config_sync import publish_config_change
 from app.core.json_formatter import set_log_level
@@ -42,7 +42,7 @@ class ObservabilityUpdate(BaseModel):
 
 @router.get("")
 async def get_observability_config(
-    current_user: User = Depends(get_current_user_from_jwt),
+    current_user: User = Depends(get_current_superadmin),
 ):
     """Get current observability configuration."""
     settings = get_settings()
@@ -60,7 +60,7 @@ async def get_observability_config(
 @router.put("")
 async def update_observability_config(
     update: ObservabilityUpdate,
-    current_user: User = Depends(get_current_user_from_jwt),
+    current_user: User = Depends(get_current_superadmin),
 ):
     """Update observability settings at runtime (no restart required).
 

--- a/backend/app/api/admin/endpoints/pricing.py
+++ b/backend/app/api/admin/endpoints/pricing.py
@@ -6,7 +6,7 @@ from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.ext.asyncio import AsyncSession
 from app.core.database import get_db
 from app.services.pricing_updater import PricingUpdater
-from app.api.deps import get_current_user_from_jwt
+from app.api.deps import get_current_superadmin
 from app.models.user import User
 import logging
 
@@ -18,7 +18,7 @@ router = APIRouter()
 @router.post("/update")
 async def update_pricing(
     db: AsyncSession = Depends(get_db),
-    current_user: User = Depends(get_current_user_from_jwt),
+    current_user: User = Depends(get_current_superadmin),
 ):
     """
     Manually trigger pricing update from AWS sources.
@@ -49,7 +49,7 @@ async def get_model_pricing(
     model_id: str,
     region: str = None,
     db: AsyncSession = Depends(get_db),
-    current_user: User = Depends(get_current_user_from_jwt),
+    current_user: User = Depends(get_current_superadmin),
 ):
     """
     Get pricing information for a specific model.

--- a/backend/app/api/admin/endpoints/teams.py
+++ b/backend/app/api/admin/endpoints/teams.py
@@ -13,6 +13,7 @@ from sqlalchemy import case, func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.api.deps import (
+    check_resource_scope,
     get_allowed_resource_ids,
     get_audit_log_service,
     require_permission,
@@ -128,16 +129,6 @@ class BatchCreateMembersResponse(BaseModel):
 # ---------------------------------------------------------------------------
 # Helper
 # ---------------------------------------------------------------------------
-
-
-def _check_team_scope(user: User, team_id: str) -> None:
-    """Raise 403 if user doesn't have access to this specific team."""
-    allowed_ids = get_allowed_resource_ids(user, "manage_teams")
-    if allowed_ids is not None and team_id not in allowed_ids:
-        raise HTTPException(
-            status_code=status.HTTP_403_FORBIDDEN,
-            detail="You don't have permission to manage this team",
-        )
 
 
 async def _invalidate_token_cache(token_hash: str) -> None:
@@ -268,7 +259,7 @@ async def get_team_dashboard(
     current_user: User = Depends(require_permission("manage_teams")),
     db: AsyncSession = Depends(get_db),
 ):
-    _check_team_scope(current_user, team_id)
+    check_resource_scope(current_user, "manage_teams", team_id)
     try:
         team_uuid = UUID(team_id)
     except ValueError:
@@ -383,7 +374,7 @@ async def update_team(
     audit_service: AuditLogService = Depends(get_audit_log_service),
     db: AsyncSession = Depends(get_db),
 ):
-    _check_team_scope(current_user, team_id)
+    check_resource_scope(current_user, "manage_teams", team_id)
     try:
         team_uuid = UUID(team_id)
     except ValueError:
@@ -428,7 +419,7 @@ async def delete_team(
     audit_service: AuditLogService = Depends(get_audit_log_service),
     db: AsyncSession = Depends(get_db),
 ):
-    _check_team_scope(current_user, team_id)
+    check_resource_scope(current_user, "manage_teams", team_id)
     try:
         team_uuid = UUID(team_id)
     except ValueError:
@@ -459,7 +450,7 @@ async def add_member(
     current_user: User = Depends(require_permission("manage_teams")),
     db: AsyncSession = Depends(get_db),
 ):
-    _check_team_scope(current_user, team_id)
+    check_resource_scope(current_user, "manage_teams", team_id)
     try:
         team_uuid = UUID(team_id)
         token_uuid = UUID(request.token_id)
@@ -495,7 +486,7 @@ async def remove_member(
     current_user: User = Depends(require_permission("manage_teams")),
     db: AsyncSession = Depends(get_db),
 ):
-    _check_team_scope(current_user, team_id)
+    check_resource_scope(current_user, "manage_teams", team_id)
     try:
         team_uuid = UUID(team_id)
         token_uuid = UUID(token_id)
@@ -525,7 +516,7 @@ async def adjust_member(
     current_user: User = Depends(require_permission("manage_teams")),
     db: AsyncSession = Depends(get_db),
 ):
-    _check_team_scope(current_user, team_id)
+    check_resource_scope(current_user, "manage_teams", team_id)
     try:
         team_uuid = UUID(team_id)
         token_uuid = UUID(token_id)
@@ -561,7 +552,7 @@ async def transfer_allocation(
     current_user: User = Depends(require_permission("manage_teams")),
     db: AsyncSession = Depends(get_db),
 ):
-    _check_team_scope(current_user, team_id)
+    check_resource_scope(current_user, "manage_teams", team_id)
     try:
         team_uuid = UUID(team_id)
         from_uuid = UUID(request.from_token_id)
@@ -608,7 +599,7 @@ async def batch_create_members(
     current_user: User = Depends(require_permission("manage_teams")),
     db: AsyncSession = Depends(get_db),
 ):
-    _check_team_scope(current_user, team_id)
+    check_resource_scope(current_user, "manage_teams", team_id)
     try:
         team_uuid = UUID(team_id)
     except ValueError:

--- a/backend/app/api/admin/endpoints/teams.py
+++ b/backend/app/api/admin/endpoints/teams.py
@@ -12,7 +12,9 @@ from pydantic import BaseModel
 from sqlalchemy import case, func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.api.deps import get_current_user_from_jwt
+from app.api.deps import get_audit_log_service, require_permission
+from app.models.audit_log import AuditAction
+from app.services.audit_log import AuditLogService
 from app.core.database import get_db
 from app.models.team import Team, TeamMember
 from app.models.token import APIToken
@@ -140,7 +142,8 @@ async def _invalidate_token_cache(token_hash: str) -> None:
 @router.post("", status_code=status.HTTP_201_CREATED)
 async def create_team(
     request: CreateTeamRequest,
-    current_user: User = Depends(get_current_user_from_jwt),
+    current_user: User = Depends(require_permission("manage_teams")),
+    audit_service: AuditLogService = Depends(get_audit_log_service),
     db: AsyncSession = Depends(get_db),
 ):
     if request.monthly_reset_policy not in ("reset", "rollover"):
@@ -158,6 +161,14 @@ async def create_team(
         monthly_reset_policy=request.monthly_reset_policy,
         daily_limit_enabled=request.daily_limit_enabled,
     )
+    await audit_service.log(
+        action=AuditAction.TEAM_CREATED,
+        user=current_user,
+        resource_type="team",
+        resource_id=str(team.id),
+        details={"name": team.name},
+    )
+
     return {
         "id": str(team.id),
         "name": team.name,
@@ -170,7 +181,7 @@ async def create_team(
 
 @router.get("", response_model=List[TeamListItem])
 async def list_teams(
-    current_user: User = Depends(get_current_user_from_jwt),
+    current_user: User = Depends(require_permission("manage_teams")),
     db: AsyncSession = Depends(get_db),
 ):
     now = datetime.utcnow()
@@ -234,7 +245,7 @@ async def list_teams(
 @router.get("/{team_id}", response_model=TeamDashboardResponse)
 async def get_team_dashboard(
     team_id: str,
-    current_user: User = Depends(get_current_user_from_jwt),
+    current_user: User = Depends(require_permission("manage_teams")),
     db: AsyncSession = Depends(get_db),
 ):
     try:
@@ -347,7 +358,8 @@ async def get_team_dashboard(
 async def update_team(
     team_id: str,
     request: UpdateTeamRequest,
-    current_user: User = Depends(get_current_user_from_jwt),
+    current_user: User = Depends(require_permission("manage_teams")),
+    audit_service: AuditLogService = Depends(get_audit_log_service),
     db: AsyncSession = Depends(get_db),
 ):
     try:
@@ -372,6 +384,14 @@ async def update_team(
         monthly_reset_policy=request.monthly_reset_policy,
         daily_limit_enabled=request.daily_limit_enabled,
     )
+    await audit_service.log(
+        action=AuditAction.TEAM_UPDATED,
+        user=current_user,
+        resource_type="team",
+        resource_id=str(team.id),
+        details={"name": team.name},
+    )
+
     return {
         "id": str(team.id),
         "name": team.name,
@@ -382,7 +402,8 @@ async def update_team(
 @router.delete("/{team_id}", status_code=status.HTTP_204_NO_CONTENT)
 async def delete_team(
     team_id: str,
-    current_user: User = Depends(get_current_user_from_jwt),
+    current_user: User = Depends(require_permission("manage_teams")),
+    audit_service: AuditLogService = Depends(get_audit_log_service),
     db: AsyncSession = Depends(get_db),
 ):
     try:
@@ -392,6 +413,14 @@ async def delete_team(
 
     service = TeamService(db)
     await service.delete_team(team_uuid, current_user.id)
+
+    await audit_service.log(
+        action=AuditAction.TEAM_DELETED,
+        user=current_user,
+        resource_type="team",
+        resource_id=team_id,
+    )
+
     return None
 
 
@@ -404,7 +433,7 @@ async def delete_team(
 async def add_member(
     team_id: str,
     request: AddMemberRequest,
-    current_user: User = Depends(get_current_user_from_jwt),
+    current_user: User = Depends(require_permission("manage_teams")),
     db: AsyncSession = Depends(get_db),
 ):
     try:
@@ -439,7 +468,7 @@ async def add_member(
 async def remove_member(
     team_id: str,
     token_id: str,
-    current_user: User = Depends(get_current_user_from_jwt),
+    current_user: User = Depends(require_permission("manage_teams")),
     db: AsyncSession = Depends(get_db),
 ):
     try:
@@ -468,7 +497,7 @@ async def adjust_member(
     team_id: str,
     token_id: str,
     request: AdjustMemberRequest,
-    current_user: User = Depends(get_current_user_from_jwt),
+    current_user: User = Depends(require_permission("manage_teams")),
     db: AsyncSession = Depends(get_db),
 ):
     try:
@@ -503,7 +532,7 @@ async def adjust_member(
 async def transfer_allocation(
     team_id: str,
     request: TransferAllocationRequest,
-    current_user: User = Depends(get_current_user_from_jwt),
+    current_user: User = Depends(require_permission("manage_teams")),
     db: AsyncSession = Depends(get_db),
 ):
     try:
@@ -549,7 +578,7 @@ async def transfer_allocation(
 async def batch_create_members(
     team_id: str,
     request: BatchCreateMembersRequest,
-    current_user: User = Depends(get_current_user_from_jwt),
+    current_user: User = Depends(require_permission("manage_teams")),
     db: AsyncSession = Depends(get_db),
 ):
     try:

--- a/backend/app/api/admin/endpoints/teams.py
+++ b/backend/app/api/admin/endpoints/teams.py
@@ -12,7 +12,11 @@ from pydantic import BaseModel
 from sqlalchemy import case, func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.api.deps import get_audit_log_service, require_permission
+from app.api.deps import (
+    get_allowed_resource_ids,
+    get_audit_log_service,
+    require_permission,
+)
 from app.models.audit_log import AuditAction
 from app.services.audit_log import AuditLogService
 from app.core.database import get_db
@@ -126,6 +130,16 @@ class BatchCreateMembersResponse(BaseModel):
 # ---------------------------------------------------------------------------
 
 
+def _check_team_scope(user: User, team_id: str) -> None:
+    """Raise 403 if user doesn't have access to this specific team."""
+    allowed_ids = get_allowed_resource_ids(user, "manage_teams")
+    if allowed_ids is not None and team_id not in allowed_ids:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="You don't have permission to manage this team",
+        )
+
+
 async def _invalidate_token_cache(token_hash: str) -> None:
     from app.api.admin.endpoints.tokens import (
         _invalidate_token_cache as _do_invalidate,
@@ -187,7 +201,8 @@ async def list_teams(
     now = datetime.utcnow()
     month_start = datetime(now.year, now.month, 1)
 
-    result = await db.execute(
+    allowed_ids = get_allowed_resource_ids(current_user, "manage_teams")
+    query = (
         select(
             Team.id,
             Team.name,
@@ -206,6 +221,11 @@ async def list_teams(
         .group_by(Team.id)
         .order_by(Team.created_at.desc())
     )
+    if allowed_ids is not None:
+        allowed_uuids = [UUID(id_) for id_ in allowed_ids]
+        query = query.where(Team.id.in_(allowed_uuids))
+
+    result = await db.execute(query)
     rows = result.all()
 
     # Get total monthly usage per team
@@ -248,6 +268,7 @@ async def get_team_dashboard(
     current_user: User = Depends(require_permission("manage_teams")),
     db: AsyncSession = Depends(get_db),
 ):
+    _check_team_scope(current_user, team_id)
     try:
         team_uuid = UUID(team_id)
     except ValueError:
@@ -362,6 +383,7 @@ async def update_team(
     audit_service: AuditLogService = Depends(get_audit_log_service),
     db: AsyncSession = Depends(get_db),
 ):
+    _check_team_scope(current_user, team_id)
     try:
         team_uuid = UUID(team_id)
     except ValueError:
@@ -406,6 +428,7 @@ async def delete_team(
     audit_service: AuditLogService = Depends(get_audit_log_service),
     db: AsyncSession = Depends(get_db),
 ):
+    _check_team_scope(current_user, team_id)
     try:
         team_uuid = UUID(team_id)
     except ValueError:
@@ -436,6 +459,7 @@ async def add_member(
     current_user: User = Depends(require_permission("manage_teams")),
     db: AsyncSession = Depends(get_db),
 ):
+    _check_team_scope(current_user, team_id)
     try:
         team_uuid = UUID(team_id)
         token_uuid = UUID(request.token_id)
@@ -471,6 +495,7 @@ async def remove_member(
     current_user: User = Depends(require_permission("manage_teams")),
     db: AsyncSession = Depends(get_db),
 ):
+    _check_team_scope(current_user, team_id)
     try:
         team_uuid = UUID(team_id)
         token_uuid = UUID(token_id)
@@ -500,6 +525,7 @@ async def adjust_member(
     current_user: User = Depends(require_permission("manage_teams")),
     db: AsyncSession = Depends(get_db),
 ):
+    _check_team_scope(current_user, team_id)
     try:
         team_uuid = UUID(team_id)
         token_uuid = UUID(token_id)
@@ -535,6 +561,7 @@ async def transfer_allocation(
     current_user: User = Depends(require_permission("manage_teams")),
     db: AsyncSession = Depends(get_db),
 ):
+    _check_team_scope(current_user, team_id)
     try:
         team_uuid = UUID(team_id)
         from_uuid = UUID(request.from_token_id)
@@ -581,6 +608,7 @@ async def batch_create_members(
     current_user: User = Depends(require_permission("manage_teams")),
     db: AsyncSession = Depends(get_db),
 ):
+    _check_team_scope(current_user, team_id)
     try:
         team_uuid = UUID(team_id)
     except ValueError:

--- a/backend/app/api/admin/endpoints/teams.py
+++ b/backend/app/api/admin/endpoints/teams.py
@@ -217,7 +217,7 @@ async def list_teams(
             ),
         )
         .outerjoin(TeamMember, TeamMember.team_id == Team.id)
-        .where(Team.user_id == current_user.id, Team.is_active)
+        .where(Team.is_active)
         .group_by(Team.id)
         .order_by(Team.created_at.desc())
     )

--- a/backend/app/api/admin/endpoints/tokens.py
+++ b/backend/app/api/admin/endpoints/tokens.py
@@ -15,6 +15,7 @@ from sqlalchemy import case, func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.api.deps import (
+    check_resource_scope,
     get_allowed_resource_ids,
     get_audit_log_service,
     get_token_service,
@@ -36,16 +37,6 @@ router = APIRouter()
 
 ALLOWED_METADATA_KEYS = {"prompt_cache_enabled", "prompt_cache_ttl"}
 ALLOWED_CACHE_TTL_VALUES = {"5m", "1h"}
-
-
-def _check_resource_scope(user: User, token_id: str) -> None:
-    """Raise 403 if user doesn't have access to this specific token."""
-    allowed_ids = get_allowed_resource_ids(user, "manage_api_keys")
-    if allowed_ids is not None and token_id not in allowed_ids:
-        raise HTTPException(
-            status_code=status.HTTP_403_FORBIDDEN,
-            detail="You don't have permission to manage this API key",
-        )
 
 
 async def _invalidate_token_cache(token_hash: str) -> None:
@@ -431,7 +422,6 @@ async def list_tokens(
 
     Returns list of user's tokens (without plain token keys).
     """
-    # Scope filtering: if admin has access to specific tokens, query by IDs directly
     allowed_ids = get_allowed_resource_ids(current_user, "manage_api_keys")
     if allowed_ids is not None:
         allowed_uuids = [UUID(id_) for id_ in allowed_ids]
@@ -556,7 +546,7 @@ async def get_token(
 
     Returns token details (without plain token key).
     """
-    _check_resource_scope(current_user, token_id)
+    check_resource_scope(current_user, "manage_api_keys", token_id)
 
     try:
         token_uuid = UUID(token_id)
@@ -609,7 +599,7 @@ async def update_token(
 
     Returns updated token details.
     """
-    _check_resource_scope(current_user, token_id)
+    check_resource_scope(current_user, "manage_api_keys", token_id)
 
     try:
         token_uuid = UUID(token_id)
@@ -695,7 +685,7 @@ async def delete_token(
 
     Permanently deletes the token. This action cannot be undone.
     """
-    _check_resource_scope(current_user, token_id)
+    check_resource_scope(current_user, "manage_api_keys", token_id)
 
     try:
         token_uuid = UUID(token_id)
@@ -749,7 +739,7 @@ async def revoke_token(
 
     Deactivates the token. Can be reactivated later via update endpoint.
     """
-    _check_resource_scope(current_user, token_id)
+    check_resource_scope(current_user, "manage_api_keys", token_id)
 
     try:
         token_uuid = UUID(token_id)
@@ -799,7 +789,7 @@ async def get_plain_token(
 
     Returns the decrypted token value for copying.
     """
-    _check_resource_scope(current_user, token_id)
+    check_resource_scope(current_user, "manage_api_keys", token_id)
 
     try:
         token_uuid = UUID(token_id)
@@ -871,7 +861,7 @@ async def adjust_token_balance(
     Positive amount increases "used" (reduces remaining balance).
     Negative amount decreases "used" (increases remaining balance).
     """
-    _check_resource_scope(current_user, token_id)
+    check_resource_scope(current_user, "manage_api_keys", token_id)
 
     if request.amount == 0:
         raise HTTPException(

--- a/backend/app/api/admin/endpoints/tokens.py
+++ b/backend/app/api/admin/endpoints/tokens.py
@@ -14,7 +14,9 @@ from pydantic import BaseModel
 from sqlalchemy import case, func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.api.deps import get_current_user_from_jwt, get_token_service
+from app.api.deps import get_audit_log_service, get_token_service, require_permission
+from app.models.audit_log import AuditAction
+from app.services.audit_log import AuditLogService
 from app.core.database import get_db
 from app.core.security import decrypt_token
 from app.models.model import Model
@@ -283,8 +285,9 @@ def build_token_response(
 )
 async def create_token(
     request: CreateTokenRequest,
-    current_user: User = Depends(get_current_user_from_jwt),
+    current_user: User = Depends(require_permission("manage_tokens")),
     token_service: TokenService = Depends(get_token_service),
+    audit_service: AuditLogService = Depends(get_audit_log_service),
     db: AsyncSession = Depends(get_db),
 ):
     """
@@ -321,6 +324,14 @@ async def create_token(
     used_usd = Decimal("0.00")
     response = build_token_response(token, used_usd)
 
+    await audit_service.log(
+        action=AuditAction.TOKEN_CREATED,
+        user=current_user,
+        resource_type="api_token",
+        resource_id=str(token.id),
+        details={"name": token.name},
+    )
+
     return TokenWithKeyResponse(token=plain_token, **response.model_dump())
 
 
@@ -331,8 +342,9 @@ async def create_token(
 )
 async def batch_create_tokens(
     request: BatchCreateTokenRequest,
-    current_user: User = Depends(get_current_user_from_jwt),
+    current_user: User = Depends(require_permission("manage_tokens")),
     token_service: TokenService = Depends(get_token_service),
+    audit_service: AuditLogService = Depends(get_audit_log_service),
     db: AsyncSession = Depends(get_db),
 ):
     """
@@ -381,13 +393,20 @@ async def batch_create_tokens(
         )
         created.append(TokenWithKeyResponse(token=plain_token, **resp_dict))
 
+    await audit_service.log(
+        action=AuditAction.TOKEN_CREATED,
+        user=current_user,
+        resource_type="api_token",
+        details={"names": [t.name for t, _ in results], "count": len(results)},
+    )
+
     return BatchCreateTokenResponse(created=created, total=len(created))
 
 
 @router.get("", response_model=List[TokenResponse])
 async def list_tokens(
     include_inactive: bool = False,
-    current_user: User = Depends(get_current_user_from_jwt),
+    current_user: User = Depends(require_permission("manage_tokens")),
     token_service: TokenService = Depends(get_token_service),
     db: AsyncSession = Depends(get_db),
 ):
@@ -501,7 +520,7 @@ async def list_tokens(
 @router.get("/{token_id}", response_model=TokenResponse)
 async def get_token(
     token_id: str,
-    current_user: User = Depends(get_current_user_from_jwt),
+    current_user: User = Depends(require_permission("manage_tokens")),
     token_service: TokenService = Depends(get_token_service),
     db: AsyncSession = Depends(get_db),
 ):
@@ -546,8 +565,9 @@ async def get_token(
 async def update_token(
     token_id: str,
     request: UpdateTokenRequest,
-    current_user: User = Depends(get_current_user_from_jwt),
+    current_user: User = Depends(require_permission("manage_tokens")),
     token_service: TokenService = Depends(get_token_service),
+    audit_service: AuditLogService = Depends(get_audit_log_service),
     db: AsyncSession = Depends(get_db),
 ):
     """
@@ -620,6 +640,14 @@ async def update_token(
 
     await _invalidate_token_cache(token.token_hash)
 
+    await audit_service.log(
+        action=AuditAction.TOKEN_UPDATED,
+        user=current_user,
+        resource_type="api_token",
+        resource_id=str(token.id),
+        details={"name": token.name},
+    )
+
     usage = await calculate_token_usage(token, db)
     return build_token_response(
         token, usage.total, monthly_used_usd=usage.monthly, daily_used_usd=usage.daily
@@ -629,8 +657,9 @@ async def update_token(
 @router.delete("/{token_id}", status_code=status.HTTP_204_NO_CONTENT)
 async def delete_token(
     token_id: str,
-    current_user: User = Depends(get_current_user_from_jwt),
+    current_user: User = Depends(require_permission("manage_tokens")),
     token_service: TokenService = Depends(get_token_service),
+    audit_service: AuditLogService = Depends(get_audit_log_service),
 ):
     """
     Delete (revoke) a token permanently.
@@ -664,6 +693,14 @@ async def delete_token(
 
     await _invalidate_token_cache(token.token_hash)
 
+    await audit_service.log(
+        action=AuditAction.TOKEN_DELETED,
+        user=current_user,
+        resource_type="api_token",
+        resource_id=str(token.id),
+        details={"name": token.name},
+    )
+
     # Delete token
     await token_service.delete_token(token_uuid)
 
@@ -673,7 +710,7 @@ async def delete_token(
 @router.post("/{token_id}/revoke", response_model=TokenResponse)
 async def revoke_token(
     token_id: str,
-    current_user: User = Depends(get_current_user_from_jwt),
+    current_user: User = Depends(require_permission("manage_tokens")),
     token_service: TokenService = Depends(get_token_service),
     db: AsyncSession = Depends(get_db),
 ):
@@ -723,7 +760,7 @@ async def revoke_token(
 @router.get("/{token_id}/plain", response_model=dict)
 async def get_plain_token(
     token_id: str,
-    current_user: User = Depends(get_current_user_from_jwt),
+    current_user: User = Depends(require_permission("manage_tokens")),
     token_service: TokenService = Depends(get_token_service),
 ):
     """
@@ -790,7 +827,7 @@ class AdjustBalanceResponse(BaseModel):
 async def adjust_token_balance(
     token_id: str,
     request: AdjustBalanceRequest,
-    current_user: User = Depends(get_current_user_from_jwt),
+    current_user: User = Depends(require_permission("manage_tokens")),
     token_service: TokenService = Depends(get_token_service),
     db: AsyncSession = Depends(get_db),
 ):

--- a/backend/app/api/admin/endpoints/tokens.py
+++ b/backend/app/api/admin/endpoints/tokens.py
@@ -285,7 +285,7 @@ def build_token_response(
 )
 async def create_token(
     request: CreateTokenRequest,
-    current_user: User = Depends(require_permission("manage_tokens")),
+    current_user: User = Depends(require_permission("manage_api_keys")),
     token_service: TokenService = Depends(get_token_service),
     audit_service: AuditLogService = Depends(get_audit_log_service),
     db: AsyncSession = Depends(get_db),
@@ -342,7 +342,7 @@ async def create_token(
 )
 async def batch_create_tokens(
     request: BatchCreateTokenRequest,
-    current_user: User = Depends(require_permission("manage_tokens")),
+    current_user: User = Depends(require_permission("manage_api_keys")),
     token_service: TokenService = Depends(get_token_service),
     audit_service: AuditLogService = Depends(get_audit_log_service),
     db: AsyncSession = Depends(get_db),
@@ -406,7 +406,7 @@ async def batch_create_tokens(
 @router.get("", response_model=List[TokenResponse])
 async def list_tokens(
     include_inactive: bool = False,
-    current_user: User = Depends(require_permission("manage_tokens")),
+    current_user: User = Depends(require_permission("manage_api_keys")),
     token_service: TokenService = Depends(get_token_service),
     db: AsyncSession = Depends(get_db),
 ):
@@ -520,7 +520,7 @@ async def list_tokens(
 @router.get("/{token_id}", response_model=TokenResponse)
 async def get_token(
     token_id: str,
-    current_user: User = Depends(require_permission("manage_tokens")),
+    current_user: User = Depends(require_permission("manage_api_keys")),
     token_service: TokenService = Depends(get_token_service),
     db: AsyncSession = Depends(get_db),
 ):
@@ -565,7 +565,7 @@ async def get_token(
 async def update_token(
     token_id: str,
     request: UpdateTokenRequest,
-    current_user: User = Depends(require_permission("manage_tokens")),
+    current_user: User = Depends(require_permission("manage_api_keys")),
     token_service: TokenService = Depends(get_token_service),
     audit_service: AuditLogService = Depends(get_audit_log_service),
     db: AsyncSession = Depends(get_db),
@@ -657,7 +657,7 @@ async def update_token(
 @router.delete("/{token_id}", status_code=status.HTTP_204_NO_CONTENT)
 async def delete_token(
     token_id: str,
-    current_user: User = Depends(require_permission("manage_tokens")),
+    current_user: User = Depends(require_permission("manage_api_keys")),
     token_service: TokenService = Depends(get_token_service),
     audit_service: AuditLogService = Depends(get_audit_log_service),
 ):
@@ -710,7 +710,7 @@ async def delete_token(
 @router.post("/{token_id}/revoke", response_model=TokenResponse)
 async def revoke_token(
     token_id: str,
-    current_user: User = Depends(require_permission("manage_tokens")),
+    current_user: User = Depends(require_permission("manage_api_keys")),
     token_service: TokenService = Depends(get_token_service),
     db: AsyncSession = Depends(get_db),
 ):
@@ -760,7 +760,7 @@ async def revoke_token(
 @router.get("/{token_id}/plain", response_model=dict)
 async def get_plain_token(
     token_id: str,
-    current_user: User = Depends(require_permission("manage_tokens")),
+    current_user: User = Depends(require_permission("manage_api_keys")),
     token_service: TokenService = Depends(get_token_service),
 ):
     """
@@ -827,7 +827,7 @@ class AdjustBalanceResponse(BaseModel):
 async def adjust_token_balance(
     token_id: str,
     request: AdjustBalanceRequest,
-    current_user: User = Depends(require_permission("manage_tokens")),
+    current_user: User = Depends(require_permission("manage_api_keys")),
     token_service: TokenService = Depends(get_token_service),
     db: AsyncSession = Depends(get_db),
 ):

--- a/backend/app/api/admin/endpoints/tokens.py
+++ b/backend/app/api/admin/endpoints/tokens.py
@@ -14,7 +14,12 @@ from pydantic import BaseModel
 from sqlalchemy import case, func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.api.deps import get_audit_log_service, get_token_service, require_permission
+from app.api.deps import (
+    get_allowed_resource_ids,
+    get_audit_log_service,
+    get_token_service,
+    require_permission,
+)
 from app.models.audit_log import AuditAction
 from app.services.audit_log import AuditLogService
 from app.core.database import get_db
@@ -31,6 +36,16 @@ router = APIRouter()
 
 ALLOWED_METADATA_KEYS = {"prompt_cache_enabled", "prompt_cache_ttl"}
 ALLOWED_CACHE_TTL_VALUES = {"5m", "1h"}
+
+
+def _check_resource_scope(user: User, token_id: str) -> None:
+    """Raise 403 if user doesn't have access to this specific token."""
+    allowed_ids = get_allowed_resource_ids(user, "manage_api_keys")
+    if allowed_ids is not None and token_id not in allowed_ids:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="You don't have permission to manage this API key",
+        )
 
 
 async def _invalidate_token_cache(token_hash: str) -> None:
@@ -425,6 +440,13 @@ async def list_tokens(
     if not tokens:
         return []
 
+    # Scope filtering: if admin only has access to specific tokens
+    allowed_ids = get_allowed_resource_ids(current_user, "manage_api_keys")
+    if allowed_ids is not None:
+        tokens = [t for t in tokens if str(t.id) in allowed_ids]
+        if not tokens:
+            return []
+
     # Batch query: get total, monthly, daily usage for all tokens in one query
     now = datetime.utcnow()
     month_start = datetime(now.year, now.month, 1)
@@ -531,6 +553,7 @@ async def get_token(
 
     Returns token details (without plain token key).
     """
+    _check_resource_scope(current_user, token_id)
 
     try:
         token_uuid = UUID(token_id)
@@ -583,6 +606,7 @@ async def update_token(
 
     Returns updated token details.
     """
+    _check_resource_scope(current_user, token_id)
 
     try:
         token_uuid = UUID(token_id)
@@ -668,6 +692,7 @@ async def delete_token(
 
     Permanently deletes the token. This action cannot be undone.
     """
+    _check_resource_scope(current_user, token_id)
 
     try:
         token_uuid = UUID(token_id)
@@ -721,6 +746,7 @@ async def revoke_token(
 
     Deactivates the token. Can be reactivated later via update endpoint.
     """
+    _check_resource_scope(current_user, token_id)
 
     try:
         token_uuid = UUID(token_id)
@@ -770,6 +796,7 @@ async def get_plain_token(
 
     Returns the decrypted token value for copying.
     """
+    _check_resource_scope(current_user, token_id)
 
     try:
         token_uuid = UUID(token_id)
@@ -841,6 +868,8 @@ async def adjust_token_balance(
     Positive amount increases "used" (reduces remaining balance).
     Negative amount decreases "used" (increases remaining balance).
     """
+    _check_resource_scope(current_user, token_id)
+
     if request.amount == 0:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,

--- a/backend/app/api/admin/endpoints/tokens.py
+++ b/backend/app/api/admin/endpoints/tokens.py
@@ -422,7 +422,6 @@ async def batch_create_tokens(
 async def list_tokens(
     include_inactive: bool = False,
     current_user: User = Depends(require_permission("manage_api_keys")),
-    token_service: TokenService = Depends(get_token_service),
     db: AsyncSession = Depends(get_db),
 ):
     """
@@ -432,20 +431,24 @@ async def list_tokens(
 
     Returns list of user's tokens (without plain token keys).
     """
-    tokens = await token_service.get_user_tokens(
-        user_id=current_user.id,
-        include_inactive=include_inactive,
-    )
+    # Scope filtering: if admin has access to specific tokens, query by IDs directly
+    allowed_ids = get_allowed_resource_ids(current_user, "manage_api_keys")
+    if allowed_ids is not None:
+        allowed_uuids = [UUID(id_) for id_ in allowed_ids]
+        query = select(APIToken).where(
+            APIToken.id.in_(allowed_uuids),
+            APIToken.is_deleted.is_(False),
+        )
+    else:
+        query = select(APIToken).where(APIToken.is_deleted.is_(False))
+
+    if not include_inactive:
+        query = query.where(APIToken.is_active)
+    result = await db.execute(query)
+    tokens = list(result.scalars().all())
 
     if not tokens:
         return []
-
-    # Scope filtering: if admin only has access to specific tokens
-    allowed_ids = get_allowed_resource_ids(current_user, "manage_api_keys")
-    if allowed_ids is not None:
-        tokens = [t for t in tokens if str(t.id) in allowed_ids]
-        if not tokens:
-            return []
 
     # Batch query: get total, monthly, daily usage for all tokens in one query
     now = datetime.utcnow()

--- a/backend/app/api/admin/endpoints/usage.py
+++ b/backend/app/api/admin/endpoints/usage.py
@@ -10,7 +10,7 @@ from pydantic import BaseModel
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.api.deps import get_current_user_from_jwt
+from app.api.deps import require_permission
 from app.core.database import get_db
 from app.models.token import APIToken
 from app.models.usage import UsageRecord
@@ -94,7 +94,7 @@ class UsageByModelResponse(BaseModel):
 
 @router.get("/stats", response_model=UsageStatsResponse)
 async def get_usage_stats(
-    current_user: User = Depends(get_current_user_from_jwt),
+    current_user: User = Depends(require_permission("view_usage")),
     db: AsyncSession = Depends(get_db),
     start_date: datetime | None = None,
     end_date: datetime | None = None,
@@ -166,7 +166,7 @@ async def get_usage_stats(
 
 @router.get("/by-token", response_model=list[UsageByTokenResponse])
 async def get_usage_by_token(
-    current_user: User = Depends(get_current_user_from_jwt),
+    current_user: User = Depends(require_permission("view_usage")),
     db: AsyncSession = Depends(get_db),
     token_id: str | None = None,
     start_date: datetime | None = None,
@@ -237,7 +237,7 @@ async def get_usage_by_token(
 
 @router.get("/by-model", response_model=list[UsageByModelResponse])
 async def get_usage_by_model(
-    current_user: User = Depends(get_current_user_from_jwt),
+    current_user: User = Depends(require_permission("view_usage")),
     db: AsyncSession = Depends(get_db),
     model: str | None = None,
     start_date: datetime | None = None,
@@ -378,7 +378,7 @@ async def get_usage_breakdown(
     tz: str = Query(
         "UTC", description="IANA timezone for date grouping, e.g. Asia/Shanghai"
     ),
-    current_user: User = Depends(get_current_user_from_jwt),
+    current_user: User = Depends(require_permission("view_usage")),
     db: AsyncSession = Depends(get_db),
 ):
     """
@@ -424,7 +424,7 @@ async def get_aggregated_stats(
     tz: str = Query(
         "UTC", description="IANA timezone for date grouping, e.g. Asia/Shanghai"
     ),
-    current_user: User = Depends(get_current_user_from_jwt),
+    current_user: User = Depends(require_permission("view_usage")),
     db: AsyncSession = Depends(get_db),
 ):
     """
@@ -469,7 +469,7 @@ async def get_aggregated_stats(
 async def get_token_summary(
     start_date: datetime,
     end_date: datetime,
-    current_user: User = Depends(get_current_user_from_jwt),
+    current_user: User = Depends(require_permission("view_usage")),
     db: AsyncSession = Depends(get_db),
 ):
     """
@@ -500,7 +500,7 @@ async def get_tokens_timeseries(
     tz: str = Query(
         "UTC", description="IANA timezone for date grouping, e.g. Asia/Shanghai"
     ),
-    current_user: User = Depends(get_current_user_from_jwt),
+    current_user: User = Depends(require_permission("view_usage")),
     db: AsyncSession = Depends(get_db),
 ):
     """

--- a/backend/app/api/admin/endpoints/users.py
+++ b/backend/app/api/admin/endpoints/users.py
@@ -85,12 +85,15 @@ async def list_assignable_resources(
         .where(Model.is_active.is_(True), Model.is_deleted.is_(False))
         .order_by(Model.model_name)
     )
+    # Deduplicate models by model_name (same model can belong to multiple tokens)
+    seen_models: dict[str, dict] = {}
+    for r in models_result.all():
+        if r.model_name not in seen_models:
+            seen_models[r.model_name] = {"id": str(r.id), "name": r.model_name}
     return {
         "api_keys": [{"id": str(r.id), "name": r.name} for r in tokens_result.all()],
         "teams": [{"id": str(r.id), "name": r.name} for r in teams_result.all()],
-        "models": [
-            {"id": str(r.id), "name": r.model_name} for r in models_result.all()
-        ],
+        "models": list(seen_models.values()),
     }
 
 

--- a/backend/app/api/admin/endpoints/users.py
+++ b/backend/app/api/admin/endpoints/users.py
@@ -1,6 +1,8 @@
 """Admin user management endpoints."""
 
+import asyncio
 import logging
+from functools import lru_cache
 from typing import List
 from uuid import UUID
 
@@ -15,7 +17,6 @@ from app.api.deps import get_audit_log_service, get_current_superadmin
 from app.core.config import get_settings
 from app.core.database import get_db
 from app.models.audit_log import AuditAction
-from app.models.model import Model
 from app.models.team import Team
 from app.models.token import APIToken
 from app.models.user import User, UserRole
@@ -26,6 +27,15 @@ logger = logging.getLogger(__name__)
 router = APIRouter()
 
 VALID_ROLES = {r.value for r in UserRole}
+
+
+@lru_cache()
+def _get_cognito_client():
+    settings = get_settings()
+    return boto3.client(
+        "cognito-idp",
+        region_name=settings.COGNITO_REGION or settings.AWS_REGION,
+    )
 
 
 class AdminUserResponse(BaseModel):
@@ -76,24 +86,20 @@ async def list_assignable_resources(
     """List all resources (tokens, teams, models) for permission assignment."""
     tokens_result = await db.execute(
         select(APIToken.id, APIToken.name)
-        .where(APIToken.is_active.is_(True), APIToken.is_deleted.is_(False))
+        .where(APIToken.is_deleted.is_(False))
         .order_by(APIToken.name)
     )
     teams_result = await db.execute(select(Team.id, Team.name).order_by(Team.name))
-    models_result = await db.execute(
-        select(Model.id, Model.model_name)
-        .where(Model.is_active.is_(True), Model.is_deleted.is_(False))
-        .order_by(Model.model_name)
-    )
-    # Deduplicate models by model_name (same model can belong to multiple tokens)
-    seen_models: dict[str, dict] = {}
-    for r in models_result.all():
-        if r.model_name not in seen_models:
-            seen_models[r.model_name] = {"id": str(r.id), "name": r.model_name}
+    # Reuse the aws-available endpoint (includes Bedrock + Gemini, cached 12h)
+    from app.api.admin.endpoints.models import list_aws_available_models
+
+    aws_result = await list_aws_available_models(current_user)
+    all_models = aws_result.get("models", [])
+    models = [{"id": m["model_id"], "name": m["model_id"]} for m in all_models]
     return {
         "api_keys": [{"id": str(r.id), "name": r.name} for r in tokens_result.all()],
         "teams": [{"id": str(r.id), "name": r.name} for r in teams_result.all()],
-        "models": list(seen_models.values()),
+        "models": models,
     }
 
 
@@ -161,17 +167,14 @@ async def invite_admin(
     # Create Cognito user with temporary password
     settings = get_settings()
     if settings.COGNITO_USER_POOL_ID:
-        # Cognito with email alias doesn't allow email-format usernames
         cognito_username = request.username
         if "@" in cognito_username:
             cognito_username = cognito_username.split("@")[0]
 
+        cognito_client = _get_cognito_client()
         try:
-            cognito_client = boto3.client(
-                "cognito-idp",
-                region_name=settings.COGNITO_REGION or settings.AWS_REGION,
-            )
-            cognito_client.admin_create_user(
+            await asyncio.to_thread(
+                cognito_client.admin_create_user,
                 UserPoolId=settings.COGNITO_USER_POOL_ID,
                 Username=cognito_username,
                 TemporaryPassword=request.temp_password,
@@ -184,9 +187,9 @@ async def invite_admin(
         except ClientError as e:
             error_code = e.response["Error"]["Code"]
             if error_code == "UsernameExistsException":
-                # User already exists in Cognito, just reset password
                 try:
-                    cognito_client.admin_set_user_password(
+                    await asyncio.to_thread(
+                        cognito_client.admin_set_user_password,
                         UserPoolId=settings.COGNITO_USER_POOL_ID,
                         Username=cognito_username,
                         Password=request.temp_password,

--- a/backend/app/api/admin/endpoints/users.py
+++ b/backend/app/api/admin/endpoints/users.py
@@ -16,6 +16,8 @@ from app.services.audit_log import AuditLogService
 
 router = APIRouter()
 
+VALID_ROLES = {r.value for r in UserRole}
+
 
 class AdminUserResponse(BaseModel):
     id: str
@@ -27,6 +29,20 @@ class AdminUserResponse(BaseModel):
     is_active: bool
     created_at: str
     last_login_at: str | None
+
+    @classmethod
+    def from_user(cls, u: User) -> "AdminUserResponse":
+        return cls(
+            id=str(u.id),
+            email=u.email,
+            first_name=u.first_name,
+            last_name=u.last_name,
+            role=u.role.value,
+            permissions=u.permissions,
+            is_active=u.is_active,
+            created_at=u.created_at.isoformat(),
+            last_login_at=u.last_login_at.isoformat() if u.last_login_at else None,
+        )
 
 
 class InviteAdminRequest(BaseModel):
@@ -55,20 +71,7 @@ async def list_admin_users(
     )
     users = result.scalars().all()
 
-    return [
-        AdminUserResponse(
-            id=str(u.id),
-            email=u.email,
-            first_name=u.first_name,
-            last_name=u.last_name,
-            role=u.role.value,
-            permissions=u.permissions,
-            is_active=u.is_active,
-            created_at=u.created_at.isoformat(),
-            last_login_at=u.last_login_at.isoformat() if u.last_login_at else None,
-        )
-        for u in users
-    ]
+    return [AdminUserResponse.from_user(u) for u in users]
 
 
 @router.post("", response_model=AdminUserResponse, status_code=status.HTTP_201_CREATED)
@@ -82,23 +85,20 @@ async def invite_admin(
     Invite a new admin by email (pre-registration).
     The invited user will be activated when they first login via OAuth.
     """
-    if request.role not in ("super_admin", "admin"):
+    if request.role not in VALID_ROLES:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
-            detail="Role must be 'super_admin' or 'admin'",
+            detail=f"Role must be one of: {', '.join(VALID_ROLES)}",
         )
 
-    # Check if user already exists
-    existing = await db.execute(
-        select(User).where(User.email == request.email)
-    )
+    existing = await db.execute(select(User).where(User.email == request.email))
     if existing.scalar_one_or_none():
         raise HTTPException(
             status_code=status.HTTP_409_CONFLICT,
             detail="User with this email already exists",
         )
 
-    role = UserRole.SUPER_ADMIN if request.role == "super_admin" else UserRole.ADMIN
+    role = UserRole(request.role)
 
     user = User(
         email=request.email,
@@ -120,42 +120,27 @@ async def invite_admin(
         details={"email": user.email, "role": request.role},
     )
 
-    return AdminUserResponse(
-        id=str(user.id),
-        email=user.email,
-        first_name=user.first_name,
-        last_name=user.last_name,
-        role=user.role.value,
-        permissions=user.permissions,
-        is_active=user.is_active,
-        created_at=user.created_at.isoformat(),
-        last_login_at=None,
-    )
+    return AdminUserResponse.from_user(user)
 
 
 @router.put("/{user_id}", response_model=AdminUserResponse)
 async def update_admin(
-    user_id: str,
+    user_id: UUID,
     request: UpdateAdminRequest,
     current_user: User = Depends(get_current_superadmin),
     audit_service: AuditLogService = Depends(get_audit_log_service),
     db: AsyncSession = Depends(get_db),
 ):
     """Update admin user role or permissions."""
-    try:
-        uid = UUID(user_id)
-    except ValueError:
-        raise HTTPException(status_code=400, detail="Invalid user ID")
-
-    result = await db.execute(select(User).where(User.id == uid))
+    result = await db.execute(select(User).where(User.id == user_id))
     user = result.scalar_one_or_none()
     if not user:
         raise HTTPException(status_code=404, detail="User not found")
 
     if request.role is not None:
-        if request.role not in ("super_admin", "admin"):
+        if request.role not in VALID_ROLES:
             raise HTTPException(status_code=400, detail="Invalid role")
-        user.role = UserRole.SUPER_ADMIN if request.role == "super_admin" else UserRole.ADMIN
+        user.role = UserRole(request.role)
 
     if request.permissions is not None:
         user.permissions = request.permissions
@@ -174,36 +159,21 @@ async def update_admin(
         details={"email": user.email, "changes": request.model_dump(exclude_none=True)},
     )
 
-    return AdminUserResponse(
-        id=str(user.id),
-        email=user.email,
-        first_name=user.first_name,
-        last_name=user.last_name,
-        role=user.role.value,
-        permissions=user.permissions,
-        is_active=user.is_active,
-        created_at=user.created_at.isoformat(),
-        last_login_at=user.last_login_at.isoformat() if user.last_login_at else None,
-    )
+    return AdminUserResponse.from_user(user)
 
 
 @router.delete("/{user_id}", status_code=status.HTTP_204_NO_CONTENT)
 async def deactivate_admin(
-    user_id: str,
+    user_id: UUID,
     current_user: User = Depends(get_current_superadmin),
     audit_service: AuditLogService = Depends(get_audit_log_service),
     db: AsyncSession = Depends(get_db),
 ):
     """Deactivate an admin user."""
-    try:
-        uid = UUID(user_id)
-    except ValueError:
-        raise HTTPException(status_code=400, detail="Invalid user ID")
-
-    if uid == current_user.id:
+    if user_id == current_user.id:
         raise HTTPException(status_code=400, detail="Cannot deactivate yourself")
 
-    result = await db.execute(select(User).where(User.id == uid))
+    result = await db.execute(select(User).where(User.id == user_id))
     user = result.scalar_one_or_none()
     if not user:
         raise HTTPException(status_code=404, detail="User not found")

--- a/backend/app/api/admin/endpoints/users.py
+++ b/backend/app/api/admin/endpoints/users.py
@@ -1,0 +1,222 @@
+"""Admin user management endpoints."""
+
+from typing import List
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from pydantic import BaseModel, EmailStr
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.api.deps import get_audit_log_service, get_current_superadmin
+from app.core.database import get_db
+from app.models.audit_log import AuditAction
+from app.models.user import User, UserRole
+from app.services.audit_log import AuditLogService
+
+router = APIRouter()
+
+
+class AdminUserResponse(BaseModel):
+    id: str
+    email: str
+    first_name: str | None
+    last_name: str | None
+    role: str
+    permissions: dict | None
+    is_active: bool
+    created_at: str
+    last_login_at: str | None
+
+
+class InviteAdminRequest(BaseModel):
+    email: EmailStr
+    role: str = "admin"
+    permissions: dict | None = None
+
+
+class UpdateAdminRequest(BaseModel):
+    role: str | None = None
+    permissions: dict | None = None
+    is_active: bool | None = None
+
+
+@router.get("", response_model=List[AdminUserResponse])
+async def list_admin_users(
+    current_user: User = Depends(get_current_superadmin),
+    db: AsyncSession = Depends(get_db),
+):
+    """List all admin users (super_admin and admin roles)."""
+    result = await db.execute(
+        select(User)
+        .where(User.role.in_([UserRole.SUPER_ADMIN, UserRole.ADMIN]))
+        .where(User.is_active.is_(True))
+        .order_by(User.created_at.desc())
+    )
+    users = result.scalars().all()
+
+    return [
+        AdminUserResponse(
+            id=str(u.id),
+            email=u.email,
+            first_name=u.first_name,
+            last_name=u.last_name,
+            role=u.role.value,
+            permissions=u.permissions,
+            is_active=u.is_active,
+            created_at=u.created_at.isoformat(),
+            last_login_at=u.last_login_at.isoformat() if u.last_login_at else None,
+        )
+        for u in users
+    ]
+
+
+@router.post("", response_model=AdminUserResponse, status_code=status.HTTP_201_CREATED)
+async def invite_admin(
+    request: InviteAdminRequest,
+    current_user: User = Depends(get_current_superadmin),
+    audit_service: AuditLogService = Depends(get_audit_log_service),
+    db: AsyncSession = Depends(get_db),
+):
+    """
+    Invite a new admin by email (pre-registration).
+    The invited user will be activated when they first login via OAuth.
+    """
+    if request.role not in ("super_admin", "admin"):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Role must be 'super_admin' or 'admin'",
+        )
+
+    # Check if user already exists
+    existing = await db.execute(
+        select(User).where(User.email == request.email)
+    )
+    if existing.scalar_one_or_none():
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="User with this email already exists",
+        )
+
+    role = UserRole.SUPER_ADMIN if request.role == "super_admin" else UserRole.ADMIN
+
+    user = User(
+        email=request.email,
+        role=role,
+        permissions=request.permissions,
+        is_active=True,
+        is_admin=True,
+        email_verified=False,
+    )
+    db.add(user)
+    await db.commit()
+    await db.refresh(user)
+
+    await audit_service.log(
+        action=AuditAction.ADMIN_CREATED,
+        user=current_user,
+        resource_type="user",
+        resource_id=str(user.id),
+        details={"email": user.email, "role": request.role},
+    )
+
+    return AdminUserResponse(
+        id=str(user.id),
+        email=user.email,
+        first_name=user.first_name,
+        last_name=user.last_name,
+        role=user.role.value,
+        permissions=user.permissions,
+        is_active=user.is_active,
+        created_at=user.created_at.isoformat(),
+        last_login_at=None,
+    )
+
+
+@router.put("/{user_id}", response_model=AdminUserResponse)
+async def update_admin(
+    user_id: str,
+    request: UpdateAdminRequest,
+    current_user: User = Depends(get_current_superadmin),
+    audit_service: AuditLogService = Depends(get_audit_log_service),
+    db: AsyncSession = Depends(get_db),
+):
+    """Update admin user role or permissions."""
+    try:
+        uid = UUID(user_id)
+    except ValueError:
+        raise HTTPException(status_code=400, detail="Invalid user ID")
+
+    result = await db.execute(select(User).where(User.id == uid))
+    user = result.scalar_one_or_none()
+    if not user:
+        raise HTTPException(status_code=404, detail="User not found")
+
+    if request.role is not None:
+        if request.role not in ("super_admin", "admin"):
+            raise HTTPException(status_code=400, detail="Invalid role")
+        user.role = UserRole.SUPER_ADMIN if request.role == "super_admin" else UserRole.ADMIN
+
+    if request.permissions is not None:
+        user.permissions = request.permissions
+
+    if request.is_active is not None:
+        user.is_active = request.is_active
+
+    await db.commit()
+    await db.refresh(user)
+
+    await audit_service.log(
+        action=AuditAction.ADMIN_UPDATED,
+        user=current_user,
+        resource_type="user",
+        resource_id=str(user.id),
+        details={"email": user.email, "changes": request.model_dump(exclude_none=True)},
+    )
+
+    return AdminUserResponse(
+        id=str(user.id),
+        email=user.email,
+        first_name=user.first_name,
+        last_name=user.last_name,
+        role=user.role.value,
+        permissions=user.permissions,
+        is_active=user.is_active,
+        created_at=user.created_at.isoformat(),
+        last_login_at=user.last_login_at.isoformat() if user.last_login_at else None,
+    )
+
+
+@router.delete("/{user_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def deactivate_admin(
+    user_id: str,
+    current_user: User = Depends(get_current_superadmin),
+    audit_service: AuditLogService = Depends(get_audit_log_service),
+    db: AsyncSession = Depends(get_db),
+):
+    """Deactivate an admin user."""
+    try:
+        uid = UUID(user_id)
+    except ValueError:
+        raise HTTPException(status_code=400, detail="Invalid user ID")
+
+    if uid == current_user.id:
+        raise HTTPException(status_code=400, detail="Cannot deactivate yourself")
+
+    result = await db.execute(select(User).where(User.id == uid))
+    user = result.scalar_one_or_none()
+    if not user:
+        raise HTTPException(status_code=404, detail="User not found")
+
+    user.is_active = False
+    await db.commit()
+
+    await audit_service.log(
+        action=AuditAction.ADMIN_DELETED,
+        user=current_user,
+        resource_type="user",
+        resource_id=str(user.id),
+        details={"email": user.email},
+    )
+
+    return None

--- a/backend/app/api/admin/endpoints/users.py
+++ b/backend/app/api/admin/endpoints/users.py
@@ -1,14 +1,18 @@
 """Admin user management endpoints."""
 
+import logging
 from typing import List
 from uuid import UUID
 
+import boto3
+from botocore.exceptions import ClientError
 from fastapi import APIRouter, Depends, HTTPException, status
 from pydantic import BaseModel, EmailStr
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.api.deps import get_audit_log_service, get_current_superadmin
+from app.core.config import get_settings
 from app.core.database import get_db
 from app.models.audit_log import AuditAction
 from app.models.model import Model
@@ -16,6 +20,8 @@ from app.models.team import Team
 from app.models.token import APIToken
 from app.models.user import User, UserRole
 from app.services.audit_log import AuditLogService
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter()
 
@@ -50,6 +56,8 @@ class AdminUserResponse(BaseModel):
 
 class InviteAdminRequest(BaseModel):
     email: EmailStr
+    username: str
+    temp_password: str
     role: str = "admin"
     permissions: dict | None = None
 
@@ -111,8 +119,8 @@ async def invite_admin(
     db: AsyncSession = Depends(get_db),
 ):
     """
-    Invite a new admin by email (pre-registration).
-    The invited user will be activated when they first login via OAuth.
+    Invite a new admin by email.
+    Creates a Cognito user with temporary password and a local user record.
     """
     if request.role not in VALID_ROLES:
         raise HTTPException(
@@ -146,6 +154,48 @@ async def invite_admin(
             email_verified=False,
         )
         db.add(user)
+
+    # Create Cognito user with temporary password
+    settings = get_settings()
+    if settings.COGNITO_USER_POOL_ID:
+        try:
+            cognito_client = boto3.client(
+                "cognito-idp",
+                region_name=settings.COGNITO_REGION or settings.AWS_REGION,
+            )
+            cognito_client.admin_create_user(
+                UserPoolId=settings.COGNITO_USER_POOL_ID,
+                Username=request.username,
+                TemporaryPassword=request.temp_password,
+                UserAttributes=[
+                    {"Name": "email", "Value": request.email},
+                    {"Name": "email_verified", "Value": "true"},
+                ],
+                MessageAction="SUPPRESS",
+            )
+        except ClientError as e:
+            error_code = e.response["Error"]["Code"]
+            if error_code == "UsernameExistsException":
+                # User already exists in Cognito, just reset password
+                try:
+                    cognito_client.admin_set_user_password(
+                        UserPoolId=settings.COGNITO_USER_POOL_ID,
+                        Username=request.username,
+                        Password=request.temp_password,
+                        Permanent=False,
+                    )
+                except ClientError as reset_err:
+                    logger.error(f"Failed to reset Cognito password: {reset_err}")
+                    raise HTTPException(
+                        status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                        detail=f"Failed to reset Cognito password: {reset_err.response['Error']['Message']}",
+                    )
+            else:
+                logger.error(f"Failed to create Cognito user: {e}")
+                raise HTTPException(
+                    status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                    detail=f"Failed to create Cognito user: {e.response['Error']['Message']}",
+                )
 
     await db.commit()
     await db.refresh(user)

--- a/backend/app/api/admin/endpoints/users.py
+++ b/backend/app/api/admin/endpoints/users.py
@@ -92,23 +92,32 @@ async def invite_admin(
         )
 
     existing = await db.execute(select(User).where(User.email == request.email))
-    if existing.scalar_one_or_none():
-        raise HTTPException(
-            status_code=status.HTTP_409_CONFLICT,
-            detail="User with this email already exists",
-        )
+    user = existing.scalar_one_or_none()
 
     role = UserRole(request.role)
 
-    user = User(
-        email=request.email,
-        role=role,
-        permissions=request.permissions,
-        is_active=True,
-        is_admin=True,
-        email_verified=False,
-    )
-    db.add(user)
+    if user:
+        if user.is_active:
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail="User with this email already exists",
+            )
+        # Reactivate previously deactivated user
+        user.is_active = True
+        user.role = role
+        user.permissions = request.permissions
+        user.is_admin = True
+    else:
+        user = User(
+            email=request.email,
+            role=role,
+            permissions=request.permissions,
+            is_active=True,
+            is_admin=True,
+            email_verified=False,
+        )
+        db.add(user)
+
     await db.commit()
     await db.refresh(user)
 

--- a/backend/app/api/admin/endpoints/users.py
+++ b/backend/app/api/admin/endpoints/users.py
@@ -161,6 +161,11 @@ async def invite_admin(
     # Create Cognito user with temporary password
     settings = get_settings()
     if settings.COGNITO_USER_POOL_ID:
+        # Cognito with email alias doesn't allow email-format usernames
+        cognito_username = request.username
+        if "@" in cognito_username:
+            cognito_username = cognito_username.split("@")[0]
+
         try:
             cognito_client = boto3.client(
                 "cognito-idp",
@@ -168,7 +173,7 @@ async def invite_admin(
             )
             cognito_client.admin_create_user(
                 UserPoolId=settings.COGNITO_USER_POOL_ID,
-                Username=request.username,
+                Username=cognito_username,
                 TemporaryPassword=request.temp_password,
                 UserAttributes=[
                     {"Name": "email", "Value": request.email},
@@ -183,7 +188,7 @@ async def invite_admin(
                 try:
                     cognito_client.admin_set_user_password(
                         UserPoolId=settings.COGNITO_USER_POOL_ID,
-                        Username=request.username,
+                        Username=cognito_username,
                         Password=request.temp_password,
                         Permanent=False,
                     )

--- a/backend/app/api/admin/endpoints/users.py
+++ b/backend/app/api/admin/endpoints/users.py
@@ -11,6 +11,9 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.api.deps import get_audit_log_service, get_current_superadmin
 from app.core.database import get_db
 from app.models.audit_log import AuditAction
+from app.models.model import Model
+from app.models.team import Team
+from app.models.token import APIToken
 from app.models.user import User, UserRole
 from app.services.audit_log import AuditLogService
 
@@ -55,6 +58,32 @@ class UpdateAdminRequest(BaseModel):
     role: str | None = None
     permissions: dict | None = None
     is_active: bool | None = None
+
+
+@router.get("/resources")
+async def list_assignable_resources(
+    current_user: User = Depends(get_current_superadmin),
+    db: AsyncSession = Depends(get_db),
+):
+    """List all resources (tokens, teams, models) for permission assignment."""
+    tokens_result = await db.execute(
+        select(APIToken.id, APIToken.name)
+        .where(APIToken.is_active.is_(True), APIToken.is_deleted.is_(False))
+        .order_by(APIToken.name)
+    )
+    teams_result = await db.execute(select(Team.id, Team.name).order_by(Team.name))
+    models_result = await db.execute(
+        select(Model.id, Model.model_name)
+        .where(Model.is_active.is_(True), Model.is_deleted.is_(False))
+        .order_by(Model.model_name)
+    )
+    return {
+        "api_keys": [{"id": str(r.id), "name": r.name} for r in tokens_result.all()],
+        "teams": [{"id": str(r.id), "name": r.name} for r in teams_result.all()],
+        "models": [
+            {"id": str(r.id), "name": r.model_name} for r in models_result.all()
+        ],
+    }
 
 
 @router.get("", response_model=List[AdminUserResponse])

--- a/backend/app/api/admin/router.py
+++ b/backend/app/api/admin/router.py
@@ -12,6 +12,7 @@ from app.api.admin.endpoints import (
     teams,
     tokens,
     usage,
+    users,
     pricing,
     monitor,
     observability,
@@ -48,8 +49,8 @@ admin_router.include_router(
     observability.router, prefix="/observability", tags=["admin-observability"]
 )
 
-# TODO: Add more admin endpoints
-# admin_router.include_router(users.router, prefix="/users", tags=["admin-users"])
+# Admin user management (super_admin only)
+admin_router.include_router(users.router, prefix="/users", tags=["admin-users"])
 
 
 @admin_router.get("/")

--- a/backend/app/api/deps.py
+++ b/backend/app/api/deps.py
@@ -411,6 +411,7 @@ def get_allowed_resource_ids(user: User, permission: str) -> Optional[list[str]]
 
     Returns None if the user has full access ("all" or super_admin).
     Returns a list of ID strings if access is scoped.
+    Returns an empty list if access is denied.
     """
     if user.role == UserRole.SUPER_ADMIN:
         return None
@@ -422,4 +423,14 @@ def get_allowed_resource_ids(user: User, permission: str) -> Optional[list[str]]
         return None
     if isinstance(perm_value, list):
         return perm_value
-    return None
+    return []
+
+
+def check_resource_scope(user: User, permission: str, resource_id: str) -> None:
+    """Raise 403 if user doesn't have access to a specific resource."""
+    allowed_ids = get_allowed_resource_ids(user, permission)
+    if allowed_ids is not None and resource_id not in allowed_ids:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Access denied to this resource",
+        )

--- a/backend/app/api/deps.py
+++ b/backend/app/api/deps.py
@@ -16,7 +16,7 @@ from app.core.database import get_db
 from app.core.log_context import set_log_context
 from app.core.security import decode_jwt_token
 from app.models.token import APIToken
-from app.models.user import User
+from app.models.user import User, UserRole
 from app.services.audit_log import AuditLogService
 from app.services.auth import AuthService
 from app.services.refresh_token import RefreshTokenService
@@ -358,3 +358,43 @@ async def get_current_user(
         )
 
     return user
+
+
+async def get_current_superadmin(
+    current_user: User = Depends(get_current_user_from_jwt),
+) -> User:
+    """Require super_admin role."""
+    if not current_user.role or current_user.role != UserRole.SUPER_ADMIN:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Super admin access required",
+        )
+    return current_user
+
+
+def require_permission(permission: str):
+    """Factory that returns a dependency checking a specific permission."""
+
+    async def _check_permission(
+        current_user: User = Depends(get_current_user_from_jwt),
+    ) -> User:
+        # Super admin bypasses all checks
+        if current_user.role == UserRole.SUPER_ADMIN:
+            return current_user
+        # Admin with specific permission or legacy is_admin users
+        if current_user.role == UserRole.ADMIN or current_user.is_admin:
+            user_perms = current_user.permissions or {}
+            if not user_perms:
+                return current_user
+            if user_perms.get(permission, False):
+                return current_user
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail=f"Permission denied: {permission}",
+            )
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Admin access required",
+        )
+
+    return _check_permission

--- a/backend/app/api/deps.py
+++ b/backend/app/api/deps.py
@@ -373,28 +373,53 @@ async def get_current_superadmin(
 
 
 def require_permission(permission: str):
-    """Factory that returns a dependency checking a specific permission."""
+    """Factory that returns a dependency checking a specific permission.
+
+    Permission values in the user's permissions JSON can be:
+    - true / "all": full access to all resources of this type
+    - list of IDs: access only to those specific resources
+    - false / missing: no access
+    """
 
     async def _check_permission(
         current_user: User = Depends(get_current_user_from_jwt),
     ) -> User:
-        # Super admin bypasses all checks
         if current_user.role == UserRole.SUPER_ADMIN:
             return current_user
-        # Admin with specific permission or legacy is_admin users
         if current_user.role == UserRole.ADMIN or current_user.is_admin:
             user_perms = current_user.permissions or {}
             if not user_perms:
                 return current_user
-            if user_perms.get(permission, False):
-                return current_user
-            raise HTTPException(
-                status_code=status.HTTP_403_FORBIDDEN,
-                detail=f"Permission denied: {permission}",
-            )
+            perm_value = user_perms.get(permission)
+            if perm_value is None or perm_value is False:
+                raise HTTPException(
+                    status_code=status.HTTP_403_FORBIDDEN,
+                    detail=f"Permission denied: {permission}",
+                )
+            # true, "all", or a list of IDs all grant access
+            return current_user
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
             detail="Admin access required",
         )
 
     return _check_permission
+
+
+def get_allowed_resource_ids(user: User, permission: str) -> Optional[list[str]]:
+    """Get the list of resource IDs the user is allowed to manage.
+
+    Returns None if the user has full access ("all" or super_admin).
+    Returns a list of ID strings if access is scoped.
+    """
+    if user.role == UserRole.SUPER_ADMIN:
+        return None
+    user_perms = user.permissions or {}
+    if not user_perms:
+        return None
+    perm_value = user_perms.get(permission)
+    if perm_value is True or perm_value == "all":
+        return None
+    if isinstance(perm_value, list):
+        return perm_value
+    return None

--- a/backend/app/models/audit_log.py
+++ b/backend/app/models/audit_log.py
@@ -43,6 +43,20 @@ class AuditAction(enum.Enum):
     PASSWORD_CHANGED = "password_changed"  # pragma: allowlist secret  # nosemgrep
     EMAIL_VERIFIED = "email_verified"
 
+    # Admin Management
+    ADMIN_CREATED = "admin_created"
+    ADMIN_UPDATED = "admin_updated"
+    ADMIN_DELETED = "admin_deleted"
+
+    # Resource Operations
+    TOKEN_CREATED = "token_created"
+    TOKEN_UPDATED = "token_updated"
+    TOKEN_DELETED = "token_deleted"
+    TEAM_CREATED = "team_created"
+    TEAM_UPDATED = "team_updated"
+    TEAM_DELETED = "team_deleted"
+    MODEL_UPDATED = "model_updated"
+
     # Authorization
     UNAUTHORIZED_ACCESS_ATTEMPT = "unauthorized_access_attempt"
     PERMISSION_DENIED = "permission_denied"

--- a/backend/app/models/user.py
+++ b/backend/app/models/user.py
@@ -5,7 +5,7 @@ from datetime import datetime
 from decimal import Decimal
 from uuid import uuid4
 
-from sqlalchemy import Boolean, Column, DateTime, Enum, Numeric, String
+from sqlalchemy import Boolean, Column, DateTime, Enum, Numeric, String, JSON
 from sqlalchemy.dialects.postgresql import UUID as PostgresUUID
 from sqlalchemy.orm import relationship
 
@@ -18,6 +18,13 @@ class AuthMethod(enum.Enum):
     LOCAL = "local"  # Local password authentication
     MICROSOFT = "microsoft"  # Microsoft OAuth
     COGNITO = "cognito"  # AWS Cognito
+
+
+class UserRole(enum.Enum):
+    """User role enum for RBAC."""
+
+    SUPER_ADMIN = "super_admin"
+    ADMIN = "admin"
 
 
 class User(Base):
@@ -33,6 +40,13 @@ class User(Base):
     )
     is_active = Column(Boolean, default=True, nullable=False)
     is_admin = Column(Boolean, default=False, nullable=False)
+    role = Column(
+        Enum(UserRole, values_callable=lambda x: [e.value for e in x]),
+        default=UserRole.ADMIN,
+        nullable=False,
+        index=True,
+    )
+    permissions = Column(JSON, nullable=True)
     email_verified = Column(Boolean, default=False, nullable=False)
 
     # Balance and credits

--- a/backend/app/services/audit_log.py
+++ b/backend/app/services/audit_log.py
@@ -93,7 +93,10 @@ class AuditLogService:
             await self.db.refresh(audit_log)
         except Exception as e:
             logger.error(f"Failed to write audit log: {e}")
-            await self.db.rollback()
+            try:
+                await self.db.rollback()
+            except Exception:
+                pass
             return audit_log
 
         # Log to application logger for monitoring

--- a/backend/app/services/audit_log.py
+++ b/backend/app/services/audit_log.py
@@ -87,9 +87,14 @@ class AuditLogService:
             created_at=datetime.utcnow(),
         )
 
-        self.db.add(audit_log)
-        await self.db.commit()
-        await self.db.refresh(audit_log)
+        try:
+            self.db.add(audit_log)
+            await self.db.commit()
+            await self.db.refresh(audit_log)
+        except Exception as e:
+            logger.error(f"Failed to write audit log: {e}")
+            await self.db.rollback()
+            return audit_log
 
         # Log to application logger for monitoring
         log_level = logging.INFO if success else logging.WARNING

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -449,6 +449,42 @@ All Admin endpoints (except OAuth login URLs) require a JWT access token:
 Authorization: Bearer <jwt_access_token>
 ```
 
+### Authorization (RBAC)
+
+The Admin API uses role-based access control with two roles:
+
+| Role | Access |
+|------|--------|
+| `super_admin` | Full access to all endpoints and resources |
+| `admin` | Scoped access controlled by `permissions` object |
+
+Admin users have a `permissions` JSON object that controls what they can manage:
+
+| Permission | Values | Controls |
+|-----------|--------|----------|
+| `manage_api_keys` | `true`/`"all"`, `[id, ...]`, `false` | API token CRUD |
+| `manage_teams` | `true`/`"all"`, `[id, ...]`, `false` | Team CRUD |
+| `manage_models` | `true`/`"all"`, `[id, ...]`, `false` | Model configuration |
+| `view_usage` | `true`/`false` | Usage statistics |
+| `view_monitor` | `true`/`false` | Request monitor |
+
+- `true` or `"all"`: full access to all resources of that type
+- Array of UUIDs: access only to those specific resources
+- `false` or missing: no access (403)
+
+Endpoints are guarded by permission requirements:
+
+| Endpoint Group | Required Permission |
+|----------------|-------------------|
+| `/admin/tokens/*` | `manage_api_keys` |
+| `/admin/teams/*` | `manage_teams` |
+| `/admin/models/*` | `manage_models` |
+| `/admin/usage/*` | `view_usage` |
+| `/admin/monitor/*` | `view_monitor` |
+| `/admin/users/*` | `super_admin` role only |
+| `/admin/audit-logs` | `super_admin` role only |
+| `/admin/audit-logs/activity` | Any admin |
+
 ### 2.1 Authentication
 
 #### GET /admin/auth/microsoft/login
@@ -491,7 +527,15 @@ Handle Microsoft OAuth callback. Creates or links user account.
     "first_name": "John",
     "last_name": "Doe",
     "is_active": true,
-    "is_admin": false,
+    "is_admin": true,
+    "role": "admin",
+    "permissions": {
+      "manage_api_keys": "all", // pragma: allowlist secret
+      "manage_teams": ["uuid1", "uuid2"],
+      "manage_models": true,
+      "view_usage": true,
+      "view_monitor": true
+    },
     "email_verified": true,
     "current_balance": "5.00"
   }
@@ -951,6 +995,137 @@ Audit activity summary with counts by action type.
     "login_failed": 20,
     "logout_all_devices": 5
   }
+}
+```
+
+#### GET /admin/audit-logs/activity
+
+Activity feed visible to all admins. Shows only management operations (token/team/model/admin CRUD) from the last N days. Non-super_admin users cannot see actions performed by super_admins.
+
+| Parameter | In | Type | Default | Description |
+|-----------|-----|------|---------|-------------|
+| `page` | query | integer | `1` | Page number (1-based) |
+| `page_size` | query | integer | `50` | Items per page (max 100) |
+| `days` | query | integer | `7` | Lookback window (1-30 days) |
+
+**Response**:
+
+```json
+{
+  "items": [
+    {
+      "id": "uuid",
+      "user_id": "uuid",
+      "user_email": "admin@example.com",
+      "action": "token_created",
+      "resource_type": "token",
+      "resource_id": "uuid",
+      "details": "{\"name\": \"New Token\"}",
+      "created_at": "2026-01-15T10:30:00"
+    }
+  ],
+  "total": 25,
+  "page": 1,
+  "page_size": 50,
+  "total_pages": 1
+}
+```
+
+### 2.6 Admin User Management
+
+Super admin only. Manage admin user accounts.
+
+#### GET /admin/users
+
+List all active admin users (super_admin and admin roles).
+
+**Response**: Array of `AdminUserResponse`:
+
+```json
+[
+  {
+    "id": "uuid",
+    "email": "admin@example.com",
+    "first_name": "John",
+    "last_name": "Doe",
+    "role": "admin",
+    "permissions": {
+      "manage_api_keys": "all", // pragma: allowlist secret
+      "manage_teams": "all",
+      "manage_models": "all",
+      "view_usage": true,
+      "view_monitor": true
+    },
+    "is_active": true,
+    "created_at": "2026-01-01T00:00:00",
+    "last_login_at": "2026-01-15T10:30:00"
+  }
+]
+```
+
+#### POST /admin/users
+
+Invite a new admin. Creates a Cognito user with a temporary password and a local user record.
+
+**Request body**:
+
+```json
+{
+  "email": "newadmin@example.com",
+  "username": "newadmin",
+  "temp_password": "TempPass123!", // pragma: allowlist secret
+  "role": "admin",
+  "permissions": {
+    "manage_api_keys": "all", // pragma: allowlist secret
+    "manage_teams": ["team-uuid-1"],
+    "manage_models": true,
+    "view_usage": true,
+    "view_monitor": true
+  }
+}
+```
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `email` | string | yes | Admin email address |
+| `username` | string | yes | Cognito login username |
+| `temp_password` | string | yes | Temporary password (must change on first login) |
+| `role` | string | no | `"super_admin"` or `"admin"` (default: `"admin"`) |
+| `permissions` | object | no | Permission scope (only for `admin` role) |
+
+**Response** (201): `AdminUserResponse`
+
+#### PUT /admin/users/{user_id}
+
+Update admin user role or permissions.
+
+**Request body** (all fields optional):
+
+```json
+{
+  "role": "admin",
+  "permissions": { "manage_api_keys": "all", "view_usage": true }, // pragma: allowlist secret
+  "is_active": true
+}
+```
+
+**Response**: Updated `AdminUserResponse`.
+
+#### DELETE /admin/users/{user_id}
+
+Deactivate an admin user. Cannot deactivate yourself. Returns 204 No Content.
+
+#### GET /admin/users/resources
+
+List all assignable resources (tokens, teams, models) for the permission editor UI.
+
+**Response**:
+
+```json
+{
+  "api_keys": [{ "id": "uuid", "name": "Token Name" }],
+  "teams": [{ "id": "uuid", "name": "Team Name" }],
+  "models": [{ "id": "model-id", "name": "model-id" }]
 }
 ```
 

--- a/docs/api-reference.zh.md
+++ b/docs/api-reference.zh.md
@@ -437,6 +437,42 @@ export CLAUDE_MODEL="us.anthropic.claude-sonnet-4-5-20250514-v1:0"
 Authorization: Bearer <jwt_access_token>
 ```
 
+### 权限控制（RBAC）
+
+Admin API 使用基于角色的访问控制，包含两个角色：
+
+| 角色 | 权限 |
+|------|------|
+| `super_admin` | 完全访问所有端点和资源 |
+| `admin` | 受 `permissions` 对象控制的有限访问 |
+
+Admin 用户有一个 `permissions` JSON 对象，控制其可管理的资源：
+
+| 权限 | 取值 | 控制范围 |
+|------|------|----------|
+| `manage_api_keys` | `true`/`"all"`、`[id, ...]`、`false` | API Token 增删改查 |
+| `manage_teams` | `true`/`"all"`、`[id, ...]`、`false` | 团队增删改查 |
+| `manage_models` | `true`/`"all"`、`[id, ...]`、`false` | 模型配置 |
+| `view_usage` | `true`/`false` | 用量统计 |
+| `view_monitor` | `true`/`false` | 请求监控 |
+
+- `true` 或 `"all"`：对该类型所有资源有完全访问权限
+- UUID 数组：仅可访问指定资源
+- `false` 或缺失：无权限（403）
+
+各端点所需权限：
+
+| 端点分组 | 所需权限 |
+|----------|----------|
+| `/admin/tokens/*` | `manage_api_keys` |
+| `/admin/teams/*` | `manage_teams` |
+| `/admin/models/*` | `manage_models` |
+| `/admin/usage/*` | `view_usage` |
+| `/admin/monitor/*` | `view_monitor` |
+| `/admin/users/*` | 仅 `super_admin` 角色 |
+| `/admin/audit-logs` | 仅 `super_admin` 角色 |
+| `/admin/audit-logs/activity` | 所有管理员 |
+
 ### 2.1 认证
 
 #### GET /admin/auth/microsoft/login
@@ -479,7 +515,15 @@ Authorization: Bearer <jwt_access_token>
     "first_name": "John",
     "last_name": "Doe",
     "is_active": true,
-    "is_admin": false,
+    "is_admin": true,
+    "role": "admin",
+    "permissions": {
+      "manage_api_keys": "all", // pragma: allowlist secret
+      "manage_teams": ["uuid1", "uuid2"],
+      "manage_models": true,
+      "view_usage": true,
+      "view_monitor": true
+    },
     "email_verified": true,
     "current_balance": "5.00"
   }
@@ -939,6 +983,137 @@ Authorization: Bearer <jwt_access_token>
     "login_failed": 20,
     "logout_all_devices": 5
   }
+}
+```
+
+#### GET /admin/audit-logs/activity
+
+所有管理员可见的活动动态。仅展示管理操作（Token/团队/模型/管理员的增删改），显示最近 N 天的记录。非 super_admin 用户无法看到 super_admin 的操作。
+
+| 参数 | 位置 | 类型 | 默认值 | 说明 |
+|------|------|------|--------|------|
+| `page` | query | integer | `1` | 页码（从 1 开始） |
+| `page_size` | query | integer | `50` | 每页条数（最大 100） |
+| `days` | query | integer | `7` | 回溯天数（1-30 天） |
+
+**响应**：
+
+```json
+{
+  "items": [
+    {
+      "id": "uuid",
+      "user_id": "uuid",
+      "user_email": "admin@example.com",
+      "action": "token_created",
+      "resource_type": "token",
+      "resource_id": "uuid",
+      "details": "{\"name\": \"New Token\"}",
+      "created_at": "2026-01-15T10:30:00"
+    }
+  ],
+  "total": 25,
+  "page": 1,
+  "page_size": 50,
+  "total_pages": 1
+}
+```
+
+### 2.6 管理员用户管理
+
+仅 super_admin 可用。管理管理员用户账户。
+
+#### GET /admin/users
+
+列出所有活跃的管理员用户（super_admin 和 admin 角色）。
+
+**响应**：`AdminUserResponse` 数组：
+
+```json
+[
+  {
+    "id": "uuid",
+    "email": "admin@example.com",
+    "first_name": "John",
+    "last_name": "Doe",
+    "role": "admin",
+    "permissions": {
+      "manage_api_keys": "all", // pragma: allowlist secret
+      "manage_teams": "all",
+      "manage_models": "all",
+      "view_usage": true,
+      "view_monitor": true
+    },
+    "is_active": true,
+    "created_at": "2026-01-01T00:00:00",
+    "last_login_at": "2026-01-15T10:30:00"
+  }
+]
+```
+
+#### POST /admin/users
+
+邀请新管理员。在 Cognito 中创建用户（设置临时密码），同时创建本地用户记录。
+
+**请求体**：
+
+```json
+{
+  "email": "newadmin@example.com",
+  "username": "newadmin",
+  "temp_password": "TempPass123!", // pragma: allowlist secret
+  "role": "admin",
+  "permissions": {
+    "manage_api_keys": "all", // pragma: allowlist secret
+    "manage_teams": ["team-uuid-1"],
+    "manage_models": true,
+    "view_usage": true,
+    "view_monitor": true
+  }
+}
+```
+
+| 字段 | 类型 | 必填 | 说明 |
+|------|------|------|------|
+| `email` | string | 是 | 管理员邮箱 |
+| `username` | string | 是 | Cognito 登录用户名 |
+| `temp_password` | string | 是 | 临时密码（首次登录必须修改） |
+| `role` | string | 否 | `"super_admin"` 或 `"admin"`（默认: `"admin"`） |
+| `permissions` | object | 否 | 权限范围（仅 `admin` 角色需要） |
+
+**响应** (201)：`AdminUserResponse`
+
+#### PUT /admin/users/{user_id}
+
+更新管理员用户的角色或权限。
+
+**请求体**（所有字段可选）：
+
+```json
+{
+  "role": "admin",
+  "permissions": { "manage_api_keys": "all", "view_usage": true }, // pragma: allowlist secret
+  "is_active": true
+}
+```
+
+**响应**：更新后的 `AdminUserResponse`。
+
+#### DELETE /admin/users/{user_id}
+
+停用管理员用户。不能停用自己。返回 204 No Content。
+
+#### GET /admin/users/resources
+
+列出所有可分配的资源（Token、团队、模型），供权限编辑器 UI 使用。
+
+**响应**：
+
+```json
+{
+  "api_keys": [{ "id": "uuid", "name": "Token Name" }],
+  "teams": [{ "id": "uuid", "name": "Team Name" }],
+  "models": [{ "id": "model-id", "name": "model-id" }]
 }
 ```
 

--- a/frontend/src/boot/axios.ts
+++ b/frontend/src/boot/axios.ts
@@ -156,13 +156,16 @@ api.interceptors.response.use(
       }
     }
 
-    // Handle 403 Forbidden - treat as auth failure, redirect to login
+    // Handle 403 Forbidden - only logout for inactive user, otherwise just reject
     if (error.response?.status === 403) {
-      localStorage.removeItem('access_token');
-      if (typeof window !== 'undefined' && !window.location.pathname.startsWith('/login')) {
-        window.location.href = '/login';
+      const detail = error.response?.data?.detail || '';
+      if (detail === 'Inactive user') {
+        localStorage.removeItem('access_token');
+        if (typeof window !== 'undefined' && !window.location.pathname.startsWith('/login')) {
+          window.location.href = '/login';
+        }
       }
-      return Promise.reject(new Error('Access denied'));
+      return Promise.reject(error as Error);
     }
 
     // Handle 5xx errors and network errors with retry logic

--- a/frontend/src/components/PermissionEditor.vue
+++ b/frontend/src/components/PermissionEditor.vue
@@ -35,16 +35,8 @@
 </template>
 
 <script setup lang="ts">
-interface ResourceOption {
-  label: string;
-  value: string;
-}
-
-interface Resources {
-  api_keys: ResourceOption[];
-  teams: ResourceOption[];
-  models: ResourceOption[];
-}
+import { computed } from 'vue';
+import type { Resources } from 'src/types/permissions';
 
 const ALL_VALUE = '__all__';
 
@@ -63,17 +55,26 @@ const managePermissions = [
   { key: 'manage_models', resourceKey: 'models' as const, label: 'Manage Models' },
 ];
 
-function getOptions(key: string): ResourceOption[] {
-  const perm = managePermissions.find((p) => p.key === key);
-  if (!perm) return [];
-  const resourceList = props.resources[perm.resourceKey] || [];
-  return [{ label: 'All', value: ALL_VALUE }, ...resourceList];
+const optionsMap = computed(() =>
+  Object.fromEntries(managePermissions.map(p => [
+    p.key,
+    [{ label: 'All', value: ALL_VALUE }, ...(props.resources[p.resourceKey] || [])],
+  ]))
+);
+
+const resourceIdsMap = computed(() =>
+  Object.fromEntries(managePermissions.map(p => [
+    p.key,
+    (props.resources[p.resourceKey] || []).map(o => o.value),
+  ]))
+);
+
+function getOptions(key: string) {
+  return optionsMap.value[key] || [];
 }
 
 function getResourceIds(key: string): string[] {
-  const perm = managePermissions.find((p) => p.key === key);
-  if (!perm) return [];
-  return (props.resources[perm.resourceKey] || []).map((o) => o.value);
+  return resourceIdsMap.value[key] || [];
 }
 
 function isAll(key: string): boolean {

--- a/frontend/src/components/PermissionEditor.vue
+++ b/frontend/src/components/PermissionEditor.vue
@@ -5,10 +5,10 @@
         :model-value="getDisplayValue(perm.key)"
         :options="getOptions(perm.key)"
         :label="perm.label"
+        :display-value="getDisplayText(perm.key)"
         multiple
         outlined
         dense
-        use-chips
         emit-value
         map-options
         option-value="value"
@@ -45,6 +45,8 @@ interface Resources {
   models: ResourceOption[];
 }
 
+const ALL_VALUE = '__all__';
+
 const props = defineProps<{
   modelValue: Record<string, unknown>;
   resources: Resources;
@@ -63,28 +65,64 @@ const managePermissions = [
 function getOptions(key: string): ResourceOption[] {
   const perm = managePermissions.find((p) => p.key === key);
   if (!perm) return [];
-  return props.resources[perm.resourceKey] || [];
+  const resourceList = props.resources[perm.resourceKey] || [];
+  return [{ label: 'All', value: ALL_VALUE }, ...resourceList];
 }
 
-function getAllIds(key: string): string[] {
-  return getOptions(key).map((o) => o.value);
+function getResourceIds(key: string): string[] {
+  const perm = managePermissions.find((p) => p.key === key);
+  if (!perm) return [];
+  return (props.resources[perm.resourceKey] || []).map((o) => o.value);
+}
+
+function isAll(key: string): boolean {
+  const val = props.modelValue[key];
+  return val === 'all' || val === true;
 }
 
 function getDisplayValue(key: string): string[] {
+  if (isAll(key)) return [ALL_VALUE, ...getResourceIds(key)];
   const val = props.modelValue[key];
-  if (val === 'all' || val === true) return getAllIds(key);
   if (Array.isArray(val)) return val;
   return [];
 }
 
+function getDisplayText(key: string): string {
+  if (isAll(key)) return 'All';
+  const val = props.modelValue[key];
+  if (Array.isArray(val) && val.length > 0) return `${val.length} selected`;
+  return 'None';
+}
+
 function onSelectionChange(key: string, newValues: string[]) {
-  const allIds = getAllIds(key);
-  if (newValues.length === 0) {
-    update(key, 'none');
-  } else if (newValues.length === allIds.length) {
+  const oldValues = getDisplayValue(key);
+  const hadAll = oldValues.includes(ALL_VALUE);
+  const hasAll = newValues.includes(ALL_VALUE);
+  const resourceIds = getResourceIds(key);
+
+  if (!hadAll && hasAll) {
+    // Checked "All"
     update(key, 'all');
+  } else if (hadAll && !hasAll) {
+    // Unchecked "All" — deselect everything
+    update(key, 'none');
+  } else if (hadAll && hasAll) {
+    // Had All, still has All, but toggled an individual item off
+    const withoutAll = newValues.filter((v) => v !== ALL_VALUE);
+    if (withoutAll.length < resourceIds.length) {
+      update(key, withoutAll);
+    } else {
+      update(key, 'all');
+    }
   } else {
-    update(key, newValues);
+    // No "All" involved
+    if (newValues.length === 0) {
+      update(key, 'none');
+    } else if (newValues.length === resourceIds.length) {
+      update(key, 'all');
+    } else {
+      update(key, newValues);
+    }
   }
 }
 

--- a/frontend/src/components/PermissionEditor.vue
+++ b/frontend/src/components/PermissionEditor.vue
@@ -19,7 +19,7 @@
         <template v-slot:option="{ itemProps, opt, selected, toggleOption }">
           <q-item v-bind="itemProps">
             <q-item-section side>
-              <q-checkbox :model-value="selected" @update:model-value="toggleOption(opt)" />
+              <q-checkbox dark :model-value="selected" @update:model-value="toggleOption(opt)" />
             </q-item-section>
             <q-item-section>
               <q-item-label>{{ opt.label }}</q-item-label>

--- a/frontend/src/components/PermissionEditor.vue
+++ b/frontend/src/components/PermissionEditor.vue
@@ -9,6 +9,7 @@
         multiple
         outlined
         dense
+        dark
         emit-value
         map-options
         option-value="value"
@@ -28,8 +29,8 @@
       </q-select>
     </div>
     <q-separator class="q-my-sm" />
-    <q-checkbox :model-value="!!modelValue.view_usage" @update:model-value="(v: boolean) => update('view_usage', v)" label="View Usage" />
-    <q-checkbox :model-value="!!modelValue.view_monitor" @update:model-value="(v: boolean) => update('view_monitor', v)" label="View Monitor" />
+    <q-checkbox dark :model-value="!!modelValue.view_usage" @update:model-value="(v: boolean) => update('view_usage', v)" label="View Usage" />
+    <q-checkbox dark :model-value="!!modelValue.view_monitor" @update:model-value="(v: boolean) => update('view_monitor', v)" label="View Monitor" />
   </div>
 </template>
 

--- a/frontend/src/components/PermissionEditor.vue
+++ b/frontend/src/components/PermissionEditor.vue
@@ -1,30 +1,31 @@
 <template>
   <div>
     <div v-for="perm in managePermissions" :key="perm.key" class="q-mb-md">
-      <div class="text-caption text-weight-medium q-mb-xs">{{ perm.label }}</div>
-      <q-btn-toggle
-        :model-value="getScope(perm.key)"
-        @update:model-value="(v: string) => setScope(perm.key, v)"
-        :options="scopeToggleOptions"
-        dense
-        no-caps
-        toggle-color="primary"
-        class="q-mb-xs"
-      />
       <q-select
-        v-if="getScope(perm.key) === 'custom'"
-        :model-value="getSelectedIds(perm.key)"
-        @update:model-value="(v: string[]) => setSelectedIds(perm.key, v)"
-        :options="getResourceOptions(perm.key)"
+        :model-value="getDisplayValue(perm.key)"
+        :options="getOptions(perm.key)"
+        :label="perm.label"
         multiple
-        emit-value
-        map-options
         outlined
         dense
         use-chips
-        class="q-mt-xs"
-        :label="`Select ${perm.label.replace('Manage ', '')}`"
-      />
+        emit-value
+        map-options
+        option-value="value"
+        option-label="label"
+        @update:model-value="(v: string[]) => onSelectionChange(perm.key, v)"
+      >
+        <template v-slot:option="{ itemProps, opt, selected, toggleOption }">
+          <q-item v-bind="itemProps">
+            <q-item-section side>
+              <q-checkbox :model-value="selected" @update:model-value="toggleOption(opt)" />
+            </q-item-section>
+            <q-item-section>
+              <q-item-label>{{ opt.label }}</q-item-label>
+            </q-item-section>
+          </q-item>
+        </template>
+      </q-select>
     </div>
     <q-separator class="q-my-sm" />
     <q-checkbox :model-value="!!modelValue.view_usage" @update:model-value="(v: boolean) => update('view_usage', v)" label="View Usage" />
@@ -44,6 +45,8 @@ interface Resources {
   models: ResourceOption[];
 }
 
+const ALL_VALUE = '__all__';
+
 const props = defineProps<{
   modelValue: Record<string, unknown>;
   resources: Resources;
@@ -54,57 +57,44 @@ const emit = defineEmits<{
 }>();
 
 const managePermissions = [
-  { key: 'manage_api_keys', resourceKey: 'api_keys' },
-  { key: 'manage_teams', resourceKey: 'teams' },
-  { key: 'manage_models', resourceKey: 'models' },
-].map((p) => ({
-  ...p,
-  label: p.key.replace(/^manage_/, '').replace(/_/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase()),
-  get label() {
-    return `Manage ${p.key.replace(/^manage_/, '').replace(/_/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase())}`;
-  },
-}));
-
-const scopeToggleOptions = [
-  { label: 'All', value: 'all' },
-  { label: 'Custom', value: 'custom' },
-  { label: 'None', value: 'none' },
+  { key: 'manage_api_keys', resourceKey: 'api_keys' as const, label: 'Manage API Keys' },
+  { key: 'manage_teams', resourceKey: 'teams' as const, label: 'Manage Teams' },
+  { key: 'manage_models', resourceKey: 'models' as const, label: 'Manage Models' },
 ];
 
-function getScope(key: string): string {
-  const val = props.modelValue[key];
-  if (val === 'all' || val === true) return 'all';
-  if (val === 'none' || val === false || val === undefined) return 'none';
-  if (Array.isArray(val)) return 'custom';
-  return 'none';
-}
-
-function getSelectedIds(key: string): string[] {
-  const val = props.modelValue[key];
-  return Array.isArray(val) ? val : [];
-}
-
-function getResourceOptions(key: string): ResourceOption[] {
+function getOptions(key: string): ResourceOption[] {
   const perm = managePermissions.find((p) => p.key === key);
   if (!perm) return [];
-  return props.resources[perm.resourceKey as keyof Resources] || [];
+  const resourceList = props.resources[perm.resourceKey] || [];
+  return [{ label: 'All', value: ALL_VALUE }, ...resourceList];
+}
+
+function getDisplayValue(key: string): string[] {
+  const val = props.modelValue[key];
+  if (val === 'all' || val === true) return [ALL_VALUE];
+  if (Array.isArray(val)) return val;
+  return [];
+}
+
+function onSelectionChange(key: string, newValues: string[]) {
+  const oldValues = getDisplayValue(key);
+  const hadAll = oldValues.includes(ALL_VALUE);
+  const hasAll = newValues.includes(ALL_VALUE);
+
+  if (!hadAll && hasAll) {
+    update(key, 'all');
+  } else if (hadAll && hasAll && newValues.length > 1) {
+    update(key, newValues.filter((v) => v !== ALL_VALUE));
+  } else if (!hasAll && newValues.length > 0) {
+    update(key, newValues);
+  } else if (!hasAll && newValues.length === 0) {
+    update(key, 'none');
+  } else {
+    update(key, 'all');
+  }
 }
 
 function update(key: string, value: unknown) {
   emit('update:modelValue', { ...props.modelValue, [key]: value });
-}
-
-function setScope(key: string, scope: string) {
-  if (scope === 'all') {
-    update(key, 'all');
-  } else if (scope === 'none') {
-    update(key, 'none');
-  } else {
-    update(key, getSelectedIds(key));
-  }
-}
-
-function setSelectedIds(key: string, ids: string[]) {
-  update(key, ids);
 }
 </script>

--- a/frontend/src/components/PermissionEditor.vue
+++ b/frontend/src/components/PermissionEditor.vue
@@ -1,0 +1,110 @@
+<template>
+  <div>
+    <div v-for="perm in managePermissions" :key="perm.key" class="q-mb-md">
+      <div class="text-caption text-weight-medium q-mb-xs">{{ perm.label }}</div>
+      <q-btn-toggle
+        :model-value="getScope(perm.key)"
+        @update:model-value="(v: string) => setScope(perm.key, v)"
+        :options="scopeToggleOptions"
+        dense
+        no-caps
+        toggle-color="primary"
+        class="q-mb-xs"
+      />
+      <q-select
+        v-if="getScope(perm.key) === 'custom'"
+        :model-value="getSelectedIds(perm.key)"
+        @update:model-value="(v: string[]) => setSelectedIds(perm.key, v)"
+        :options="getResourceOptions(perm.key)"
+        multiple
+        emit-value
+        map-options
+        outlined
+        dense
+        use-chips
+        class="q-mt-xs"
+        :label="`Select ${perm.label.replace('Manage ', '')}`"
+      />
+    </div>
+    <q-separator class="q-my-sm" />
+    <q-checkbox :model-value="!!modelValue.view_usage" @update:model-value="(v: boolean) => update('view_usage', v)" label="View Usage" />
+    <q-checkbox :model-value="!!modelValue.view_monitor" @update:model-value="(v: boolean) => update('view_monitor', v)" label="View Monitor" />
+  </div>
+</template>
+
+<script setup lang="ts">
+interface ResourceOption {
+  label: string;
+  value: string;
+}
+
+interface Resources {
+  api_keys: ResourceOption[];
+  teams: ResourceOption[];
+  models: ResourceOption[];
+}
+
+const props = defineProps<{
+  modelValue: Record<string, unknown>;
+  resources: Resources;
+}>();
+
+const emit = defineEmits<{
+  'update:modelValue': [value: Record<string, unknown>];
+}>();
+
+const managePermissions = [
+  { key: 'manage_api_keys', resourceKey: 'api_keys' },
+  { key: 'manage_teams', resourceKey: 'teams' },
+  { key: 'manage_models', resourceKey: 'models' },
+].map((p) => ({
+  ...p,
+  label: p.key.replace(/^manage_/, '').replace(/_/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase()),
+  get label() {
+    return `Manage ${p.key.replace(/^manage_/, '').replace(/_/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase())}`;
+  },
+}));
+
+const scopeToggleOptions = [
+  { label: 'All', value: 'all' },
+  { label: 'Custom', value: 'custom' },
+  { label: 'None', value: 'none' },
+];
+
+function getScope(key: string): string {
+  const val = props.modelValue[key];
+  if (val === 'all' || val === true) return 'all';
+  if (val === 'none' || val === false || val === undefined) return 'none';
+  if (Array.isArray(val)) return 'custom';
+  return 'none';
+}
+
+function getSelectedIds(key: string): string[] {
+  const val = props.modelValue[key];
+  return Array.isArray(val) ? val : [];
+}
+
+function getResourceOptions(key: string): ResourceOption[] {
+  const perm = managePermissions.find((p) => p.key === key);
+  if (!perm) return [];
+  return props.resources[perm.resourceKey as keyof Resources] || [];
+}
+
+function update(key: string, value: unknown) {
+  emit('update:modelValue', { ...props.modelValue, [key]: value });
+}
+
+function setScope(key: string, scope: string) {
+  if (scope === 'all') {
+    update(key, 'all');
+  } else if (scope === 'none') {
+    update(key, 'none');
+  } else {
+    update(key, getSelectedIds(key));
+  }
+}
+
+function setSelectedIds(key: string, ids: string[]) {
+  update(key, ids);
+}
+</script>

--- a/frontend/src/components/PermissionEditor.vue
+++ b/frontend/src/components/PermissionEditor.vue
@@ -45,8 +45,6 @@ interface Resources {
   models: ResourceOption[];
 }
 
-const ALL_VALUE = '__all__';
-
 const props = defineProps<{
   modelValue: Record<string, unknown>;
   resources: Resources;
@@ -65,32 +63,28 @@ const managePermissions = [
 function getOptions(key: string): ResourceOption[] {
   const perm = managePermissions.find((p) => p.key === key);
   if (!perm) return [];
-  const resourceList = props.resources[perm.resourceKey] || [];
-  return [{ label: 'All', value: ALL_VALUE }, ...resourceList];
+  return props.resources[perm.resourceKey] || [];
+}
+
+function getAllIds(key: string): string[] {
+  return getOptions(key).map((o) => o.value);
 }
 
 function getDisplayValue(key: string): string[] {
   const val = props.modelValue[key];
-  if (val === 'all' || val === true) return [ALL_VALUE];
+  if (val === 'all' || val === true) return getAllIds(key);
   if (Array.isArray(val)) return val;
   return [];
 }
 
 function onSelectionChange(key: string, newValues: string[]) {
-  const oldValues = getDisplayValue(key);
-  const hadAll = oldValues.includes(ALL_VALUE);
-  const hasAll = newValues.includes(ALL_VALUE);
-
-  if (!hadAll && hasAll) {
-    update(key, 'all');
-  } else if (hadAll && hasAll && newValues.length > 1) {
-    update(key, newValues.filter((v) => v !== ALL_VALUE));
-  } else if (!hasAll && newValues.length > 0) {
-    update(key, newValues);
-  } else if (!hasAll && newValues.length === 0) {
+  const allIds = getAllIds(key);
+  if (newValues.length === 0) {
     update(key, 'none');
-  } else {
+  } else if (newValues.length === allIds.length) {
     update(key, 'all');
+  } else {
+    update(key, newValues);
   }
 }
 

--- a/frontend/src/layouts/MainLayout.vue
+++ b/frontend/src/layouts/MainLayout.vue
@@ -100,7 +100,6 @@ const allMenuLinks = [
     caption: 'Overview and usage statistics',
     icon: 'dashboard',
     to: '/',
-    permission: null,
   },
   {
     title: 'Teams',
@@ -128,7 +127,6 @@ const allMenuLinks = [
     caption: 'Test conversations',
     icon: 'chat',
     to: '/playground',
-    permission: null,
   },
   {
     title: 'Monitor',
@@ -142,29 +140,27 @@ const allMenuLinks = [
     caption: 'Recent admin operations',
     icon: 'history',
     to: '/activity',
-    permission: null,
   },
   {
     title: 'Admin Users',
     caption: 'Manage admin accounts',
     icon: 'admin_panel_settings',
     to: '/admin-users',
-    permission: '__super_admin__',
+    requiresSuperAdmin: true,
   },
   {
     title: 'Settings',
     caption: 'Account settings',
     icon: 'settings',
     to: '/settings',
-    permission: null,
   },
 ];
 
 const menuLinks = computed(() =>
   allMenuLinks.filter((link) => {
-    if (!link.permission) return true;
-    if (link.permission === '__super_admin__') return authStore.isSuperAdmin;
-    return authStore.hasPermission(link.permission);
+    if ('requiresSuperAdmin' in link && link.requiresSuperAdmin) return authStore.isSuperAdmin;
+    if ('permission' in link && link.permission) return authStore.hasPermission(link.permission);
+    return true;
   }),
 );
 

--- a/frontend/src/layouts/MainLayout.vue
+++ b/frontend/src/layouts/MainLayout.vue
@@ -94,50 +94,79 @@ const leftDrawerOpen = ref(false);
 
 const user = computed(() => authStore.currentUser);
 
-const menuLinks = [
+const allMenuLinks = [
   {
     title: 'Dashboard',
     caption: 'Overview and usage statistics',
     icon: 'dashboard',
     to: '/',
+    permission: null,
   },
   {
     title: 'Teams',
     caption: 'Team budget management',
     icon: 'groups',
     to: '/teams',
+    permission: 'manage_teams',
   },
   {
     title: 'API Keys',
     caption: 'API Key management',
     icon: 'vpn_key',
     to: '/tokens',
+    permission: 'manage_tokens',
   },
   {
     title: 'Models',
     caption: 'Model management',
     icon: 'psychology',
     to: '/models',
+    permission: 'manage_models',
   },
   {
     title: 'Playground',
     caption: 'Test conversations',
     icon: 'chat',
     to: '/playground',
+    permission: null,
   },
   {
     title: 'Monitor',
     caption: 'Usage charts and analytics',
     icon: 'insights',
     to: '/monitor',
+    permission: 'view_monitor',
+  },
+  {
+    title: 'Activity',
+    caption: 'Recent admin operations',
+    icon: 'history',
+    to: '/activity',
+    permission: null,
+  },
+  {
+    title: 'Admin Users',
+    caption: 'Manage admin accounts',
+    icon: 'admin_panel_settings',
+    to: '/admin-users',
+    permission: '__super_admin__',
   },
   {
     title: 'Settings',
     caption: 'Account settings',
     icon: 'settings',
     to: '/settings',
+    permission: null,
   },
 ];
+
+const menuLinks = computed(() =>
+  allMenuLinks.filter((link) => {
+    if (!link.permission) return true;
+    if (link.permission === '__super_admin__') return authStore.isSuperAdmin;
+    return authStore.hasPermission(link.permission);
+  }),
+);
 
 function toggleLeftDrawer() {
   leftDrawerOpen.value = !leftDrawerOpen.value;

--- a/frontend/src/layouts/MainLayout.vue
+++ b/frontend/src/layouts/MainLayout.vue
@@ -114,7 +114,7 @@ const allMenuLinks = [
     caption: 'API Key management',
     icon: 'vpn_key',
     to: '/tokens',
-    permission: 'manage_tokens',
+    permission: 'manage_api_keys',
   },
   {
     title: 'Models',

--- a/frontend/src/pages/ActivityPage.vue
+++ b/frontend/src/pages/ActivityPage.vue
@@ -1,0 +1,115 @@
+<template>
+  <q-page padding>
+    <div class="row items-center q-mb-lg">
+      <div class="text-h5 q-mr-md">Activity</div>
+      <q-select
+        v-model="days"
+        :options="dayOptions"
+        dense
+        outlined
+        style="width: 140px"
+        @update:model-value="fetchActivity"
+      />
+      <q-space />
+      <q-btn flat icon="refresh" @click="fetchActivity" />
+    </div>
+
+    <q-table
+      :rows="items"
+      :columns="columns"
+      row-key="id"
+      :loading="loading"
+      flat
+      :pagination="{ rowsPerPage: 50 }"
+    >
+      <template v-slot:body-cell-action="props">
+        <q-td :props="props">
+          <q-badge :color="actionColor(props.row.action)" :label="formatAction(props.row.action)" />
+        </q-td>
+      </template>
+      <template v-slot:body-cell-created_at="props">
+        <q-td :props="props">
+          {{ formatTime(props.row.created_at) }}
+        </q-td>
+      </template>
+    </q-table>
+  </q-page>
+</template>
+
+<script setup lang="ts">
+import { ref, onMounted } from 'vue';
+import { api } from 'src/boot/axios';
+
+interface ActivityItem {
+  id: string;
+  user_id: string | null;
+  user_email: string | null;
+  action: string;
+  resource_type: string | null;
+  resource_id: string | null;
+  details: string | null;
+  created_at: string;
+}
+
+const items = ref<ActivityItem[]>([]);
+const loading = ref(false);
+const days = ref({ label: 'Last 7 days', value: 7 });
+const dayOptions = [
+  { label: 'Last 7 days', value: 7 },
+  { label: 'Last 14 days', value: 14 },
+  { label: 'Last 30 days', value: 30 },
+];
+
+const columns = [
+  { name: 'user_email', label: 'User', field: 'user_email', align: 'left' as const },
+  { name: 'action', label: 'Action', field: 'action', align: 'left' as const },
+  { name: 'resource_type', label: 'Resource', field: 'resource_type', align: 'left' as const },
+  { name: 'details', label: 'Details', field: (row: ActivityItem) => parseDetails(row.details), align: 'left' as const },
+  { name: 'created_at', label: 'Time', field: 'created_at', align: 'left' as const },
+];
+
+function parseDetails(details: string | null): string {
+  if (!details) return '';
+  try {
+    const obj = JSON.parse(details);
+    if (obj.name) return obj.name;
+    if (obj.email) return obj.email;
+    if (obj.names) return `${obj.count} tokens`;
+    return JSON.stringify(obj);
+  } catch {
+    return details;
+  }
+}
+
+function formatAction(action: string): string {
+  return action.replace(/_/g, ' ');
+}
+
+function actionColor(action: string): string {
+  if (action.includes('created')) return 'positive';
+  if (action.includes('deleted')) return 'negative';
+  if (action.includes('updated')) return 'info';
+  if (action.includes('login')) return 'primary';
+  return 'grey';
+}
+
+function formatTime(iso: string): string {
+  return new Date(iso).toLocaleString();
+}
+
+async function fetchActivity() {
+  loading.value = true;
+  try {
+    const response = await api.get('/admin/audit-logs/activity', {
+      params: { days: days.value.value, page_size: 100 },
+    });
+    items.value = response.data.items;
+  } catch {
+    // handled by axios interceptor
+  } finally {
+    loading.value = false;
+  }
+}
+
+onMounted(fetchActivity);
+</script>

--- a/frontend/src/pages/AdminUsersPage.vue
+++ b/frontend/src/pages/AdminUsersPage.vue
@@ -45,8 +45,8 @@
       </template>
       <template v-slot:body-cell-actions="props">
         <q-td :props="props">
-          <q-btn flat dense round size="sm" icon="edit" @click="editUser(props.row)" />
-          <q-btn flat dense round size="sm" icon="block" color="negative" @click="deactivateUser(props.row)" v-if="props.row.role !== 'super_admin'" />
+          <q-btn flat dense round size="xs" icon="edit" class="action-btn" @click="editUser(props.row)" />
+          <q-btn flat dense round size="xs" icon="block" color="negative" class="action-btn" @click="deactivateUser(props.row)" v-if="props.row.role !== 'super_admin'" />
         </q-td>
       </template>
     </q-table>
@@ -122,6 +122,7 @@ import { api } from 'src/boot/axios';
 import { Notify } from 'quasar';
 import { extractErrorMessage } from 'src/utils/error';
 import PermissionEditor from 'src/components/PermissionEditor.vue';
+import type { Resources } from 'src/types/permissions';
 
 interface AdminUser {
   id: string;
@@ -133,17 +134,6 @@ interface AdminUser {
   is_active: boolean;
   created_at: string;
   last_login_at: string | null;
-}
-
-interface ResourceOption {
-  label: string;
-  value: string;
-}
-
-interface Resources {
-  api_keys: ResourceOption[]; // pragma: allowlist secret
-  teams: ResourceOption[];
-  models: ResourceOption[];
 }
 
 const users = ref<AdminUser[]>([]);
@@ -324,3 +314,12 @@ onMounted(async () => {
   await Promise.all([fetchUsers(), fetchResources()]);
 });
 </script>
+
+<style scoped>
+.action-btn {
+  min-height: 24px !important;
+  min-width: 24px !important;
+  padding: 2px !important;
+  font-size: 16px !important;
+}
+</style>

--- a/frontend/src/pages/AdminUsersPage.vue
+++ b/frontend/src/pages/AdminUsersPage.vue
@@ -106,6 +106,7 @@
 import { ref, onMounted } from 'vue';
 import { api } from 'src/boot/axios';
 import { Notify } from 'quasar';
+import { extractErrorMessage } from 'src/utils/error';
 
 interface AdminUser {
   id: string;
@@ -184,10 +185,7 @@ async function submitInvite() {
     inviteForm.value = { email: '', role: 'admin', permissions: defaultPermissions() };
     await fetchUsers();
   } catch (error: unknown) {
-    const msg = error && typeof error === 'object' && 'response' in error
-      ? (error.response as { data?: { detail?: string } })?.data?.detail || 'Failed'
-      : 'Failed';
-    Notify.create({ type: 'negative', message: msg, position: 'top' });
+    Notify.create({ type: 'negative', message: extractErrorMessage(error), position: 'top' });
   } finally {
     submitting.value = false;
   }
@@ -215,10 +213,7 @@ async function submitEdit() {
     showEditDialog.value = false;
     await fetchUsers();
   } catch (error: unknown) {
-    const msg = error && typeof error === 'object' && 'response' in error
-      ? (error.response as { data?: { detail?: string } })?.data?.detail || 'Failed'
-      : 'Failed';
-    Notify.create({ type: 'negative', message: msg, position: 'top' });
+    Notify.create({ type: 'negative', message: extractErrorMessage(error), position: 'top' });
   } finally {
     submitting.value = false;
   }
@@ -231,10 +226,7 @@ async function deactivateUser(user: AdminUser) {
     Notify.create({ type: 'positive', message: 'Admin deactivated', position: 'top' });
     await fetchUsers();
   } catch (error: unknown) {
-    const msg = error && typeof error === 'object' && 'response' in error
-      ? (error.response as { data?: { detail?: string } })?.data?.detail || 'Failed'
-      : 'Failed';
-    Notify.create({ type: 'negative', message: msg, position: 'top' });
+    Notify.create({ type: 'negative', message: extractErrorMessage(error), position: 'top' });
   }
 }
 

--- a/frontend/src/pages/AdminUsersPage.vue
+++ b/frontend/src/pages/AdminUsersPage.vue
@@ -45,8 +45,8 @@
       </template>
       <template v-slot:body-cell-actions="props">
         <q-td :props="props">
-          <q-btn flat dense icon="edit" @click="editUser(props.row)" />
-          <q-btn flat dense icon="block" color="negative" @click="deactivateUser(props.row)" v-if="props.row.role !== 'super_admin'" />
+          <q-btn flat dense round size="sm" icon="edit" @click="editUser(props.row)" />
+          <q-btn flat dense round size="sm" icon="block" color="negative" @click="deactivateUser(props.row)" v-if="props.row.role !== 'super_admin'" />
         </q-td>
       </template>
     </q-table>

--- a/frontend/src/pages/AdminUsersPage.vue
+++ b/frontend/src/pages/AdminUsersPage.vue
@@ -1,0 +1,242 @@
+<template>
+  <q-page padding>
+    <div class="row items-center q-mb-lg">
+      <div class="text-h5">Admin Users</div>
+      <q-space />
+      <q-btn color="primary" icon="person_add" label="Invite Admin" @click="showInviteDialog = true" />
+    </div>
+
+    <q-table
+      :rows="users"
+      :columns="columns"
+      row-key="id"
+      :loading="loading"
+      flat
+      :pagination="{ rowsPerPage: 20 }"
+    >
+      <template v-slot:body-cell-role="props">
+        <q-td :props="props">
+          <q-badge :color="props.row.role === 'super_admin' ? 'purple' : 'blue'" :label="props.row.role" />
+        </q-td>
+      </template>
+      <template v-slot:body-cell-permissions="props">
+        <q-td :props="props">
+          <template v-if="props.row.role === 'super_admin'">
+            <q-badge color="purple" label="all" />
+          </template>
+          <template v-else-if="props.row.permissions">
+            <q-badge
+              v-for="(val, key) in props.row.permissions"
+              :key="key"
+              :color="val ? 'positive' : 'grey'"
+              :label="String(key)"
+              class="q-mr-xs"
+            />
+          </template>
+          <template v-else>
+            <span class="text-grey">none</span>
+          </template>
+        </q-td>
+      </template>
+      <template v-slot:body-cell-last_login_at="props">
+        <q-td :props="props">
+          {{ props.row.last_login_at ? new Date(props.row.last_login_at).toLocaleString() : 'Never' }}
+        </q-td>
+      </template>
+      <template v-slot:body-cell-actions="props">
+        <q-td :props="props">
+          <q-btn flat dense icon="edit" @click="editUser(props.row)" />
+          <q-btn flat dense icon="block" color="negative" @click="deactivateUser(props.row)" v-if="props.row.role !== 'super_admin'" />
+        </q-td>
+      </template>
+    </q-table>
+
+    <!-- Invite Dialog -->
+    <q-dialog v-model="showInviteDialog">
+      <q-card style="min-width: 400px">
+        <q-card-section>
+          <div class="text-h6">Invite Admin</div>
+        </q-card-section>
+        <q-card-section>
+          <q-input v-model="inviteForm.email" label="Email" type="email" outlined class="q-mb-md" />
+          <q-select v-model="inviteForm.role" :options="roleOptions" label="Role" outlined class="q-mb-md" />
+          <div v-if="inviteForm.role === 'admin'" class="q-mb-md">
+            <div class="text-subtitle2 q-mb-sm">Permissions</div>
+            <q-checkbox v-model="inviteForm.permissions.manage_tokens" label="Manage Tokens" />
+            <q-checkbox v-model="inviteForm.permissions.manage_teams" label="Manage Teams" />
+            <q-checkbox v-model="inviteForm.permissions.manage_models" label="Manage Models" />
+            <q-checkbox v-model="inviteForm.permissions.view_usage" label="View Usage" />
+            <q-checkbox v-model="inviteForm.permissions.view_monitor" label="View Monitor" />
+          </div>
+        </q-card-section>
+        <q-card-actions align="right">
+          <q-btn flat label="Cancel" v-close-popup />
+          <q-btn color="primary" label="Invite" @click="submitInvite" :loading="submitting" />
+        </q-card-actions>
+      </q-card>
+    </q-dialog>
+
+    <!-- Edit Dialog -->
+    <q-dialog v-model="showEditDialog">
+      <q-card style="min-width: 400px">
+        <q-card-section>
+          <div class="text-h6">Edit {{ editForm.email }}</div>
+        </q-card-section>
+        <q-card-section>
+          <q-select v-model="editForm.role" :options="roleOptions" label="Role" outlined class="q-mb-md" />
+          <div v-if="editForm.role === 'admin'" class="q-mb-md">
+            <div class="text-subtitle2 q-mb-sm">Permissions</div>
+            <q-checkbox v-model="editForm.permissions.manage_tokens" label="Manage Tokens" />
+            <q-checkbox v-model="editForm.permissions.manage_teams" label="Manage Teams" />
+            <q-checkbox v-model="editForm.permissions.manage_models" label="Manage Models" />
+            <q-checkbox v-model="editForm.permissions.view_usage" label="View Usage" />
+            <q-checkbox v-model="editForm.permissions.view_monitor" label="View Monitor" />
+          </div>
+        </q-card-section>
+        <q-card-actions align="right">
+          <q-btn flat label="Cancel" v-close-popup />
+          <q-btn color="primary" label="Save" @click="submitEdit" :loading="submitting" />
+        </q-card-actions>
+      </q-card>
+    </q-dialog>
+  </q-page>
+</template>
+
+<script setup lang="ts">
+import { ref, onMounted } from 'vue';
+import { api } from 'src/boot/axios';
+import { Notify } from 'quasar';
+
+interface AdminUser {
+  id: string;
+  email: string;
+  first_name: string | null;
+  last_name: string | null;
+  role: string;
+  permissions: Record<string, boolean> | null;
+  is_active: boolean;
+  created_at: string;
+  last_login_at: string | null;
+}
+
+const users = ref<AdminUser[]>([]);
+const loading = ref(false);
+const submitting = ref(false);
+const showInviteDialog = ref(false);
+const showEditDialog = ref(false);
+
+const roleOptions = ['super_admin', 'admin'];
+
+const columns = [
+  { name: 'email', label: 'Email', field: 'email', align: 'left' as const },
+  { name: 'role', label: 'Role', field: 'role', align: 'left' as const },
+  { name: 'permissions', label: 'Permissions', field: 'permissions', align: 'left' as const },
+  { name: 'last_login_at', label: 'Last Login', field: 'last_login_at', align: 'left' as const },
+  { name: 'actions', label: 'Actions', field: 'id', align: 'center' as const },
+];
+
+const defaultPermissions = () => ({
+  manage_tokens: true,
+  manage_teams: true,
+  manage_models: true,
+  view_usage: true,
+  view_monitor: true,
+});
+
+const inviteForm = ref({
+  email: '',
+  role: 'admin',
+  permissions: defaultPermissions(),
+});
+
+const editForm = ref({
+  id: '',
+  email: '',
+  role: 'admin',
+  permissions: defaultPermissions(),
+});
+
+async function fetchUsers() {
+  loading.value = true;
+  try {
+    const response = await api.get('/admin/users');
+    users.value = response.data;
+  } catch {
+    // handled by interceptor
+  } finally {
+    loading.value = false;
+  }
+}
+
+async function submitInvite() {
+  submitting.value = true;
+  try {
+    const payload: Record<string, unknown> = {
+      email: inviteForm.value.email,
+      role: inviteForm.value.role,
+    };
+    if (inviteForm.value.role === 'admin') {
+      payload.permissions = inviteForm.value.permissions;
+    }
+    await api.post('/admin/users', payload);
+    Notify.create({ type: 'positive', message: 'Admin invited', position: 'top' });
+    showInviteDialog.value = false;
+    inviteForm.value = { email: '', role: 'admin', permissions: defaultPermissions() };
+    await fetchUsers();
+  } catch (error: unknown) {
+    const msg = error && typeof error === 'object' && 'response' in error
+      ? (error.response as { data?: { detail?: string } })?.data?.detail || 'Failed'
+      : 'Failed';
+    Notify.create({ type: 'negative', message: msg, position: 'top' });
+  } finally {
+    submitting.value = false;
+  }
+}
+
+function editUser(user: AdminUser) {
+  editForm.value = {
+    id: user.id,
+    email: user.email,
+    role: user.role,
+    permissions: user.permissions ? { ...defaultPermissions(), ...user.permissions } : defaultPermissions(),
+  };
+  showEditDialog.value = true;
+}
+
+async function submitEdit() {
+  submitting.value = true;
+  try {
+    const payload: Record<string, unknown> = { role: editForm.value.role };
+    if (editForm.value.role === 'admin') {
+      payload.permissions = editForm.value.permissions;
+    }
+    await api.put(`/admin/users/${editForm.value.id}`, payload);
+    Notify.create({ type: 'positive', message: 'Admin updated', position: 'top' });
+    showEditDialog.value = false;
+    await fetchUsers();
+  } catch (error: unknown) {
+    const msg = error && typeof error === 'object' && 'response' in error
+      ? (error.response as { data?: { detail?: string } })?.data?.detail || 'Failed'
+      : 'Failed';
+    Notify.create({ type: 'negative', message: msg, position: 'top' });
+  } finally {
+    submitting.value = false;
+  }
+}
+
+async function deactivateUser(user: AdminUser) {
+  if (!confirm(`Deactivate ${user.email}?`)) return;
+  try {
+    await api.delete(`/admin/users/${user.id}`);
+    Notify.create({ type: 'positive', message: 'Admin deactivated', position: 'top' });
+    await fetchUsers();
+  } catch (error: unknown) {
+    const msg = error && typeof error === 'object' && 'response' in error
+      ? (error.response as { data?: { detail?: string } })?.data?.detail || 'Failed'
+      : 'Failed';
+    Notify.create({ type: 'negative', message: msg, position: 'top' });
+  }
+}
+
+onMounted(fetchUsers);
+</script>

--- a/frontend/src/pages/AdminUsersPage.vue
+++ b/frontend/src/pages/AdminUsersPage.vue
@@ -72,6 +72,26 @@
       </q-card>
     </q-dialog>
 
+    <!-- Invite Link Dialog -->
+    <q-dialog v-model="showInviteLinkDialog">
+      <q-card style="min-width: 450px">
+        <q-card-section>
+          <div class="text-h6">Invite Link</div>
+        </q-card-section>
+        <q-card-section>
+          <p>Share this link with the invited admin:</p>
+          <q-input :model-value="inviteLink" readonly outlined dense>
+            <template v-slot:append>
+              <q-btn flat dense icon="content_copy" @click="copyInviteLink" />
+            </template>
+          </q-input>
+        </q-card-section>
+        <q-card-actions align="right">
+          <q-btn flat label="Close" v-close-popup />
+        </q-card-actions>
+      </q-card>
+    </q-dialog>
+
     <!-- Edit Dialog -->
     <q-dialog v-model="showEditDialog">
       <q-card style="min-width: 550px">
@@ -128,7 +148,9 @@ const users = ref<AdminUser[]>([]);
 const loading = ref(false);
 const submitting = ref(false);
 const showInviteDialog = ref(false);
+const showInviteLinkDialog = ref(false);
 const showEditDialog = ref(false);
+const inviteLink = ref('');
 const resources = ref<Resources>({ api_keys: [], teams: [], models: [] });
 
 const roleOptions = ['super_admin', 'admin'];
@@ -205,6 +227,11 @@ async function fetchResources() {
   }
 }
 
+function copyInviteLink() {
+  void navigator.clipboard.writeText(inviteLink.value);
+  Notify.create({ type: 'positive', message: 'Link copied', position: 'top' });
+}
+
 function buildPermissionsPayload(perms: Record<string, unknown>): Record<string, unknown> {
   const result: Record<string, unknown> = {};
   for (const [key, val] of Object.entries(perms)) {
@@ -225,8 +252,9 @@ async function submitInvite() {
       payload.permissions = buildPermissionsPayload(inviteForm.value.permissions);
     }
     await api.post('/admin/users', payload);
-    Notify.create({ type: 'positive', message: 'Admin invited', position: 'top' });
     showInviteDialog.value = false;
+    inviteLink.value = `${window.location.origin}/login`;
+    showInviteLinkDialog.value = true;
     inviteForm.value = { email: '', role: 'admin', permissions: defaultPermissions() };
     await fetchUsers();
   } catch (error: unknown) {

--- a/frontend/src/pages/AdminUsersPage.vue
+++ b/frontend/src/pages/AdminUsersPage.vue
@@ -156,7 +156,7 @@ const managePermissions = [
 
 const scopeOptions = [
   { label: 'All', value: 'all' },
-  { label: 'None', value: false },
+  { label: 'None', value: 'none' },
 ];
 
 const columns = [
@@ -210,7 +210,7 @@ async function fetchUsers() {
 function buildPermissionsPayload(perms: Record<string, unknown>): Record<string, unknown> {
   const result: Record<string, unknown> = {};
   for (const [key, val] of Object.entries(perms)) {
-    if (val === false) continue;
+    if (val === 'none' || val === false) continue;
     result[key] = val;
   }
   return result;
@@ -243,9 +243,10 @@ function editUser(user: AdminUser) {
   if (user.permissions) {
     for (const key of Object.keys(perms)) {
       if (key in user.permissions) {
-        perms[key] = user.permissions[key];
+        const v = user.permissions[key];
+        perms[key] = v === false ? 'none' : v;
       } else {
-        perms[key] = false;
+        perms[key] = 'none';
       }
     }
   }

--- a/frontend/src/pages/AdminUsersPage.vue
+++ b/frontend/src/pages/AdminUsersPage.vue
@@ -184,22 +184,19 @@ async function fetchUsers() {
 
 async function fetchResources() {
   try {
-    const [tokensRes, teamsRes, modelsRes] = await Promise.all([
-      api.get('/admin/tokens'),
-      api.get('/admin/teams'),
-      api.get('/admin/models'),
-    ]);
+    const res = await api.get('/admin/users/resources');
+    const data = res.data;
     resources.value = {
-      api_keys: (tokensRes.data || []).map((t: { id: string; name: string }) => ({
+      api_keys: (data.api_keys || []).map((t: { id: string; name: string }) => ({
         label: t.name,
         value: t.id,
       })),
-      teams: (teamsRes.data || []).map((t: { id: string; name: string }) => ({
+      teams: (data.teams || []).map((t: { id: string; name: string }) => ({
         label: t.name,
         value: t.id,
       })),
-      models: (modelsRes.data || []).map((m: { id: string; model_name?: string; friendly_name?: string }) => ({
-        label: m.friendly_name || m.model_name || m.id,
+      models: (data.models || []).map((m: { id: string; name: string }) => ({
+        label: m.name,
         value: m.id,
       })),
     };

--- a/frontend/src/pages/AdminUsersPage.vue
+++ b/frontend/src/pages/AdminUsersPage.vue
@@ -53,7 +53,7 @@
 
     <!-- Invite Dialog -->
     <q-dialog v-model="showInviteDialog">
-      <q-card style="min-width: 550px">
+      <q-card dark style="min-width: 550px">
         <q-card-section>
           <div class="text-h6">Invite Admin</div>
         </q-card-section>
@@ -76,7 +76,7 @@
 
     <!-- Invite Link Dialog -->
     <q-dialog v-model="showInviteLinkDialog">
-      <q-card style="min-width: 450px">
+      <q-card dark style="min-width: 450px">
         <q-card-section>
           <div class="text-h6">Invite Link</div>
         </q-card-section>
@@ -96,7 +96,7 @@
 
     <!-- Edit Dialog -->
     <q-dialog v-model="showEditDialog">
-      <q-card style="min-width: 550px">
+      <q-card dark style="min-width: 550px">
         <q-card-section>
           <div class="text-h6">Edit {{ editForm.email }}</div>
         </q-card-section>

--- a/frontend/src/pages/AdminUsersPage.vue
+++ b/frontend/src/pages/AdminUsersPage.vue
@@ -62,7 +62,7 @@
           <q-select v-model="inviteForm.role" :options="roleOptions" label="Role" outlined class="q-mb-md" />
           <div v-if="inviteForm.role === 'admin'" class="q-mb-md">
             <div class="text-subtitle2 q-mb-sm">Permissions</div>
-            <q-checkbox v-model="inviteForm.permissions.manage_tokens" label="Manage Tokens" />
+            <q-checkbox v-model="inviteForm.permissions.manage_api_keys" label="Manage API Keys" />
             <q-checkbox v-model="inviteForm.permissions.manage_teams" label="Manage Teams" />
             <q-checkbox v-model="inviteForm.permissions.manage_models" label="Manage Models" />
             <q-checkbox v-model="inviteForm.permissions.view_usage" label="View Usage" />
@@ -86,7 +86,7 @@
           <q-select v-model="editForm.role" :options="roleOptions" label="Role" outlined class="q-mb-md" />
           <div v-if="editForm.role === 'admin'" class="q-mb-md">
             <div class="text-subtitle2 q-mb-sm">Permissions</div>
-            <q-checkbox v-model="editForm.permissions.manage_tokens" label="Manage Tokens" />
+            <q-checkbox v-model="editForm.permissions.manage_api_keys" label="Manage API Keys" />
             <q-checkbox v-model="editForm.permissions.manage_teams" label="Manage Teams" />
             <q-checkbox v-model="editForm.permissions.manage_models" label="Manage Models" />
             <q-checkbox v-model="editForm.permissions.view_usage" label="View Usage" />
@@ -137,7 +137,7 @@ const columns = [
 ];
 
 const defaultPermissions = () => ({
-  manage_tokens: true,
+  manage_api_keys: true,
   manage_teams: true,
   manage_models: true,
   view_usage: true,

--- a/frontend/src/pages/AdminUsersPage.vue
+++ b/frontend/src/pages/AdminUsersPage.vue
@@ -58,10 +58,10 @@
           <div class="text-h6">Invite Admin</div>
         </q-card-section>
         <q-card-section>
-          <q-input v-model="inviteForm.email" label="Email" type="email" outlined class="q-mb-md" />
-          <q-input v-model="inviteForm.username" label="Username" outlined class="q-mb-md" hint="Cognito login username" />
-          <q-input v-model="inviteForm.temp_password" label="Temporary Password" type="password" outlined class="q-mb-md" hint="User must change on first login" />
-          <q-select v-model="inviteForm.role" :options="roleOptions" label="Role" outlined class="q-mb-md" />
+          <q-input v-model="inviteForm.email" label="Email" type="email" outlined dark class="q-mb-md" />
+          <q-input v-model="inviteForm.username" label="Username" outlined dark class="q-mb-md" hint="Cognito login username" />
+          <q-input v-model="inviteForm.temp_password" label="Temporary Password" type="password" outlined dark class="q-mb-md" hint="User must change on first login" />
+          <q-select v-model="inviteForm.role" :options="roleOptions" label="Role" outlined dark class="q-mb-md" />
           <div v-if="inviteForm.role === 'admin'" class="q-mb-md">
             <div class="text-subtitle2 q-mb-sm">Permissions</div>
             <PermissionEditor v-model="inviteForm.permissions" :resources="resources" />
@@ -101,7 +101,7 @@
           <div class="text-h6">Edit {{ editForm.email }}</div>
         </q-card-section>
         <q-card-section>
-          <q-select v-model="editForm.role" :options="roleOptions" label="Role" outlined class="q-mb-md" />
+          <q-select v-model="editForm.role" :options="roleOptions" label="Role" outlined dark class="q-mb-md" />
           <div v-if="editForm.role === 'admin'" class="q-mb-md">
             <div class="text-subtitle2 q-mb-sm">Permissions</div>
             <PermissionEditor v-model="editForm.permissions" :resources="resources" />

--- a/frontend/src/pages/AdminUsersPage.vue
+++ b/frontend/src/pages/AdminUsersPage.vue
@@ -53,7 +53,7 @@
 
     <!-- Invite Dialog -->
     <q-dialog v-model="showInviteDialog">
-      <q-card style="min-width: 450px">
+      <q-card style="min-width: 550px">
         <q-card-section>
           <div class="text-h6">Invite Admin</div>
         </q-card-section>
@@ -62,21 +62,7 @@
           <q-select v-model="inviteForm.role" :options="roleOptions" label="Role" outlined class="q-mb-md" />
           <div v-if="inviteForm.role === 'admin'" class="q-mb-md">
             <div class="text-subtitle2 q-mb-sm">Permissions</div>
-            <div v-for="perm in managePermissions" :key="perm.key" class="row items-center q-mb-sm">
-              <q-select
-                v-model="inviteForm.permissions[perm.key]"
-                :options="scopeOptions"
-                :label="perm.label"
-                outlined
-                dense
-                emit-value
-                map-options
-                style="width: 100%"
-              />
-            </div>
-            <q-separator class="q-my-sm" />
-            <q-checkbox v-model="inviteForm.permissions.view_usage" label="View Usage" />
-            <q-checkbox v-model="inviteForm.permissions.view_monitor" label="View Monitor" />
+            <PermissionEditor v-model="inviteForm.permissions" :resources="resources" />
           </div>
         </q-card-section>
         <q-card-actions align="right">
@@ -88,7 +74,7 @@
 
     <!-- Edit Dialog -->
     <q-dialog v-model="showEditDialog">
-      <q-card style="min-width: 450px">
+      <q-card style="min-width: 550px">
         <q-card-section>
           <div class="text-h6">Edit {{ editForm.email }}</div>
         </q-card-section>
@@ -96,21 +82,7 @@
           <q-select v-model="editForm.role" :options="roleOptions" label="Role" outlined class="q-mb-md" />
           <div v-if="editForm.role === 'admin'" class="q-mb-md">
             <div class="text-subtitle2 q-mb-sm">Permissions</div>
-            <div v-for="perm in managePermissions" :key="perm.key" class="row items-center q-mb-sm">
-              <q-select
-                v-model="editForm.permissions[perm.key]"
-                :options="scopeOptions"
-                :label="perm.label"
-                outlined
-                dense
-                emit-value
-                map-options
-                style="width: 100%"
-              />
-            </div>
-            <q-separator class="q-my-sm" />
-            <q-checkbox v-model="editForm.permissions.view_usage" label="View Usage" />
-            <q-checkbox v-model="editForm.permissions.view_monitor" label="View Monitor" />
+            <PermissionEditor v-model="editForm.permissions" :resources="resources" />
           </div>
         </q-card-section>
         <q-card-actions align="right">
@@ -127,6 +99,7 @@ import { ref, onMounted } from 'vue';
 import { api } from 'src/boot/axios';
 import { Notify } from 'quasar';
 import { extractErrorMessage } from 'src/utils/error';
+import PermissionEditor from 'src/components/PermissionEditor.vue';
 
 interface AdminUser {
   id: string;
@@ -140,24 +113,25 @@ interface AdminUser {
   last_login_at: string | null;
 }
 
+interface ResourceOption {
+  label: string;
+  value: string;
+}
+
+interface Resources {
+  api_keys: ResourceOption[]; // pragma: allowlist secret
+  teams: ResourceOption[];
+  models: ResourceOption[];
+}
+
 const users = ref<AdminUser[]>([]);
 const loading = ref(false);
 const submitting = ref(false);
 const showInviteDialog = ref(false);
 const showEditDialog = ref(false);
+const resources = ref<Resources>({ api_keys: [], teams: [], models: [] });
 
 const roleOptions = ['super_admin', 'admin'];
-
-const managePermissions = [
-  { key: 'manage_api_keys', label: 'Manage API Keys' },
-  { key: 'manage_teams', label: 'Manage Teams' },
-  { key: 'manage_models', label: 'Manage Models' },
-];
-
-const scopeOptions = [
-  { label: 'All', value: 'all' },
-  { label: 'None', value: 'none' },
-];
 
 const columns = [
   { name: 'email', label: 'Email', field: 'email', align: 'left' as const },
@@ -170,6 +144,7 @@ const columns = [
 function formatPermLabel(key: string, val: unknown): string {
   const name = key.replace(/^manage_/, '').replace(/_/g, ' ');
   if (val === 'all' || val === true) return name;
+  if (Array.isArray(val)) return `${name} (${val.length})`;
   if (val === false) return '';
   return name;
 }
@@ -204,6 +179,32 @@ async function fetchUsers() {
     // handled by interceptor
   } finally {
     loading.value = false;
+  }
+}
+
+async function fetchResources() {
+  try {
+    const [tokensRes, teamsRes, modelsRes] = await Promise.all([
+      api.get('/admin/tokens'),
+      api.get('/admin/teams'),
+      api.get('/admin/models'),
+    ]);
+    resources.value = {
+      api_keys: (tokensRes.data || []).map((t: { id: string; name: string }) => ({
+        label: t.name,
+        value: t.id,
+      })),
+      teams: (teamsRes.data || []).map((t: { id: string; name: string }) => ({
+        label: t.name,
+        value: t.id,
+      })),
+      models: (modelsRes.data || []).map((m: { id: string; model_name?: string; friendly_name?: string }) => ({
+        label: m.friendly_name || m.model_name || m.id,
+        value: m.id,
+      })),
+    };
+  } catch {
+    // non-critical
   }
 }
 
@@ -288,5 +289,7 @@ async function deactivateUser(user: AdminUser) {
   }
 }
 
-onMounted(fetchUsers);
+onMounted(async () => {
+  await Promise.all([fetchUsers(), fetchResources()]);
+});
 </script>

--- a/frontend/src/pages/AdminUsersPage.vue
+++ b/frontend/src/pages/AdminUsersPage.vue
@@ -59,6 +59,8 @@
         </q-card-section>
         <q-card-section>
           <q-input v-model="inviteForm.email" label="Email" type="email" outlined class="q-mb-md" />
+          <q-input v-model="inviteForm.username" label="Username" outlined class="q-mb-md" hint="Cognito login username" />
+          <q-input v-model="inviteForm.temp_password" label="Temporary Password" type="password" outlined class="q-mb-md" hint="User must change on first login" />
           <q-select v-model="inviteForm.role" :options="roleOptions" label="Role" outlined class="q-mb-md" />
           <div v-if="inviteForm.role === 'admin'" class="q-mb-md">
             <div class="text-subtitle2 q-mb-sm">Permissions</div>
@@ -181,6 +183,8 @@ const defaultPermissions = (): Record<string, unknown> => ({
 
 const inviteForm = ref({
   email: '',
+  username: '',
+  temp_password: '',
   role: 'admin',
   permissions: defaultPermissions(),
 });
@@ -246,6 +250,8 @@ async function submitInvite() {
   try {
     const payload: Record<string, unknown> = {
       email: inviteForm.value.email,
+      username: inviteForm.value.username,
+      temp_password: inviteForm.value.temp_password,
       role: inviteForm.value.role,
     };
     if (inviteForm.value.role === 'admin') {
@@ -255,7 +261,7 @@ async function submitInvite() {
     showInviteDialog.value = false;
     inviteLink.value = `${window.location.origin}/login`;
     showInviteLinkDialog.value = true;
-    inviteForm.value = { email: '', role: 'admin', permissions: defaultPermissions() };
+    inviteForm.value = { email: '', username: '', temp_password: '', role: 'admin', permissions: defaultPermissions() };
     await fetchUsers();
   } catch (error: unknown) {
     Notify.create({ type: 'negative', message: extractErrorMessage(error), position: 'top' });

--- a/frontend/src/pages/AdminUsersPage.vue
+++ b/frontend/src/pages/AdminUsersPage.vue
@@ -29,12 +29,12 @@
               v-for="(val, key) in props.row.permissions"
               :key="key"
               :color="val ? 'positive' : 'grey'"
-              :label="String(key)"
+              :label="formatPermLabel(String(key), val)"
               class="q-mr-xs"
             />
           </template>
           <template v-else>
-            <span class="text-grey">none</span>
+            <q-badge color="positive" label="all" />
           </template>
         </q-td>
       </template>
@@ -53,7 +53,7 @@
 
     <!-- Invite Dialog -->
     <q-dialog v-model="showInviteDialog">
-      <q-card style="min-width: 400px">
+      <q-card style="min-width: 450px">
         <q-card-section>
           <div class="text-h6">Invite Admin</div>
         </q-card-section>
@@ -62,9 +62,19 @@
           <q-select v-model="inviteForm.role" :options="roleOptions" label="Role" outlined class="q-mb-md" />
           <div v-if="inviteForm.role === 'admin'" class="q-mb-md">
             <div class="text-subtitle2 q-mb-sm">Permissions</div>
-            <q-checkbox v-model="inviteForm.permissions.manage_api_keys" label="Manage API Keys" />
-            <q-checkbox v-model="inviteForm.permissions.manage_teams" label="Manage Teams" />
-            <q-checkbox v-model="inviteForm.permissions.manage_models" label="Manage Models" />
+            <div v-for="perm in managePermissions" :key="perm.key" class="row items-center q-mb-sm">
+              <q-select
+                v-model="inviteForm.permissions[perm.key]"
+                :options="scopeOptions"
+                :label="perm.label"
+                outlined
+                dense
+                emit-value
+                map-options
+                style="width: 100%"
+              />
+            </div>
+            <q-separator class="q-my-sm" />
             <q-checkbox v-model="inviteForm.permissions.view_usage" label="View Usage" />
             <q-checkbox v-model="inviteForm.permissions.view_monitor" label="View Monitor" />
           </div>
@@ -78,7 +88,7 @@
 
     <!-- Edit Dialog -->
     <q-dialog v-model="showEditDialog">
-      <q-card style="min-width: 400px">
+      <q-card style="min-width: 450px">
         <q-card-section>
           <div class="text-h6">Edit {{ editForm.email }}</div>
         </q-card-section>
@@ -86,9 +96,19 @@
           <q-select v-model="editForm.role" :options="roleOptions" label="Role" outlined class="q-mb-md" />
           <div v-if="editForm.role === 'admin'" class="q-mb-md">
             <div class="text-subtitle2 q-mb-sm">Permissions</div>
-            <q-checkbox v-model="editForm.permissions.manage_api_keys" label="Manage API Keys" />
-            <q-checkbox v-model="editForm.permissions.manage_teams" label="Manage Teams" />
-            <q-checkbox v-model="editForm.permissions.manage_models" label="Manage Models" />
+            <div v-for="perm in managePermissions" :key="perm.key" class="row items-center q-mb-sm">
+              <q-select
+                v-model="editForm.permissions[perm.key]"
+                :options="scopeOptions"
+                :label="perm.label"
+                outlined
+                dense
+                emit-value
+                map-options
+                style="width: 100%"
+              />
+            </div>
+            <q-separator class="q-my-sm" />
             <q-checkbox v-model="editForm.permissions.view_usage" label="View Usage" />
             <q-checkbox v-model="editForm.permissions.view_monitor" label="View Monitor" />
           </div>
@@ -114,7 +134,7 @@ interface AdminUser {
   first_name: string | null;
   last_name: string | null;
   role: string;
-  permissions: Record<string, boolean> | null;
+  permissions: Record<string, unknown> | null;
   is_active: boolean;
   created_at: string;
   last_login_at: string | null;
@@ -128,6 +148,17 @@ const showEditDialog = ref(false);
 
 const roleOptions = ['super_admin', 'admin'];
 
+const managePermissions = [
+  { key: 'manage_api_keys', label: 'Manage API Keys' },
+  { key: 'manage_teams', label: 'Manage Teams' },
+  { key: 'manage_models', label: 'Manage Models' },
+];
+
+const scopeOptions = [
+  { label: 'All', value: 'all' },
+  { label: 'None', value: false },
+];
+
 const columns = [
   { name: 'email', label: 'Email', field: 'email', align: 'left' as const },
   { name: 'role', label: 'Role', field: 'role', align: 'left' as const },
@@ -136,10 +167,17 @@ const columns = [
   { name: 'actions', label: 'Actions', field: 'id', align: 'center' as const },
 ];
 
-const defaultPermissions = () => ({
-  manage_api_keys: true,
-  manage_teams: true,
-  manage_models: true,
+function formatPermLabel(key: string, val: unknown): string {
+  const name = key.replace(/^manage_/, '').replace(/_/g, ' ');
+  if (val === 'all' || val === true) return name;
+  if (val === false) return '';
+  return name;
+}
+
+const defaultPermissions = (): Record<string, unknown> => ({
+  manage_api_keys: 'all', // pragma: allowlist secret
+  manage_teams: 'all',
+  manage_models: 'all',
   view_usage: true,
   view_monitor: true,
 });
@@ -169,6 +207,15 @@ async function fetchUsers() {
   }
 }
 
+function buildPermissionsPayload(perms: Record<string, unknown>): Record<string, unknown> {
+  const result: Record<string, unknown> = {};
+  for (const [key, val] of Object.entries(perms)) {
+    if (val === false) continue;
+    result[key] = val;
+  }
+  return result;
+}
+
 async function submitInvite() {
   submitting.value = true;
   try {
@@ -177,7 +224,7 @@ async function submitInvite() {
       role: inviteForm.value.role,
     };
     if (inviteForm.value.role === 'admin') {
-      payload.permissions = inviteForm.value.permissions;
+      payload.permissions = buildPermissionsPayload(inviteForm.value.permissions);
     }
     await api.post('/admin/users', payload);
     Notify.create({ type: 'positive', message: 'Admin invited', position: 'top' });
@@ -192,11 +239,21 @@ async function submitInvite() {
 }
 
 function editUser(user: AdminUser) {
+  const perms = defaultPermissions();
+  if (user.permissions) {
+    for (const key of Object.keys(perms)) {
+      if (key in user.permissions) {
+        perms[key] = user.permissions[key];
+      } else {
+        perms[key] = false;
+      }
+    }
+  }
   editForm.value = {
     id: user.id,
     email: user.email,
     role: user.role,
-    permissions: user.permissions ? { ...defaultPermissions(), ...user.permissions } : defaultPermissions(),
+    permissions: perms,
   };
   showEditDialog.value = true;
 }
@@ -206,7 +263,7 @@ async function submitEdit() {
   try {
     const payload: Record<string, unknown> = { role: editForm.value.role };
     if (editForm.value.role === 'admin') {
-      payload.permissions = editForm.value.permissions;
+      payload.permissions = buildPermissionsPayload(editForm.value.permissions);
     }
     await api.put(`/admin/users/${editForm.value.id}`, payload);
     Notify.create({ type: 'positive', message: 'Admin updated', position: 'top' });

--- a/frontend/src/pages/DashboardPage.vue
+++ b/frontend/src/pages/DashboardPage.vue
@@ -150,6 +150,7 @@ import { api } from 'src/boot/axios';
 
 const tokensStore = useTokensStore();
 const dashboardStore = useDashboardStore();
+const authStore = useAuthStore();
 const exporting = ref(false);
 
 const groupBy = ref<'token' | 'model'>('token');
@@ -326,6 +327,7 @@ async function fetchUsageByModel() {
 }
 
 watch(groupBy, async (newValue) => {
+  if (!authStore.hasPermission('view_usage')) return;
   if (newValue === 'token') {
     await fetchUsageByToken();
   } else {
@@ -334,12 +336,14 @@ watch(groupBy, async (newValue) => {
 });
 
 watch(selectedToken, async () => {
+  if (!authStore.hasPermission('view_usage')) return;
   if (groupBy.value === 'token') {
     await fetchUsageByToken();
   }
 });
 
 watch([startDate, endDate], async () => {
+  if (!authStore.hasPermission('view_usage')) return;
   if (groupBy.value === 'token') {
     await fetchUsageByToken();
   } else {
@@ -406,7 +410,6 @@ async function exportCsv() {
 }
 
 onMounted(async () => {
-  const authStore = useAuthStore();
   const tasks: Promise<unknown>[] = [];
   if (authStore.hasPermission('manage_api_keys')) {
     tasks.push(tokensStore.fetchTokens());

--- a/frontend/src/pages/DashboardPage.vue
+++ b/frontend/src/pages/DashboardPage.vue
@@ -145,6 +145,7 @@
 import { ref, computed, onMounted, watch } from 'vue';
 import { useTokensStore } from 'src/stores/tokens';
 import { useDashboardStore } from 'src/stores/dashboard';
+import { useAuthStore } from 'src/stores/auth';
 import { api } from 'src/boot/axios';
 
 const tokensStore = useTokensStore();
@@ -405,11 +406,16 @@ async function exportCsv() {
 }
 
 onMounted(async () => {
-  await Promise.all([
-    tokensStore.fetchTokens(),
-    fetchUsageByToken(),
-    fetchUsageByModel(),
-  ]);
+  const authStore = useAuthStore();
+  const tasks: Promise<unknown>[] = [];
+  if (authStore.hasPermission('manage_api_keys')) {
+    tasks.push(tokensStore.fetchTokens());
+  }
+  if (authStore.hasPermission('view_usage')) {
+    tasks.push(fetchUsageByToken());
+    tasks.push(fetchUsageByModel());
+  }
+  await Promise.all(tasks);
 });
 </script>
 

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -5,6 +5,7 @@ import {
   createWebHashHistory,
   createWebHistory,
 } from 'vue-router';
+import { useAuthStore } from 'src/stores/auth';
 import routes from './routes';
 
 /*
@@ -36,14 +37,20 @@ export default defineRouter(function (/* { store, ssrContext } */) {
   // Navigation guard for authentication
   Router.beforeEach((to, from, next) => {
     const requiresAuth = to.matched.some((record) => record.meta.requiresAuth);
+    const requiresSuperAdmin = to.matched.some((record) => record.meta.requiresSuperAdmin);
     const accessToken = localStorage.getItem('access_token');
 
     if (requiresAuth && !accessToken) {
-      // Redirect to login if route requires auth and user is not authenticated
       next('/login');
     } else if (!requiresAuth && accessToken && to.path === '/login') {
-      // Redirect to dashboard if already logged in and trying to access login
       next('/');
+    } else if (requiresSuperAdmin) {
+      const authStore = useAuthStore();
+      if (!authStore.isSuperAdmin) {
+        next('/');
+      } else {
+        next();
+      }
     } else {
       next();
     }

--- a/frontend/src/router/routes.ts
+++ b/frontend/src/router/routes.ts
@@ -55,6 +55,17 @@ const routes: RouteRecordRaw[] = [
         component: () => import('pages/MonitorPage.vue'),
       },
       {
+        path: 'activity',
+        name: 'activity',
+        component: () => import('pages/ActivityPage.vue'),
+      },
+      {
+        path: 'admin-users',
+        name: 'admin-users',
+        component: () => import('pages/AdminUsersPage.vue'),
+        meta: { requiresSuperAdmin: true },
+      },
+      {
         path: 'settings',
         name: 'settings',
         component: () => import('pages/SettingsPage.vue'),

--- a/frontend/src/stores/auth.ts
+++ b/frontend/src/stores/auth.ts
@@ -9,6 +9,8 @@ export interface User {
   last_name: string | null;
   is_active: boolean;
   is_admin: boolean;
+  role?: 'super_admin' | 'admin';
+  permissions?: Record<string, boolean> | null;
   email_verified: boolean;
   current_balance: string;
 }
@@ -30,6 +32,14 @@ export const useAuthStore = defineStore('auth', {
     isLoggedIn: (state) => state.isAuthenticated && !!state.accessToken,
     currentUser: (state) => state.user,
     isAdmin: (state) => state.user?.is_admin || false,
+    isSuperAdmin: (state) => state.user?.role === 'super_admin',
+    hasPermission: (state) => (permission: string) => {
+      if (!state.user) return false;
+      if (state.user.role === 'super_admin') return true;
+      if (!state.user.permissions || Object.keys(state.user.permissions).length === 0)
+        return true;
+      return state.user.permissions[permission] ?? false;
+    },
   },
 
   actions: {

--- a/frontend/src/stores/auth.ts
+++ b/frontend/src/stores/auth.ts
@@ -38,7 +38,10 @@ export const useAuthStore = defineStore('auth', {
       if (state.user.role === 'super_admin') return true;
       if (!state.user.permissions || Object.keys(state.user.permissions).length === 0)
         return true;
-      return state.user.permissions[permission] ?? false;
+      const val = state.user.permissions[permission];
+      if (val === 'all' || val === true) return true;
+      if (Array.isArray(val) && val.length > 0) return true;
+      return false;
     },
   },
 

--- a/frontend/src/stores/auth.ts
+++ b/frontend/src/stores/auth.ts
@@ -10,7 +10,7 @@ export interface User {
   is_active: boolean;
   is_admin: boolean;
   role?: 'super_admin' | 'admin';
-  permissions?: Record<string, boolean> | null;
+  permissions?: Record<string, boolean | string | string[]> | null;
   email_verified: boolean;
   current_balance: string;
 }

--- a/frontend/src/types/permissions.ts
+++ b/frontend/src/types/permissions.ts
@@ -1,0 +1,10 @@
+export interface ResourceOption {
+  label: string;
+  value: string;
+}
+
+export interface Resources {
+  api_keys: ResourceOption[];
+  teams: ResourceOption[];
+  models: ResourceOption[];
+}

--- a/frontend/src/utils/error.ts
+++ b/frontend/src/utils/error.ts
@@ -1,0 +1,11 @@
+export function extractErrorMessage(
+  error: unknown,
+  fallback = 'Operation failed',
+): string {
+  if (error && typeof error === 'object' && 'response' in error) {
+    const resp = (error as { response?: { data?: { detail?: string } } })
+      .response;
+    return resp?.data?.detail || fallback;
+  }
+  return fallback;
+}

--- a/iac/modules/eks-addons/main.tf
+++ b/iac/modules/eks-addons/main.tf
@@ -98,6 +98,14 @@ resource "aws_iam_policy" "backend_bedrock" {
           "bedrock:*"
         ]
         Resource = "*"
+      },
+      {
+        Effect = "Allow"
+        Action = [
+          "cognito-idp:AdminCreateUser",
+          "cognito-idp:AdminSetUserPassword"
+        ]
+        Resource = "*"
       }
     ]
   })

--- a/iac/modules/rds-aurora-postgresql/main.tf
+++ b/iac/modules/rds-aurora-postgresql/main.tf
@@ -91,7 +91,7 @@ locals {
   default_database_name   = "kolyabrproxy"
   default_master_username = "postgres"
   default_engine          = "aurora-postgresql"
-  default_engine_version  = "16.6"
+  default_engine_version  = "16.11"
   default_instance_class  = var.workspace == "prod" ? "db.r6g.large" : "db.r6g.large"
 
   # Use created monitoring role if monitoring is enabled and no role ARN provided


### PR DESCRIPTION
## Summary

- Add role-based access control (RBAC) with `super_admin` and `admin` roles
- Admin permissions support resource-level scoping: `manage_api_keys`, `manage_teams`, `manage_models`, `view_usage`, `view_monitor` — each can be `true`/"all" (full access), an array of UUIDs (scoped), or `false` (denied)
- Admin User Management UI: invite admins with Cognito temp password, edit roles/permissions, deactivate
- Activity feed endpoint (`/admin/audit-logs/activity`) for all admins, with super_admin actions hidden from regular admins
- Code quality: security fix for `get_allowed_resource_ids`, shared `check_resource_scope` helper, async boto3 calls, permission guards in watchers, computed memoization
- Updated API reference docs (EN + ZH) with RBAC authorization model, admin user management endpoints, and activity feed

## Test plan

- [ ] Login as super_admin → can access all admin pages and manage all resources
- [ ] Login as scoped admin → can only see/manage assigned resources, 403 on others
- [ ] Invite new admin with scoped permissions → Cognito user created, can login with temp password
- [ ] Activity feed shows management operations but hides super_admin actions from regular admins
- [ ] Dashboard watchers don't trigger 403 errors for restricted admins
- [ ] `pre-commit run --all-files` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)