### PR TITLE
feat: secure key export, WAF OPTIONS exclusion, CORS fix

### DIFF
--- a/backend/alembic/versions/k2l3m4n5o6p7_add_rbac_fields.py
+++ b/backend/alembic/versions/k2l3m4n5o6p7_add_rbac_fields.py
@@ -32,8 +32,13 @@ def upgrade() -> None:
         sa.Column("permissions", sa.JSON(), nullable=True),
     )
 
-    # Migrate existing super admins
-    op.execute("UPDATE users SET role = 'super_admin' WHERE is_admin = true")
+    # Promote the earliest created user to super_admin
+    op.execute("""
+        UPDATE users SET role = 'super_admin', is_admin = true
+        WHERE id = (
+            SELECT id FROM users ORDER BY created_at ASC LIMIT 1
+        )
+    """)
 
     # Add new audit action enum values
     op.execute("ALTER TYPE auditaction ADD VALUE IF NOT EXISTS 'admin_created'")

--- a/backend/alembic/versions/l3m4n5o6p7q8_set_superadmin.py
+++ b/backend/alembic/versions/l3m4n5o6p7q8_set_superadmin.py
@@ -14,9 +14,14 @@ depends_on = None
 
 
 def upgrade() -> None:
-    op.execute(
-        "UPDATE users SET role = 'super_admin', is_admin = true WHERE email = 'kolya@amazon.com'"
-    )
+    # Ensure the earliest user is super_admin (idempotent)
+    op.execute("""
+        UPDATE users SET role = 'super_admin', is_admin = true
+        WHERE id = (
+            SELECT id FROM users ORDER BY created_at ASC LIMIT 1
+        )
+        AND NOT EXISTS (SELECT 1 FROM users WHERE role = 'super_admin')
+    """)
 
 
 def downgrade() -> None:

--- a/backend/app/api/admin/endpoints/tokens.py
+++ b/backend/app/api/admin/endpoints/tokens.py
@@ -3,13 +3,16 @@ API Token management endpoints.
 """
 
 import calendar
+import csv
+import io
 import uuid as uuid_mod
 from datetime import datetime
 from decimal import Decimal
 from typing import List
 from uuid import UUID
 
-from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi import APIRouter, Depends, HTTPException, Request, status
+from fastapi.responses import Response
 from pydantic import BaseModel
 from sqlalchemy import case, func, select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -21,15 +24,16 @@ from app.api.deps import (
     get_token_service,
     require_permission,
 )
-from app.models.audit_log import AuditAction
-from app.services.audit_log import AuditLogService
 from app.core.database import get_db
-from app.core.security import decrypt_token
+from app.core.security import decode_jwt_token, decrypt_token
+from app.models.audit_log import AuditAction
 from app.models.model import Model
 from app.models.team import Team, TeamMember
 from app.models.token import APIToken
 from app.models.usage import UsageRecord
-from app.models.user import User
+from app.models.user import User, UserRole
+from app.services.audit_log import AuditLogService
+from app.services.auth import AuthService
 from app.services.token import TokenService
 
 router = APIRouter()
@@ -530,6 +534,105 @@ async def list_tokens(
         )
 
     return token_responses
+
+
+@router.get("/export/keys")
+async def export_keys_csv(
+    request_obj: Request,
+    db: AsyncSession = Depends(get_db),
+):
+    """
+    Export all API keys as CSV file (super_admin only).
+
+    Accepts JWT via Authorization header OR ?token= query param (for window.open downloads).
+    Returns a downloadable CSV with: Name, Key, Status, Quota, Used, Created.
+    The response is a file attachment — key values never appear in JSON responses.
+    """
+    jwt_token = None
+    auth_header = request_obj.headers.get("authorization", "")
+    if auth_header.lower().startswith("bearer "):
+        jwt_token = auth_header[7:]
+    if not jwt_token:
+        jwt_token = request_obj.query_params.get("token")
+    if not jwt_token:
+        raise HTTPException(status_code=401, detail="Missing authentication")
+
+    try:
+        payload = decode_jwt_token(jwt_token)
+        if payload.get("type") != "access":
+            raise HTTPException(status_code=401, detail="Invalid token type")
+        user_id = UUID(payload.get("sub"))
+    except HTTPException:
+        raise
+    except Exception:
+        raise HTTPException(status_code=401, detail="Invalid token")
+
+    auth_service = AuthService(db)
+    user = await auth_service.get_user_by_id(user_id)
+    if not user or user.role != UserRole.SUPER_ADMIN:
+        raise HTTPException(status_code=403, detail="Super admin access required")
+
+    result = await db.execute(select(APIToken))
+    tokens = list(result.scalars().all())
+
+    usage_result = await db.execute(
+        select(
+            UsageRecord.token_id,
+            func.coalesce(func.sum(UsageRecord.cost_usd), Decimal("0.00")),
+        ).group_by(UsageRecord.token_id)
+    )
+    usage_map = {row[0]: row[1] for row in usage_result.all()}
+
+    output = io.StringIO()
+    writer = csv.writer(output)
+    writer.writerow(
+        ["Name", "Key", "Status", "Quota (USD)", "Used (USD)", "Created At"]
+    )
+
+    for token in tokens:
+        plain_key = ""
+        try:
+            if token.encrypted_token:
+                plain_key = decrypt_token(token.encrypted_token)
+        except Exception:
+            plain_key = "(decrypt failed)"
+
+        if token.is_deleted:
+            token_status = "Deleted"
+        elif not token.is_active:
+            token_status = "Revoked"
+        elif token.is_expired:
+            token_status = "Expired"
+        elif token.is_quota_exceeded:
+            token_status = "Quota Exceeded"
+        else:
+            token_status = "Active"
+
+        used = usage_map.get(token.id, Decimal("0.00"))
+
+        writer.writerow(
+            [
+                token.name,
+                plain_key,
+                token_status,
+                str(token.quota_usd) if token.quota_usd else "Unlimited",
+                str(used),
+                token.created_at.strftime("%Y-%m-%d %H:%M:%S")
+                if token.created_at
+                else "",
+            ]
+        )
+
+    filename = f"api_keys_{datetime.utcnow().strftime('%Y%m%d_%H%M%S')}.csv"
+
+    return Response(
+        content=output.getvalue(),
+        media_type="text/csv",
+        headers={
+            "Content-Disposition": f'attachment; filename="{filename}"',
+            "Cache-Control": "no-store",
+        },
+    )
 
 
 @router.get("/{token_id}", response_model=TokenResponse)

--- a/backend/app/middleware/security.py
+++ b/backend/app/middleware/security.py
@@ -125,6 +125,11 @@ class SecurityMiddleware(BaseHTTPMiddleware):
             logger.warning(f"Failed to parse referer: {e}")
             return False
 
+    _CORS_ALLOW_HEADERS = (
+        "Authorization, Content-Type, X-Requested-With, Accept, Origin, "
+        "X-Api-Key, x-api-key, x-goog-api-key"
+    )
+
     def _add_cors_headers(self, response: Response, origin: Optional[str]) -> Response:
         """
         Add CORS headers to response.
@@ -139,12 +144,18 @@ class SecurityMiddleware(BaseHTTPMiddleware):
         if origin and self._is_origin_allowed(origin):
             response.headers["Access-Control-Allow-Origin"] = origin
             response.headers["Access-Control-Allow-Credentials"] = "true"
-            response.headers["Access-Control-Allow-Methods"] = "*"
-            response.headers["Access-Control-Allow-Headers"] = "*"
+            response.headers["Access-Control-Allow-Methods"] = (
+                "GET, POST, PUT, DELETE, OPTIONS, PATCH"
+            )
+            response.headers["Access-Control-Allow-Headers"] = self._CORS_ALLOW_HEADERS
+            response.headers["Access-Control-Max-Age"] = "3600"
         elif "*" in self.exact_origins:
             response.headers["Access-Control-Allow-Origin"] = "*"
-            response.headers["Access-Control-Allow-Methods"] = "*"
-            response.headers["Access-Control-Allow-Headers"] = "*"
+            response.headers["Access-Control-Allow-Methods"] = (
+                "GET, POST, PUT, DELETE, OPTIONS, PATCH"
+            )
+            response.headers["Access-Control-Allow-Headers"] = self._CORS_ALLOW_HEADERS
+            response.headers["Access-Control-Max-Age"] = "3600"
         return response
 
     async def dispatch(self, request: Request, call_next) -> Response:
@@ -165,9 +176,12 @@ class SecurityMiddleware(BaseHTTPMiddleware):
         if path.startswith("/health"):
             return await call_next(request)
 
-        # Skip security checks for OPTIONS (CORS preflight)
+        # Handle OPTIONS (CORS preflight) directly — BaseHTTPMiddleware can
+        # lose headers set by inner CORSMiddleware, causing intermittent failures.
         if method == "OPTIONS":
-            return await call_next(request)
+            origin = request.headers.get("origin")
+            response = Response(status_code=200)
+            return self._add_cors_headers(response, origin)
 
         # Get origin header
         origin = request.headers.get("origin")

--- a/backend/app/services/token.py
+++ b/backend/app/services/token.py
@@ -362,6 +362,7 @@ class TokenService:
             return False
 
         token.is_deleted = True
+        token.is_active = False
         token.deleted_at = datetime.utcnow()
         await self.db.commit()
         return True

--- a/backend/app/services/token_cache.py
+++ b/backend/app/services/token_cache.py
@@ -55,7 +55,7 @@ class CachedTokenService:
             token = await self._token_from_cache(cached_data)
             if token:
                 # Still need to check dynamic conditions
-                if token.is_expired or token.is_quota_exceeded:
+                if not token.is_active or token.is_expired or token.is_quota_exceeded:
                     await self.cache.delete(cache_key)
                     return None
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -709,7 +709,7 @@ Update token settings.
 
 #### DELETE /admin/tokens/{token_id}
 
-Permanently delete a token. Returns 204 No Content.
+Soft-delete a token. Sets `is_deleted = true`, `is_active = false`, and invalidates the Redis cache. The token is immediately blocked from API access. Historical usage data is preserved. Returns 204 No Content.
 
 #### POST /admin/tokens/{token_id}/revoke
 

--- a/docs/api-reference.zh.md
+++ b/docs/api-reference.zh.md
@@ -718,7 +718,7 @@ Admin 用户有一个 `permissions` JSON 对象，控制其可管理的资源：
 
 #### DELETE /admin/tokens/{token_id}
 
-永久删除 Token。返回 204 No Content。
+软删除 Token。设置 `is_deleted = true`、`is_active = false`，并失效 Redis 缓存。Token 立即被禁止 API 访问，历史用量数据保留。返回 204 No Content。
 
 #### POST /admin/tokens/{token_id}/revoke
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -624,6 +624,20 @@ Plain SHA256 is fast, which means an attacker with a leaked database could brute
 
 ---
 
+## API Token Deletion Protection
+
+When a token is deleted via `DELETE /admin/tokens/{token_id}`, three layers ensure it is immediately blocked from API access:
+
+| Layer | Mechanism | Protection |
+|-------|-----------|------------|
+| 1 | `is_active = false` | `validate_token()` queries `WHERE is_active = TRUE` — DB returns no match |
+| 2 | Redis cache invalidation | `_invalidate_token_cache()` deletes the cached entry on deletion |
+| 3 | Cache-hit guard | Even if a stale cache is hit (race condition), `is_active` is checked before returning the token |
+
+The token is soft-deleted (`is_deleted = true`) to preserve historical usage data for reporting, but `is_active = false` is the authoritative gate for API access.
+
+---
+
 ## Refresh Token Security Hardening
 
 ### PBKDF2 Hashing for Refresh Tokens

--- a/docs/security.zh.md
+++ b/docs/security.zh.md
@@ -625,6 +625,20 @@ def hash_token(token: str) -> str:
 
 ---
 
+## API Token 删除保护
+
+通过 `DELETE /admin/tokens/{token_id}` 删除 Token 时，三层机制确保其立即被禁止 API 访问：
+
+| 层级 | 机制 | 防护 |
+|------|------|------|
+| 1 | `is_active = false` | `validate_token()` 查询条件 `WHERE is_active = TRUE` — 数据库直接无匹配 |
+| 2 | Redis 缓存失效 | 删除时调用 `_invalidate_token_cache()` 清除缓存条目 |
+| 3 | 缓存命中守卫 | 即使竞态条件下命中旧缓存，也会检查 `is_active` 后拒绝 |
+
+Token 采用软删除（`is_deleted = true`）以保留历史用量数据用于报表，但 `is_active = false` 是 API 访问的权威拦截门。
+
+---
+
 ## Refresh Token 安全加固
 
 ### PBKDF2 哈希

--- a/frontend/src/pages/DashboardPage.vue
+++ b/frontend/src/pages/DashboardPage.vue
@@ -6,7 +6,7 @@
     <q-card class="q-mb-md">
       <q-card-section>
         <div class="text-h6">Account Balance</div>
-        <div v-if="tokensStore.loading" class="q-mt-md">
+        <div v-if="!tokensStore.loaded" class="q-mt-md">
           <q-skeleton type="text" width="200px" height="48px" />
         </div>
         <div v-else class="text-h3 text-primary q-mt-md">
@@ -100,6 +100,18 @@
           >
             <q-tooltip>Export CSV</q-tooltip>
           </q-btn>
+          <q-btn
+            v-if="authStore.isSuperAdmin"
+            icon="vpn_key"
+            flat
+            dense
+            round
+            size="xs"
+            color="grey-7"
+            @click="exportKeys"
+          >
+            <q-tooltip>Export All Keys</q-tooltip>
+          </q-btn>
         </div>
 
         <q-table
@@ -143,10 +155,12 @@
 
 <script setup lang="ts">
 import { ref, computed, onMounted, watch } from 'vue';
+import { Notify } from 'quasar';
 import { useTokensStore } from 'src/stores/tokens';
 import { useDashboardStore } from 'src/stores/dashboard';
 import { useAuthStore } from 'src/stores/auth';
 import { api } from 'src/boot/axios';
+import { getApiBaseUrl } from 'src/utils/api';
 
 const tokensStore = useTokensStore();
 const dashboardStore = useDashboardStore();
@@ -364,7 +378,8 @@ async function exportCsv() {
       params.start_date = start.toISOString();
     } else {
       const d = new Date();
-      d.setDate(d.getDate() - 30);
+      d.setDate(d.getDate() - 89);
+      d.setHours(0, 0, 0, 0);
       params.start_date = d.toISOString();
     }
     if (endDate.value) {
@@ -384,17 +399,25 @@ async function exportCsv() {
     const response = await api.get('/admin/usage/breakdown', { params });
     const rows = response.data.data as Array<Record<string, unknown>>;
 
-    const headers = ['Date', 'API Key', 'Model', 'Prompt Tokens', 'Completion Tokens', 'Total Tokens', 'Requests', 'Cost (USD)'];
-    const csvRows = rows.map(r => [
-      r.time_bucket,
-      r.token_name,
-      r.model,
-      r.prompt_tokens,
-      r.completion_tokens,
-      r.total_tokens,
-      r.request_count,
-      r.total_cost,
-    ].map(v => `"${String(v).replace(/"/g, '""')}"`).join(','));
+    if (!rows || rows.length === 0) {
+      Notify.create({ type: 'warning', message: 'No data to export', position: 'top' });
+      return;
+    }
+
+    const tokenStatusMap = new Map(
+      tokensStore.tokens.map(t => [t.id, t.is_active ? 'Active' : 'Inactive'])
+    );
+
+    const isSuperAdmin = authStore.isSuperAdmin;
+    const headers = isSuperAdmin
+      ? ['Date', 'API Key', 'Status', 'Model', 'Prompt Tokens', 'Completion Tokens', 'Total Tokens', 'Requests', 'Cost (USD)']
+      : ['Date', 'Status', 'Model', 'Prompt Tokens', 'Completion Tokens', 'Total Tokens', 'Requests', 'Cost (USD)'];
+    const csvRows = rows.map(r => {
+      const row = isSuperAdmin
+        ? [r.time_bucket, r.token_name, tokenStatusMap.get(String(r.token_id)) ?? 'Unknown', r.model, r.prompt_tokens, r.completion_tokens, r.total_tokens, r.request_count, r.total_cost]
+        : [r.time_bucket, tokenStatusMap.get(String(r.token_id)) ?? 'Unknown', r.model, r.prompt_tokens, r.completion_tokens, r.total_tokens, r.request_count, r.total_cost];
+      return row.map(v => `"${String(v).replace(/"/g, '""')}"`).join(',');
+    });
 
     const csv = [headers.join(','), ...csvRows].join('\n');
     const blob = new Blob([csv], { type: 'text/csv;charset=utf-8;' });
@@ -402,11 +425,26 @@ async function exportCsv() {
     const link = document.createElement('a');
     link.href = url;
     link.download = `usage_${params.start_date.slice(0, 10)}_${params.end_date.slice(0, 10)}.csv`;
+    document.body.appendChild(link);
     link.click();
+    document.body.removeChild(link);
     URL.revokeObjectURL(url);
+  } catch (error: unknown) {
+    const err = error as { response?: { data?: { detail?: string } } };
+    Notify.create({
+      type: 'negative',
+      message: err.response?.data?.detail || 'Failed to export CSV',
+      position: 'top',
+    });
   } finally {
     exporting.value = false;
   }
+}
+
+function exportKeys() {
+  const token = localStorage.getItem('access_token');
+  if (!token) return;
+  window.open(`${getApiBaseUrl()}/admin/tokens/export/keys?token=${encodeURIComponent(token)}`, '_blank');
 }
 
 onMounted(async () => {

--- a/frontend/src/stores/tokens.ts
+++ b/frontend/src/stores/tokens.ts
@@ -61,6 +61,7 @@ export const useTokensStore = defineStore('tokens', {
   state: () => ({
     tokens: [] as APIToken[],
     loading: false,
+    loaded: false,
   }),
 
   actions: {
@@ -99,6 +100,7 @@ export const useTokensStore = defineStore('tokens', {
         }
       } finally {
         this.loading = false;
+        this.loaded = true;
       }
     },
 

--- a/iac/modules/waf/README.md
+++ b/iac/modules/waf/README.md
@@ -38,7 +38,7 @@ No modules.
 | <a name="input_frontend_alb_arn"></a> [frontend\_alb\_arn](#input\_frontend\_alb\_arn) | ARN of the frontend ALB (leave empty to auto-discover by name) | `string` | `""` | no |
 | <a name="input_frontend_alb_name"></a> [frontend\_alb\_name](#input\_frontend\_alb\_name) | Name of the frontend ALB for auto-discovery | `string` | `"kolya-br-proxy-frontend-alb"` | no |
 | <a name="input_project_name_alias"></a> [project\_name\_alias](#input\_project\_name\_alias) | The short name of the project | `string` | n/a | yes |
-| <a name="input_rate_limit_auth"></a> [rate\_limit\_auth](#input\_rate\_limit\_auth) | Rate limit per IP for /admin/auth/* (requests per 5 minutes) | `number` | `20` | no |
+| <a name="input_rate_limit_auth"></a> [rate\_limit\_auth](#input\_rate\_limit\_auth) | Rate limit per IP for /admin/auth/* (requests per 5 minutes, excludes OPTIONS preflight) | `number` | `50` | no |
 | <a name="input_rate_limit_chat"></a> [rate\_limit\_chat](#input\_rate\_limit\_chat) | Rate limit per IP for inference endpoints: /v1/chat/completions, /v1/messages, /v1beta/models/ (requests per 5 minutes) | `number` | `300` | no |
 | <a name="input_rate_limit_global"></a> [rate\_limit\_global](#input\_rate\_limit\_global) | Global rate limit per IP (requests per 5 minutes) | `number` | `2000` | no |
 | <a name="input_workspace"></a> [workspace](#input\_workspace) | The workspace/environment name | `string` | n/a | yes |

--- a/iac/modules/waf/main.tf
+++ b/iac/modules/waf/main.tf
@@ -19,6 +19,8 @@ resource "aws_wafv2_web_acl" "main" {
   }
 
   # Rule 1: Rate limit on /admin/auth/* (lowest priority = evaluated first)
+  # Excludes OPTIONS (CORS preflight) — browsers send preflight before every
+  # cross-origin request and counting them inflates the rate unfairly.
   rule {
     name     = "rate-limit-auth"
     priority = 1
@@ -33,17 +35,41 @@ resource "aws_wafv2_web_acl" "main" {
         aggregate_key_type = "IP"
 
         scope_down_statement {
-          byte_match_statement {
-            search_string         = "/admin/auth/"
-            positional_constraint = "STARTS_WITH"
+          and_statement {
+            statement {
+              byte_match_statement {
+                search_string         = "/admin/auth/"
+                positional_constraint = "STARTS_WITH"
 
-            field_to_match {
-              uri_path {}
+                field_to_match {
+                  uri_path {}
+                }
+
+                text_transformation {
+                  priority = 0
+                  type     = "LOWERCASE"
+                }
+              }
             }
 
-            text_transformation {
-              priority = 0
-              type     = "LOWERCASE"
+            statement {
+              not_statement {
+                statement {
+                  byte_match_statement {
+                    search_string         = "OPTIONS"
+                    positional_constraint = "EXACTLY"
+
+                    field_to_match {
+                      method {}
+                    }
+
+                    text_transformation {
+                      priority = 0
+                      type     = "NONE"
+                    }
+                  }
+                }
+              }
             }
           }
         }

--- a/iac/modules/waf/variables.tf
+++ b/iac/modules/waf/variables.tf
@@ -41,9 +41,9 @@ variable "rate_limit_global" {
 }
 
 variable "rate_limit_auth" {
-  description = "Rate limit per IP for /admin/auth/* (requests per 5 minutes)"
+  description = "Rate limit per IP for /admin/auth/* (requests per 5 minutes, excludes OPTIONS preflight)"
   type        = number
-  default     = 20
+  default     = 50
 }
 
 variable "rate_limit_chat" {


### PR DESCRIPTION
## Summary

- **Secure key export**: Super admins can download all API keys as CSV via `window.open()` — plaintext keys never appear in XHR/JSON responses (防抓包)
- **WAF CORS fix**: Exclude OPTIONS preflight from `/admin/auth/*` rate limit rule; raised threshold from 20→50 req/5min
- **CORS reliability**: SecurityMiddleware handles OPTIONS directly instead of relying on `call_next` which intermittently lost headers
- **Token deletion hardening**: `delete_token()` now sets `is_active=False` + invalidates Redis cache
- **Dashboard improvements**: Balance skeleton loader, CSV export with status column, "Export All Keys" button (super_admin only)
- **Migration safety**: Removed hardcoded emails, promote earliest user to super_admin idempotently

## Test plan

- [ ] Login and verify no CORS errors on rapid page navigation
- [ ] As super_admin, click "Export All Keys" on Dashboard → CSV downloads with correct key values and status
- [ ] Verify keys never appear in browser Network tab XHR responses
- [ ] Delete a token → confirm it shows "Deleted" status and cached requests are rejected
- [ ] Terraform plan the WAF module → verify OPTIONS exclusion rule is correct
- [ ] Non-super_admin cannot access `/admin/tokens/export/keys`

🤖 Generated with [Claude Code](https://claude.com/claude-code)