### PR TITLE
feat: data export/import + EKS Auto Mode deployment fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,13 +5,9 @@
 !*.tfvars.example
 .terraform/
 .terraform.lock.hcl
+tfplan
 crash.log
 crash.*.log
-
-# Helm values (generated per-environment, contain cluster-specific info)
-k8s/infrastructure/helm-installations/aws-load-balancer-controller-values.yaml
-k8s/infrastructure/helm-installations/karpenter-values.yaml
-
 
 # IDE
 .vscode/
@@ -48,6 +44,9 @@ frontend/.env.*
 !.secrets.baseline
 !*.template
 !*-values.yaml
+# Generated per-environment Helm values (cluster-specific; un-ignored by !*-values.yaml above, so re-ignore here)
+k8s/infrastructure/helm-installations/aws-load-balancer-controller-values.yaml
+k8s/infrastructure/helm-installations/karpenter-values.yaml
 *password*
 aws-credentials
 .aws/credentials

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -184,7 +184,7 @@
         "filename": "deploy-all.sh",
         "hashed_secret": "5ffe533b830f08a0326348a9160afafc8ada44db",
         "is_verified": false,
-        "line_number": 2705
+        "line_number": 2709
       }
     ],
     "frontend/src/pages/EntraGroupsPage.vue": [
@@ -3881,5 +3881,5 @@
       }
     ]
   },
-  "generated_at": "2026-05-31T12:22:33Z"
+  "generated_at": "2026-05-31T12:41:33Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -184,7 +184,7 @@
         "filename": "deploy-all.sh",
         "hashed_secret": "5ffe533b830f08a0326348a9160afafc8ada44db",
         "is_verified": false,
-        "line_number": 2608
+        "line_number": 2705
       }
     ],
     "frontend/src/pages/EntraGroupsPage.vue": [
@@ -3881,5 +3881,5 @@
       }
     ]
   },
-  "generated_at": "2026-05-30T09:08:04Z"
+  "generated_at": "2026-05-31T12:22:33Z"
 }

--- a/backend/alembic/versions/u2v3w4x5y6z7_add_data_management_audit_actions.py
+++ b/backend/alembic/versions/u2v3w4x5y6z7_add_data_management_audit_actions.py
@@ -1,0 +1,25 @@
+"""add data management audit actions to auditaction enum
+
+Revision ID: u2v3w4x5y6z7
+Revises: t1u2v3w4x5y6
+Create Date: 2026-05-31 00:00:00.000000
+"""
+
+from alembic import op
+
+revision = "u2v3w4x5y6z7"
+down_revision = "t1u2v3w4x5y6"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # SQLAlchemy stores enum NAMES (uppercase) in the auditaction PG enum.
+    # The data export/import endpoints write these actions, so the values must
+    # exist in the DB or the INSERT fails on existing deployments.
+    op.execute("ALTER TYPE auditaction ADD VALUE IF NOT EXISTS 'DATA_EXPORTED'")
+    op.execute("ALTER TYPE auditaction ADD VALUE IF NOT EXISTS 'DATA_IMPORTED'")
+
+
+def downgrade() -> None:
+    pass

--- a/backend/app/api/admin/endpoints/auth.py
+++ b/backend/app/api/admin/endpoints/auth.py
@@ -818,6 +818,20 @@ async def cognito_callback(
 
         settings = get_settings()
 
+        # Bootstrap: the very first user to register becomes super_admin so the
+        # system has an owner who can manage everything (mirrors the Microsoft
+        # group-sync bootstrap). All subsequent users default to admin.
+        existing_user = (
+            await db.execute(select(User.id).limit(1))
+        ).scalar_one_or_none()
+        bootstrap_role = (
+            UserRole.SUPER_ADMIN if existing_user is None else UserRole.ADMIN
+        )
+        if bootstrap_role == UserRole.SUPER_ADMIN:
+            logger.info(
+                f"COGNITO_BOOTSTRAP: first user, granting super_admin to {email}"
+            )
+
         user = User(
             email=email,
             password_hash=None,  # No password for OAuth users
@@ -827,7 +841,7 @@ async def cognito_callback(
             current_balance=Decimal(str(settings.INITIAL_USER_BALANCE_USD)),
             is_active=True,
             is_admin=True,
-            role=UserRole.ADMIN,
+            role=bootstrap_role,
             email_verified=True,  # Cognito accounts are pre-verified
         )
         db.add(user)

--- a/backend/app/api/admin/endpoints/data_management.py
+++ b/backend/app/api/admin/endpoints/data_management.py
@@ -1,0 +1,107 @@
+"""
+Data management endpoints for exporting and importing application configuration.
+Super-admin only.
+"""
+
+import json
+import logging
+
+from fastapi import APIRouter, Depends, File, Form, HTTPException, UploadFile
+from fastapi.responses import Response
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.api.deps import get_audit_log_service, get_current_superadmin
+from app.core.database import get_db
+from app.models.audit_log import AuditAction
+from app.models.user import User
+from app.services.audit_log import AuditLogService
+from app.services.data_management import DataManagementService
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter()
+
+
+@router.get("/export")
+async def export_config(
+    current_user: User = Depends(get_current_superadmin),
+    audit_service: AuditLogService = Depends(get_audit_log_service),
+    db: AsyncSession = Depends(get_db),
+):
+    """Export all application configuration as a downloadable JSON file."""
+    service = DataManagementService(db)
+    data = await service.export_config(exported_by=current_user.email)
+
+    await audit_service.log(
+        action=AuditAction.DATA_EXPORTED,
+        user=current_user,
+        resource_type="config",
+        details={
+            "sections": list(data["sections"].keys()),
+            "counts": {k: len(v) for k, v in data["sections"].items()},
+        },
+    )
+
+    content = json.dumps(data, indent=2, ensure_ascii=False)
+    filename = f"config_export_{data['exported_at'][:10].replace('-', '')}.json"
+
+    return Response(
+        content=content,
+        media_type="application/json",
+        headers={
+            "Content-Disposition": f'attachment; filename="{filename}"',
+            "Cache-Control": "no-store",
+        },
+    )
+
+
+@router.post("/import")
+async def import_config(
+    file: UploadFile = File(...),
+    conflict_strategy: str = Form("skip"),
+    current_user: User = Depends(get_current_superadmin),
+    audit_service: AuditLogService = Depends(get_audit_log_service),
+    db: AsyncSession = Depends(get_db),
+):
+    """Import application configuration from a JSON file."""
+    if conflict_strategy not in ("skip", "overwrite"):
+        raise HTTPException(
+            status_code=400, detail="conflict_strategy must be 'skip' or 'overwrite'"
+        )
+
+    # Read and parse file
+    try:
+        content = await file.read()
+        data = json.loads(content.decode("utf-8"))
+    except (json.JSONDecodeError, UnicodeDecodeError) as e:
+        raise HTTPException(status_code=400, detail=f"Invalid JSON file: {e}")
+
+    # Validate structure
+    if "version" not in data or "sections" not in data:
+        raise HTTPException(
+            status_code=400,
+            detail="Invalid file format: missing 'version' or 'sections'",
+        )
+
+    service = DataManagementService(db)
+    try:
+        results = await service.import_config(data, conflict_strategy)
+    except Exception as e:
+        logger.exception("Import failed")
+        await db.rollback()
+        raise HTTPException(status_code=500, detail=f"Import failed: {e}")
+
+    await audit_service.log(
+        action=AuditAction.DATA_IMPORTED,
+        user=current_user,
+        resource_type="config",
+        details={
+            "conflict_strategy": conflict_strategy,
+            "results": {
+                k: {kk: vv for kk, vv in v.items() if kk != "generated_keys"}
+                for k, v in results.items()
+            },
+        },
+    )
+
+    return results

--- a/backend/app/api/admin/router.py
+++ b/backend/app/api/admin/router.py
@@ -9,6 +9,7 @@ from app.api.admin.endpoints import (
     alerts,
     audit,
     auth,
+    data_management,
     entra_groups,
     models,
     teams,
@@ -60,6 +61,11 @@ admin_router.include_router(users.router, prefix="/users", tags=["admin-users"])
 # Entra ID group mapping (super_admin only)
 admin_router.include_router(
     entra_groups.router, prefix="/entra-groups", tags=["admin-entra-groups"]
+)
+
+# Data management - export/import (super_admin only)
+admin_router.include_router(
+    data_management.router, prefix="/data-management", tags=["admin-data-management"]
 )
 
 

--- a/backend/app/models/audit_log.py
+++ b/backend/app/models/audit_log.py
@@ -67,6 +67,10 @@ class AuditAction(enum.Enum):
     ALERT_RULE_UPDATED = "alert_rule_updated"
     ALERT_RULE_DELETED = "alert_rule_deleted"
 
+    # Data Management
+    DATA_EXPORTED = "data_exported"
+    DATA_IMPORTED = "data_imported"
+
     # Authorization
     UNAUTHORIZED_ACCESS_ATTEMPT = "unauthorized_access_attempt"
     PERMISSION_DENIED = "permission_denied"

--- a/backend/app/services/data_management.py
+++ b/backend/app/services/data_management.py
@@ -1,0 +1,730 @@
+"""
+Data management service for export/import of application configuration.
+"""
+
+import logging
+from datetime import datetime
+from decimal import Decimal
+from typing import Any
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.security import encrypt_token, generate_api_token, hash_token
+from app.models.alert import AlertRule
+from app.models.entra_group_mapping import EntraGroupMapping
+from app.models.model import Model
+from app.models.team import Team, TeamMember
+from app.models.token import APIToken
+from app.models.user import AuthMethod, User, UserRole
+
+logger = logging.getLogger(__name__)
+
+EXPORT_VERSION = "1.0"
+
+
+class SectionResult:
+    def __init__(self):
+        self.created = 0
+        self.skipped = 0
+        self.overwritten = 0
+        self.errors: list[str] = []
+
+    def to_dict(self) -> dict:
+        return {
+            "created": self.created,
+            "skipped": self.skipped,
+            "overwritten": self.overwritten,
+            "errors": self.errors,
+        }
+
+
+class DataManagementService:
+    def __init__(self, db: AsyncSession):
+        self.db = db
+
+    async def export_config(self, exported_by: str) -> dict:
+        """Export all application configuration as a JSON-serializable dict."""
+        return {
+            "version": EXPORT_VERSION,
+            "exported_at": datetime.utcnow().isoformat() + "Z",
+            "exported_by": exported_by,
+            "sections": {
+                "users": await self._export_users(),
+                "teams": await self._export_teams(),
+                "tokens": await self._export_tokens(),
+                "team_members": await self._export_team_members(),
+                "alert_rules": await self._export_alert_rules(),
+                "entra_group_mappings": await self._export_entra_group_mappings(),
+            },
+        }
+
+    async def import_config(self, data: dict, conflict_strategy: str) -> dict[str, Any]:
+        """
+        Import configuration from a JSON dict.
+        Returns result summary with generated token keys.
+        """
+        sections = data.get("sections", {})
+
+        results: dict[str, Any] = {}
+        results["users"] = (
+            await self._import_users(sections.get("users", []), conflict_strategy)
+        ).to_dict()
+        results["teams"] = (
+            await self._import_teams(sections.get("teams", []), conflict_strategy)
+        ).to_dict()
+
+        token_result, generated_keys = await self._import_tokens(
+            sections.get("tokens", []), conflict_strategy
+        )
+        token_dict = token_result.to_dict()
+        token_dict["generated_keys"] = generated_keys
+        results["tokens"] = token_dict
+
+        results["team_members"] = (
+            await self._import_team_members(
+                sections.get("team_members", []), conflict_strategy
+            )
+        ).to_dict()
+        results["alert_rules"] = (
+            await self._import_alert_rules(
+                sections.get("alert_rules", []), conflict_strategy
+            )
+        ).to_dict()
+        results["entra_group_mappings"] = (
+            await self._import_entra_group_mappings(
+                sections.get("entra_group_mappings", []), conflict_strategy
+            )
+        ).to_dict()
+
+        await self.db.commit()
+        return results
+
+    # ─── Export helpers ─────────────────────────────────────────────
+
+    async def _export_users(self) -> list[dict]:
+        result = await self.db.execute(select(User).where(User.is_active.is_(True)))
+        users = result.scalars().all()
+        return [
+            {
+                "email": u.email,
+                "role": u.role.value if u.role else None,
+                "permissions": u.permissions,
+                "is_active": u.is_active,
+                "is_admin": u.is_admin,
+                "first_name": u.first_name,
+                "last_name": u.last_name,
+                "auth_method": u.auth_method.value if u.auth_method else None,
+            }
+            for u in users
+        ]
+
+    async def _export_teams(self) -> list[dict]:
+        result = await self.db.execute(select(Team).where(Team.is_active.is_(True)))
+        teams = result.scalars().all()
+        return [
+            {
+                "name": t.name,
+                "monthly_budget_usd": str(t.monthly_budget_usd)
+                if t.monthly_budget_usd
+                else None,
+                "monthly_reset_policy": t.monthly_reset_policy,
+                "daily_limit_enabled": t.daily_limit_enabled,
+            }
+            for t in teams
+        ]
+
+    async def _export_tokens(self) -> list[dict]:
+        result = await self.db.execute(
+            select(APIToken).where(
+                APIToken.is_deleted.is_(False), APIToken.is_active.is_(True)
+            )
+        )
+        tokens = result.scalars().all()
+
+        exported = []
+        for t in tokens:
+            # Get user email
+            user_result = await self.db.execute(
+                select(User.email).where(User.id == t.user_id)
+            )
+            user_email = user_result.scalar_one_or_none()
+
+            # Get allowed models
+            models_result = await self.db.execute(
+                select(Model.model_name).where(
+                    Model.token_id == t.id,
+                    Model.is_active.is_(True),
+                    Model.is_deleted.is_(False),
+                )
+            )
+            model_names = list(models_result.scalars().all())
+
+            exported.append(
+                {
+                    "name": t.name,
+                    "user_email": user_email,
+                    "quota_usd": str(t.quota_usd) if t.quota_usd else None,
+                    "monthly_quota_usd": str(t.monthly_quota_usd)
+                    if t.monthly_quota_usd
+                    else None,
+                    "monthly_reset_policy": t.monthly_reset_policy,
+                    "allowed_ips": t.allowed_ips or [],
+                    "is_active": t.is_active,
+                    "token_metadata": t.token_metadata,
+                    "allowed_models": model_names,
+                }
+            )
+        return exported
+
+    async def _export_team_members(self) -> list[dict]:
+        result = await self.db.execute(
+            select(TeamMember, Team.name, APIToken.name, User.email)
+            .join(Team, TeamMember.team_id == Team.id)
+            .join(APIToken, TeamMember.token_id == APIToken.id)
+            .join(User, APIToken.user_id == User.id)
+            .where(Team.is_active.is_(True))
+        )
+        rows = result.all()
+        return [
+            {
+                "team_name": team_name,
+                "token_name": token_name,
+                "token_user_email": user_email,
+                "allocated_usd": str(tm.allocated_usd) if tm.allocated_usd else None,
+            }
+            for tm, team_name, token_name, user_email in rows
+        ]
+
+    async def _export_alert_rules(self) -> list[dict]:
+        result = await self.db.execute(
+            select(AlertRule).where(AlertRule.is_active.is_(True))
+        )
+        rules = result.scalars().all()
+
+        exported = []
+        for r in rules:
+            # Resolve user email
+            user_result = await self.db.execute(
+                select(User.email).where(User.id == r.user_id)
+            )
+            user_email = user_result.scalar_one_or_none()
+
+            # Resolve token name + user email if token_id set
+            token_name = None
+            token_user_email = None
+            if r.token_id:
+                tok_result = await self.db.execute(
+                    select(APIToken.name, User.email)
+                    .join(User, APIToken.user_id == User.id)
+                    .where(APIToken.id == r.token_id)
+                )
+                row = tok_result.first()
+                if row:
+                    token_name, token_user_email = row
+
+            # Resolve team name if team_id set
+            team_name = None
+            if r.team_id:
+                team_result = await self.db.execute(
+                    select(Team.name).where(Team.id == r.team_id)
+                )
+                team_name = team_result.scalar_one_or_none()
+
+            exported.append(
+                {
+                    "user_email": user_email,
+                    "alert_type": r.alert_type,
+                    "rule_key": r.rule_key,
+                    "threshold_value": str(r.threshold_value)
+                    if r.threshold_value
+                    else None,
+                    "cooldown_hours": r.cooldown_hours,
+                    "notify_email": r.notify_email,
+                    "notify_in_app": r.notify_in_app,
+                    "token_name": token_name,
+                    "token_user_email": token_user_email,
+                    "team_name": team_name,
+                }
+            )
+        return exported
+
+    async def _export_entra_group_mappings(self) -> list[dict]:
+        result = await self.db.execute(select(EntraGroupMapping))
+        mappings = result.scalars().all()
+        return [
+            {
+                "entra_group_id": m.entra_group_id,
+                "group_name": m.group_name,
+                "role": m.role.value if m.role else None,
+                "permissions": m.permissions,
+                "priority": m.priority,
+            }
+            for m in mappings
+        ]
+
+    # ─── Import helpers ─────────────────────────────────────────────
+
+    async def _resolve_user_by_email(self, email: str) -> User | None:
+        result = await self.db.execute(select(User).where(User.email == email))
+        return result.scalar_one_or_none()
+
+    async def _import_users(
+        self, users_data: list[dict], strategy: str
+    ) -> SectionResult:
+        sr = SectionResult()
+        for item in users_data:
+            email = item.get("email")
+            if not email:
+                sr.errors.append("User entry missing email")
+                continue
+
+            existing = await self._resolve_user_by_email(email)
+            if existing:
+                if strategy == "skip":
+                    sr.skipped += 1
+                else:
+                    existing.role = (
+                        UserRole(item["role"]) if item.get("role") else existing.role
+                    )
+                    existing.permissions = item.get("permissions", existing.permissions)
+                    existing.is_active = item.get("is_active", existing.is_active)
+                    if "is_admin" in item:
+                        existing.is_admin = item["is_admin"]
+                    existing.first_name = item.get("first_name", existing.first_name)
+                    existing.last_name = item.get("last_name", existing.last_name)
+                    if item.get("auth_method"):
+                        existing.auth_method = AuthMethod(item["auth_method"])
+                    sr.overwritten += 1
+            else:
+                role = UserRole(item["role"]) if item.get("role") else UserRole.ADMIN
+                user = User(
+                    email=email,
+                    role=role,
+                    permissions=item.get("permissions"),
+                    is_active=item.get("is_active", True),
+                    # Preserve the source's admin flag; fall back to deriving it
+                    # from role (every role here is an admin tier) — never elevate.
+                    is_admin=item.get(
+                        "is_admin", role in (UserRole.ADMIN, UserRole.SUPER_ADMIN)
+                    ),
+                    first_name=item.get("first_name"),
+                    last_name=item.get("last_name"),
+                    auth_method=AuthMethod(item["auth_method"])
+                    if item.get("auth_method")
+                    else AuthMethod.COGNITO,
+                    email_verified=False,
+                )
+                self.db.add(user)
+                sr.created += 1
+
+        await self.db.flush()
+        return sr
+
+    async def _import_teams(
+        self, teams_data: list[dict], strategy: str
+    ) -> SectionResult:
+        sr = SectionResult()
+        for item in teams_data:
+            name = item.get("name")
+            if not name:
+                sr.errors.append("Team entry missing name")
+                continue
+
+            result = await self.db.execute(
+                select(Team).where(Team.name == name, Team.is_active.is_(True))
+            )
+            existing = result.scalar_one_or_none()
+
+            if existing:
+                if strategy == "skip":
+                    sr.skipped += 1
+                else:
+                    if item.get("monthly_budget_usd"):
+                        existing.monthly_budget_usd = Decimal(
+                            item["monthly_budget_usd"]
+                        )
+                    existing.monthly_reset_policy = item.get(
+                        "monthly_reset_policy", existing.monthly_reset_policy
+                    )
+                    existing.daily_limit_enabled = item.get(
+                        "daily_limit_enabled", existing.daily_limit_enabled
+                    )
+                    sr.overwritten += 1
+            else:
+                # Find a super-admin to be the team owner
+                admin_result = await self.db.execute(
+                    select(User).where(User.role == UserRole.SUPER_ADMIN).limit(1)
+                )
+                owner = admin_result.scalar_one_or_none()
+                if not owner:
+                    sr.errors.append(f"Team '{name}': no super-admin found to be owner")
+                    continue
+
+                team = Team(
+                    name=name,
+                    user_id=owner.id,
+                    monthly_budget_usd=Decimal(item["monthly_budget_usd"])
+                    if item.get("monthly_budget_usd")
+                    else None,
+                    monthly_reset_policy=item.get("monthly_reset_policy"),
+                    daily_limit_enabled=item.get("daily_limit_enabled", False),
+                    monthly_budget_start=datetime.utcnow(),
+                    is_active=True,
+                )
+                self.db.add(team)
+                sr.created += 1
+
+        await self.db.flush()
+        return sr
+
+    async def _import_tokens(
+        self, tokens_data: list[dict], strategy: str
+    ) -> tuple[SectionResult, list[dict]]:
+        sr = SectionResult()
+        generated_keys: list[dict] = []
+
+        for item in tokens_data:
+            name = item.get("name")
+            user_email = item.get("user_email")
+            if not name or not user_email:
+                sr.errors.append(f"Token entry missing name or user_email: {name}")
+                continue
+
+            user = await self._resolve_user_by_email(user_email)
+            if not user:
+                sr.errors.append(f"Token '{name}': user '{user_email}' not found")
+                continue
+
+            result = await self.db.execute(
+                select(APIToken).where(
+                    APIToken.name == name,
+                    APIToken.user_id == user.id,
+                    APIToken.is_deleted.is_(False),
+                )
+            )
+            existing = result.scalar_one_or_none()
+
+            if existing:
+                if strategy == "skip":
+                    sr.skipped += 1
+                else:
+                    if item.get("quota_usd"):
+                        existing.quota_usd = Decimal(item["quota_usd"])
+                    if item.get("monthly_quota_usd"):
+                        existing.monthly_quota_usd = Decimal(item["monthly_quota_usd"])
+                    existing.monthly_reset_policy = item.get(
+                        "monthly_reset_policy", existing.monthly_reset_policy
+                    )
+                    if "allowed_ips" in item:
+                        existing.allowed_ips = item["allowed_ips"]
+                    if "token_metadata" in item:
+                        existing.token_metadata = item["token_metadata"]
+                    if "is_active" in item:
+                        existing.is_active = item["is_active"]
+                    # Sync allowed_models
+                    if "allowed_models" in item:
+                        await self._sync_token_models(
+                            existing.id, item["allowed_models"]
+                        )
+                    sr.overwritten += 1
+            else:
+                # Generate new token
+                plain_token = generate_api_token()
+                token_hash = hash_token(plain_token)
+                encrypted = encrypt_token(plain_token)
+
+                token = APIToken(
+                    user_id=user.id,
+                    name=name,
+                    token_hash=token_hash,
+                    encrypted_token=encrypted,
+                    quota_usd=Decimal(item["quota_usd"])
+                    if item.get("quota_usd")
+                    else None,
+                    monthly_quota_usd=Decimal(item["monthly_quota_usd"])
+                    if item.get("monthly_quota_usd")
+                    else None,
+                    monthly_reset_policy=item.get("monthly_reset_policy"),
+                    monthly_quota_start=datetime.utcnow()
+                    if item.get("monthly_quota_usd")
+                    else None,
+                    allowed_ips=item.get("allowed_ips", []),
+                    token_metadata=item.get("token_metadata"),
+                    is_active=item.get("is_active", True),
+                )
+                self.db.add(token)
+                await self.db.flush()
+
+                # Create model associations
+                for model_name in item.get("allowed_models", []):
+                    model = Model(
+                        token_id=token.id,
+                        model_name=model_name,
+                        is_active=True,
+                    )
+                    self.db.add(model)
+
+                generated_keys.append(
+                    {
+                        "name": name,
+                        "user_email": user_email,
+                        "token": plain_token,
+                    }
+                )
+                sr.created += 1
+
+        await self.db.flush()
+        return sr, generated_keys
+
+    async def _sync_token_models(self, token_id, model_names: list[str]) -> None:
+        """Sync allowed models for a token: deactivate removed, add/reactivate new ones."""
+        # Include soft-deleted rows so they can be reactivated instead of duplicated
+        result = await self.db.execute(select(Model).where(Model.token_id == token_id))
+        existing_models = {m.model_name: m for m in result.scalars().all()}
+
+        desired = set(model_names)
+        current = set(existing_models.keys())
+
+        # Deactivate models no longer in the list
+        for name in current - desired:
+            existing_models[name].is_active = False
+            existing_models[name].is_deleted = True
+            existing_models[name].deleted_at = datetime.utcnow()
+
+        # Re-activate or create models in the list
+        for name in desired:
+            if name in existing_models:
+                existing_models[name].is_active = True
+                existing_models[name].is_deleted = False
+                existing_models[name].deleted_at = None
+            else:
+                self.db.add(Model(token_id=token_id, model_name=name, is_active=True))
+
+    async def _import_team_members(
+        self, members_data: list[dict], strategy: str
+    ) -> SectionResult:
+        sr = SectionResult()
+        for item in members_data:
+            team_name = item.get("team_name")
+            token_name = item.get("token_name")
+            token_user_email = item.get("token_user_email")
+
+            if not team_name or not token_name or not token_user_email:
+                sr.errors.append(f"TeamMember entry missing required fields: {item}")
+                continue
+
+            # Resolve team
+            team_result = await self.db.execute(
+                select(Team).where(Team.name == team_name, Team.is_active.is_(True))
+            )
+            team = team_result.scalar_one_or_none()
+            if not team:
+                sr.errors.append(f"TeamMember: team '{team_name}' not found")
+                continue
+
+            # Resolve token
+            user = await self._resolve_user_by_email(token_user_email)
+            if not user:
+                sr.errors.append(f"TeamMember: user '{token_user_email}' not found")
+                continue
+
+            token_result = await self.db.execute(
+                select(APIToken).where(
+                    APIToken.name == token_name,
+                    APIToken.user_id == user.id,
+                    APIToken.is_deleted.is_(False),
+                )
+            )
+            token = token_result.scalar_one_or_none()
+            if not token:
+                sr.errors.append(
+                    f"TeamMember: token '{token_name}' for '{token_user_email}' not found"
+                )
+                continue
+
+            # Check existing
+            existing_result = await self.db.execute(
+                select(TeamMember).where(
+                    TeamMember.team_id == team.id, TeamMember.token_id == token.id
+                )
+            )
+            existing = existing_result.scalar_one_or_none()
+
+            if existing:
+                if strategy == "skip":
+                    sr.skipped += 1
+                else:
+                    if item.get("allocated_usd"):
+                        existing.allocated_usd = Decimal(item["allocated_usd"])
+                    sr.overwritten += 1
+            else:
+                member = TeamMember(
+                    team_id=team.id,
+                    token_id=token.id,
+                    allocated_usd=Decimal(item["allocated_usd"])
+                    if item.get("allocated_usd")
+                    else None,
+                )
+                self.db.add(member)
+                sr.created += 1
+
+        await self.db.flush()
+        return sr
+
+    async def _import_alert_rules(
+        self, rules_data: list[dict], strategy: str
+    ) -> SectionResult:
+        sr = SectionResult()
+        for item in rules_data:
+            user_email = item.get("user_email")
+            rule_key = item.get("rule_key")
+            alert_type = item.get("alert_type")
+
+            if not user_email or not rule_key or not alert_type:
+                sr.errors.append(f"AlertRule entry missing required fields: {item}")
+                continue
+
+            user = await self._resolve_user_by_email(user_email)
+            if not user:
+                sr.errors.append(f"AlertRule: user '{user_email}' not found")
+                continue
+
+            # Resolve optional token
+            token_id = None
+            if item.get("token_name") and item.get("token_user_email"):
+                token_user = await self._resolve_user_by_email(item["token_user_email"])
+                if token_user:
+                    tok_result = await self.db.execute(
+                        select(APIToken.id).where(
+                            APIToken.name == item["token_name"],
+                            APIToken.user_id == token_user.id,
+                            APIToken.is_deleted.is_(False),
+                        )
+                    )
+                    token_id = tok_result.scalar_one_or_none()
+
+            # Resolve optional team
+            team_id = None
+            if item.get("team_name"):
+                team_result = await self.db.execute(
+                    select(Team.id).where(
+                        Team.name == item["team_name"], Team.is_active.is_(True)
+                    )
+                )
+                team_id = team_result.scalar_one_or_none()
+
+            # A declared scope that fails to resolve must error, not silently
+            # degrade the rule to a global (unscoped) rule — which the alert
+            # engine forbids (see create_rule in services/alert.py).
+            if item.get("token_name") and token_id is None:
+                sr.errors.append(
+                    f"AlertRule '{rule_key}' for '{user_email}': "
+                    f"token '{item['token_name']}' not found"
+                )
+                continue
+            if item.get("team_name") and team_id is None:
+                sr.errors.append(
+                    f"AlertRule '{rule_key}' for '{user_email}': "
+                    f"team '{item['team_name']}' not found"
+                )
+                continue
+            if token_id is None and team_id is None:
+                sr.errors.append(
+                    f"AlertRule '{rule_key}' for '{user_email}': "
+                    f"missing token or team scope"
+                )
+                continue
+
+            # Check existing
+            existing_result = await self.db.execute(
+                select(AlertRule).where(
+                    AlertRule.user_id == user.id,
+                    AlertRule.rule_key == rule_key,
+                    AlertRule.alert_type == alert_type,
+                )
+            )
+            existing = existing_result.scalar_one_or_none()
+
+            if existing:
+                if strategy == "skip":
+                    sr.skipped += 1
+                else:
+                    if item.get("threshold_value"):
+                        existing.threshold_value = Decimal(item["threshold_value"])
+                    existing.cooldown_hours = item.get(
+                        "cooldown_hours", existing.cooldown_hours
+                    )
+                    existing.notify_email = item.get(
+                        "notify_email", existing.notify_email
+                    )
+                    existing.notify_in_app = item.get(
+                        "notify_in_app", existing.notify_in_app
+                    )
+                    # Scope is validated above to be exactly one of token/team;
+                    # assign directly so a changed scope type clears the other
+                    # (CheckConstraint forbids both being set).
+                    existing.token_id = token_id
+                    existing.team_id = team_id
+                    sr.overwritten += 1
+            else:
+                rule = AlertRule(
+                    user_id=user.id,
+                    alert_type=alert_type,
+                    rule_key=rule_key,
+                    threshold_value=Decimal(item["threshold_value"])
+                    if item.get("threshold_value")
+                    else None,
+                    cooldown_hours=item.get("cooldown_hours", 24),
+                    notify_email=item.get("notify_email"),
+                    notify_in_app=item.get("notify_in_app", True),
+                    token_id=token_id,
+                    team_id=team_id,
+                    is_active=True,
+                )
+                self.db.add(rule)
+                sr.created += 1
+
+        await self.db.flush()
+        return sr
+
+    async def _import_entra_group_mappings(
+        self, mappings_data: list[dict], strategy: str
+    ) -> SectionResult:
+        sr = SectionResult()
+        for item in mappings_data:
+            entra_group_id = item.get("entra_group_id")
+            if not entra_group_id:
+                sr.errors.append("EntraGroupMapping entry missing entra_group_id")
+                continue
+
+            result = await self.db.execute(
+                select(EntraGroupMapping).where(
+                    EntraGroupMapping.entra_group_id == entra_group_id
+                )
+            )
+            existing = result.scalar_one_or_none()
+
+            if existing:
+                if strategy == "skip":
+                    sr.skipped += 1
+                else:
+                    existing.group_name = item.get("group_name", existing.group_name)
+                    if item.get("role"):
+                        existing.role = UserRole(item["role"])
+                    existing.permissions = item.get("permissions", existing.permissions)
+                    existing.priority = item.get("priority", existing.priority)
+                    sr.overwritten += 1
+            else:
+                mapping = EntraGroupMapping(
+                    entra_group_id=entra_group_id,
+                    group_name=item.get("group_name", ""),
+                    role=UserRole(item["role"]) if item.get("role") else UserRole.ADMIN,
+                    permissions=item.get("permissions"),
+                    priority=item.get("priority", 0),
+                )
+                self.db.add(mapping)
+                sr.created += 1
+
+        await self.db.flush()
+        return sr

--- a/build-and-push.sh
+++ b/build-and-push.sh
@@ -12,6 +12,10 @@
 
 set -e
 
+# Use BuildKit (not the deprecated legacy builder) — handles --platform
+# cross-builds natively and silences the "legacy builder is deprecated" warning.
+export DOCKER_BUILDKIT=1
+
 # Colors
 RED='\033[0;31m'
 GREEN='\033[0;32m'

--- a/deploy-all.sh
+++ b/deploy-all.sh
@@ -136,16 +136,51 @@ _tf_output() {
     echo "$val"
 }
 
-# Detect whether a terraform module is present in state (for bool toggles)
-# Usage: _detect_bool_from_state "module_name"  →  prints "true" or "false"
-_detect_bool_from_state() {
-    local module_name="$1"
-    cd "$IAC_DIR"
-    if terraform state list 2>/dev/null | grep -q "module.${module_name}"; then
-        echo "true"
-    else
-        echo "false"
+# Read a field from providers.tf (e.g. "region", "bucket")
+_read_providers_field() {
+    local field="$1"
+    grep "$field" "$IAC_DIR/providers.tf" 2>/dev/null | head -1 | sed 's/.*= *"\(.*\)"/\1/'
+}
+
+# Ensure an S3 bucket exists; offer to create if not.
+# Usage: _ensure_s3_bucket "bucket-name" "region"
+_ensure_s3_bucket() {
+    local bucket="$1" region="$2"
+    if ! aws s3api head-bucket --bucket "$bucket" --region "$region" 2>/dev/null; then
+        print_warning "S3 bucket '$bucket' does not exist in $region"
+        read -p "Create it now? (yes/no) [yes]: " create_bucket
+        create_bucket="${create_bucket:-yes}"
+        if [[ "$create_bucket" == "yes" ]]; then
+            if [[ "$region" == "us-east-1" ]]; then
+                aws s3api create-bucket --bucket "$bucket" --region "$region"
+            else
+                aws s3api create-bucket --bucket "$bucket" --region "$region" \
+                    --create-bucket-configuration LocationConstraint="$region"
+            fi
+            aws s3api put-bucket-versioning --bucket "$bucket" --versioning-configuration Status=Enabled
+            print_success "Bucket '$bucket' created with versioning enabled"
+        else
+            print_warning "Bucket does not exist — terraform init will fail"
+        fi
     fi
+}
+
+# Prompt user for a boolean tfvar with current value as default.
+# Usage: _prompt_bool_tfvar "var_name" "Display Label"
+_prompt_bool_tfvar() {
+    local var_name="$1" label="$2"
+    local current
+    current=$(_read_tfvar "$var_name")
+    echo ""
+    print_substep "$label"
+    if [[ -n "$current" ]]; then
+        echo "  Current: $var_name = $current"
+    fi
+    local input
+    read -p "Enable ${label}? (true/false) [${current:-false}]: " input
+    input="${input:-${current:-false}}"
+    _write_tfvar "$var_name" "$input" "bare"
+    print_success "$var_name = $input"
 }
 
 # Step 0: Configure terraform.tfvars as single source of truth
@@ -160,7 +195,7 @@ configure_tfvars() {
     detected_account=$(aws sts get-caller-identity --query Account --output text 2>/dev/null || echo "")
     # Region priority: --region flag (AWS_REGION) > existing tfvars > aws configure
     local existing_region
-    existing_region=$(_read_tfvar "region" 2>/dev/null || echo "")
+    existing_region=$(_read_tfvar "region")
     local detected_region="${AWS_REGION:-${existing_region:-$(aws configure get region 2>/dev/null || echo "")}}"
 
     if [[ -n "$detected_account" ]]; then
@@ -172,22 +207,9 @@ configure_tfvars() {
         print_success "region = $detected_region"
     fi
 
-    # 2. Auto-detect boolean toggles from terraform state
-    print_substep "Detecting feature flags from Terraform state..."
-    if [[ -d "$IAC_DIR/.terraform" ]]; then
-        local detected_waf
-        detected_waf=$(_detect_bool_from_state "waf")
-        _write_tfvar "enable_waf" "$detected_waf" "bare"
-        print_success "enable_waf = $detected_waf (from state)"
-
-        local detected_ga
-        detected_ga=$(_detect_bool_from_state "global_accelerator")
-        _write_tfvar "enable_global_accelerator" "$detected_ga" "bare"
-        print_success "enable_global_accelerator = $detected_ga (from state)"
-
-    else
-        print_warning "Terraform not initialized, skipping state detection"
-    fi
+    # 2. WAF and Global Accelerator
+    _prompt_bool_tfvar "enable_waf" "WAF (Web Application Firewall)"
+    _prompt_bool_tfvar "enable_global_accelerator" "Global Accelerator"
 
     # 2b. Authentication provider selection (always prompt, show current value as default)
     local current_cognito
@@ -227,15 +249,18 @@ configure_tfvars() {
     case "$auth_choice" in
         1)
             _write_tfvar "enable_cognito" "true" "bare"
+            _write_tfvar "enable_microsoft" "false" "bare"
             print_success "enable_cognito = true"
             ;;
         2|microsoft)
             _write_tfvar "enable_cognito" "false" "bare"
+            _write_tfvar "enable_microsoft" "true" "bare"
             print_success "enable_cognito = false (Microsoft only)"
             ;;
         3)
             _write_tfvar "enable_cognito" "true" "bare"
-            print_success "enable_cognito = true (+ Microsoft via Secrets Manager)"
+            _write_tfvar "enable_microsoft" "true" "bare"
+            print_success "enable_cognito = true + Microsoft Entra ID"
             ;;
         *)
             # Keep current or default to Cognito
@@ -735,23 +760,49 @@ push_secrets_to_sm() {
         cfg_cognito_client_secret=$(_tf_output cognito_app_client_secret || echo "")
     fi
 
-    # Read existing MS config from SM (preserve if present)
-    local cfg_ms_client_id=""
-    local cfg_ms_client_secret=""
-    local cfg_ms_tenant_id=""
-    cfg_ms_client_id=$(aws secretsmanager get-secret-value --secret-id "$secret_name" --query SecretString --output text 2>/dev/null | jq -r '."microsoft-client-id" // empty' 2>/dev/null || echo "")
-    cfg_ms_client_secret=$(aws secretsmanager get-secret-value --secret-id "$secret_name" --query SecretString --output text 2>/dev/null | jq -r '."microsoft-client-secret" // empty' 2>/dev/null || echo "")
-    cfg_ms_tenant_id=$(aws secretsmanager get-secret-value --secret-id "$secret_name" --query SecretString --output text 2>/dev/null | jq -r '."microsoft-tenant-id" // empty' 2>/dev/null || echo "")
+    # Read all existing values from SM in a single API call
+    local _sm_json
+    _sm_json=$(aws secretsmanager get-secret-value --secret-id "$secret_name" --query SecretString --output text 2>/dev/null || echo "{}")
 
-    # Read existing Gemini API key from SM (preserve if present)
-    local cfg_gemini_api_key=""
-    cfg_gemini_api_key=$(aws secretsmanager get-secret-value --secret-id "$secret_name" --query SecretString --output text 2>/dev/null | jq -r '."gemini-api-key" // empty' 2>/dev/null || echo "")
+    local cfg_ms_client_id cfg_ms_client_secret cfg_ms_tenant_id
+    cfg_ms_client_id=$(echo "$_sm_json" | jq -r '."microsoft-client-id" // empty')
+    cfg_ms_client_secret=$(echo "$_sm_json" | jq -r '."microsoft-client-secret" // empty')
+    cfg_ms_tenant_id=$(echo "$_sm_json" | jq -r '."microsoft-tenant-id" // empty')
 
-    # Read existing cert ARNs from SM (preserve if present)
-    local cfg_frontend_cert_arn=""
-    local cfg_api_cert_arn=""
-    cfg_frontend_cert_arn=$(aws secretsmanager get-secret-value --secret-id "$secret_name" --query SecretString --output text 2>/dev/null | jq -r '."acm-certificate-frontend-arn" // empty' 2>/dev/null || echo "")
-    cfg_api_cert_arn=$(aws secretsmanager get-secret-value --secret-id "$secret_name" --query SecretString --output text 2>/dev/null | jq -r '."acm-certificate-api-arn" // empty' 2>/dev/null || echo "")
+    # Read enable_microsoft from tfvars (persisted by step 0)
+    local _enable_microsoft
+    _enable_microsoft=$(_read_tfvar "enable_microsoft")
+    if [[ "$_enable_microsoft" == "true" && ( -z "$cfg_ms_client_id" || -z "$cfg_ms_client_secret" || -z "$cfg_ms_tenant_id" ) ]]; then
+        echo ""
+        print_substep "Microsoft Entra ID Configuration"
+        echo ""
+        echo "  You need the following from Azure Portal → App registrations → Your app:"
+        echo "    • Application (client) ID    → Overview page"
+        echo "    • Client secret              → Certificates & secrets → New client secret"
+        echo "    • Directory (tenant) ID      → Overview page"
+        echo ""
+        echo "  Also ensure:"
+        echo "    • API permissions → Add 'GroupMember.Read.All' (Delegated) → Grant admin consent"
+        echo "    • Redirect URI → https://<your-frontend-domain>/auth/microsoft/callback"
+        echo ""
+        read -p "Microsoft Client ID (Application ID): " cfg_ms_client_id
+        read -s -p "Microsoft Client Secret: " cfg_ms_client_secret
+        echo ""
+        read -p "Microsoft Tenant ID (Directory ID): " cfg_ms_tenant_id
+        if [[ -z "$cfg_ms_client_id" || -z "$cfg_ms_client_secret" || -z "$cfg_ms_tenant_id" ]]; then
+            print_warning "Microsoft credentials incomplete — skipping (configure later with: ./deploy-all.sh auth)"
+            cfg_ms_client_id=""
+            cfg_ms_client_secret=""
+            cfg_ms_tenant_id=""
+        fi
+    fi
+
+    local cfg_gemini_api_key
+    cfg_gemini_api_key=$(echo "$_sm_json" | jq -r '."gemini-api-key" // empty')
+
+    local cfg_frontend_cert_arn cfg_api_cert_arn
+    cfg_frontend_cert_arn=$(echo "$_sm_json" | jq -r '."acm-certificate-frontend-arn" // empty')
+    cfg_api_cert_arn=$(echo "$_sm_json" | jq -r '."acm-certificate-api-arn" // empty')
 
     # Validate cert ARNs: must match deployment region
     if [[ -n "$cfg_frontend_cert_arn" && "$cfg_frontend_cert_arn" != *":${cfg_region}:"* ]]; then
@@ -1550,9 +1601,9 @@ verify_terraform_state() {
         need_configure=true
     else
         # Show current backend config and let user confirm
-        local current_bucket=$(grep 'bucket' "$IAC_DIR/providers.tf" | head -1 | sed 's/.*= *"\(.*\)"/\1/')
-        local current_region=$(grep 'region' "$IAC_DIR/providers.tf" | head -1 | sed 's/.*= *"\(.*\)"/\1/')
-        local current_key=$(grep 'key' "$IAC_DIR/providers.tf" | head -1 | sed 's/.*= *"\(.*\)"/\1/')
+        local current_bucket=$(_read_providers_field 'bucket')
+        local current_region=$(_read_providers_field 'region')
+        local current_key=$(_read_providers_field 'key')
 
         echo ""
         print_info "Current Terraform backend configuration:"
@@ -1586,6 +1637,8 @@ verify_terraform_state() {
 
         local tf_state_region="$AWS_REGION"
         local tf_state_key="kolya-br-proxy/tf.state"
+
+        _ensure_s3_bucket "$tf_state_bucket" "$tf_state_region"
 
         export TF_STATE_BUCKET="$tf_state_bucket"
         export TF_STATE_REGION="$tf_state_region"
@@ -1655,6 +1708,21 @@ deploy_terraform() {
 
     # --- Backend & Init (must happen before any workspace operations) ---
 
+    # Check if providers.tf region matches current deployment region
+    if [[ -f "$IAC_DIR/providers.tf" ]]; then
+        local backend_region=$(_read_providers_field 'region')
+        if [[ -n "$backend_region" && "$backend_region" != "$AWS_REGION" ]]; then
+            local backend_bucket=$(_read_providers_field 'bucket')
+            print_warning "Backend region mismatch: providers.tf has '$backend_region', deployment target is '$AWS_REGION'"
+            print_info "Current backend: bucket=$backend_bucket, region=$backend_region"
+            read -p "Reconfigure backend for $AWS_REGION? (yes/no) [yes]: " reconfig_choice
+            reconfig_choice="${reconfig_choice:-yes}"
+            if [[ "$reconfig_choice" == "yes" ]]; then
+                rm -f "$IAC_DIR/providers.tf"
+            fi
+        fi
+    fi
+
     # Generate providers.tf from template if it doesn't exist
     local backend_changed=false
     if [[ ! -f "$IAC_DIR/providers.tf" ]]; then
@@ -1667,7 +1735,6 @@ deploy_terraform() {
 
         echo ""
         print_info "Terraform remote state requires an S3 bucket."
-        print_info "Please create the bucket first if it doesn't exist."
         echo ""
 
         local tf_state_bucket=""
@@ -1680,6 +1747,8 @@ deploy_terraform() {
 
         local tf_state_region="$AWS_REGION"
         local tf_state_key="kolya-br-proxy/tf.state"
+
+        _ensure_s3_bucket "$tf_state_bucket" "$tf_state_region"
 
         export TF_STATE_BUCKET="$tf_state_bucket"
         export TF_STATE_REGION="$tf_state_region"
@@ -1849,11 +1918,39 @@ deploy_terraform() {
         fi
     fi
 
-    # Terraform apply
+    # Terraform apply (with auto-recovery for Secrets Manager conflicts)
     print_substep "Deploying infrastructure..."
-    if ! terraform apply tfplan; then
-        print_error "Terraform apply failed"
-        exit 1
+    # Stream output to the terminal live AND capture it to a log for conflict inspection.
+    # PIPESTATUS[0] is terraform's real exit code (not tee's), so the conflict-recovery
+    # below still works while the user sees real-time "Still creating..." progress.
+    local apply_rc=0
+    terraform apply tfplan 2>&1 | tee /tmp/tf_apply_err.log
+    apply_rc=${PIPESTATUS[0]}
+    if [[ $apply_rc -ne 0 ]]; then
+        if grep -q "Secrets Manager Secret" /tmp/tf_apply_err.log && grep -q "scheduled for deletion\|ResourceExistsException\|already exists\|KMSInvalidStateException" /tmp/tf_apply_err.log; then
+            # Secrets Manager conflict (pending deletion, exists, or KMS issue) — force delete and retry
+            local sm_secret_id
+            sm_secret_id=$(grep "Secrets Manager Secret" /tmp/tf_apply_err.log | sed 's/.*Secret (\([^)]*\)).*/\1/' | head -1)
+            local sm_resource_addr
+            sm_resource_addr=$(grep "with " /tmp/tf_apply_err.log | sed 's/.*with \([^,]*\).*/\1/' | head -1)
+            if [[ -n "$sm_secret_id" ]]; then
+                print_warning "Secrets Manager conflict for '$sm_secret_id' — cleaning up and retrying..."
+                aws secretsmanager delete-secret --secret-id "$sm_secret_id" --force-delete-without-recovery --region "$AWS_REGION" 2>/dev/null || true
+                if [[ -n "$sm_resource_addr" ]]; then
+                    terraform state rm "$sm_resource_addr" 2>/dev/null || true
+                fi
+                print_info "Re-running terraform plan + apply..."
+                terraform plan -out=tfplan && terraform apply tfplan || { print_error "Terraform apply failed after cleanup"; exit 1; }
+            else
+                cat /tmp/tf_apply_err.log >&2
+                print_error "Terraform apply failed (Secrets Manager conflict but could not parse secret ID)"
+                exit 1
+            fi
+        else
+            cat /tmp/tf_apply_err.log >&2
+            print_error "Terraform apply failed"
+            exit 1
+        fi
     fi
 
     # Clean up plan file
@@ -1952,7 +2049,7 @@ build_and_push_images() {
     # Override AWS_REGION from tfvars (single source of truth), in case
     # 'aws configure get region' returned a different region than the deployment
     local tfvars_region
-    tfvars_region=$(_read_tfvar "region" 2>/dev/null || echo "")
+    tfvars_region=$(_read_tfvar "region")
     if [[ -n "$tfvars_region" ]]; then
         AWS_REGION="$tfvars_region"
         print_info "Region from tfvars: $AWS_REGION"
@@ -2112,7 +2209,7 @@ deploy_application() {
     local ops_low
     ops_low=$(_read_tfvar "ops_low")
     if [[ "$ops_low" == "true" ]]; then
-        export KARPENTER_NODEPOOL="general-purpose"
+        export KARPENTER_NODEPOOL="graviton-pool"
     else
         export KARPENTER_NODEPOOL="common-nodepool"
     fi

--- a/deploy-all.sh
+++ b/deploy-all.sh
@@ -22,6 +22,10 @@ set -e
 # Disable AWS CLI pager so commands never block waiting for user input
 export AWS_PAGER=""
 
+# Use BuildKit (not the deprecated legacy builder) — handles --platform
+# cross-builds natively and silences the "legacy builder is deprecated" warning.
+export DOCKER_BUILDKIT=1
+
 # Color definitions
 RED='\033[0;31m'
 GREEN='\033[0;32m'

--- a/deploy-to-existing.sh
+++ b/deploy-to-existing.sh
@@ -27,6 +27,10 @@
 
 set -e
 
+# Use BuildKit (not the deprecated legacy builder) — handles --platform
+# cross-builds natively and silences the "legacy builder is deprecated" warning.
+export DOCKER_BUILDKIT=1
+
 # Color definitions
 RED='\033[0;31m'
 GREEN='\033[0;32m'

--- a/destroy.sh
+++ b/destroy.sh
@@ -430,6 +430,47 @@ cleanup_k8s_resources() {
 
     echo ""
     print_success "Kubernetes resources cleanup complete"
+
+    # Wait for Karpenter to reclaim all nodes (empty nodes get terminated after workloads are gone)
+    print_header "Waiting for Karpenter Node Reclamation"
+    print_info "Karpenter will terminate empty nodes after workloads are removed."
+    print_info "This must complete before destroying VPC/subnets to avoid dependency errors."
+    echo ""
+
+    local node_max_wait=300
+    local node_waited=0
+    while [[ $node_waited -lt $node_max_wait ]]; do
+        # Count nodes managed by Karpenter (any node carrying the karpenter.sh/nodepool
+        # label — covers graviton-pool in Auto Mode and common-nodepool otherwise)
+        local karpenter_nodes
+        karpenter_nodes=$(kubectl get nodes -l 'karpenter.sh/nodepool' --no-headers 2>/dev/null | wc -l | xargs)
+
+        if [[ "$karpenter_nodes" -eq 0 ]]; then
+            print_success "All Karpenter-managed nodes have been reclaimed"
+            break
+        fi
+
+        if [[ $((node_waited % 30)) -eq 0 ]]; then
+            print_info "Waiting for $karpenter_nodes Karpenter node(s) to be reclaimed... (${node_waited}s/${node_max_wait}s)"
+        fi
+        sleep 10
+        node_waited=$((node_waited + 10))
+    done
+
+    if [[ $node_waited -ge $node_max_wait ]]; then
+        print_warning "Timeout waiting for Karpenter node reclamation (${node_max_wait}s)"
+        local remaining_nodes
+        remaining_nodes=$(kubectl get nodes -l 'karpenter.sh/nodepool' --no-headers 2>/dev/null || true)
+        if [[ -n "$remaining_nodes" ]]; then
+            echo "$remaining_nodes"
+            echo ""
+            read -p "Proceed with destroy anyway? Remaining nodes may cause VPC dependency errors. (yes/no): " proceed_anyway
+            if [[ "$proceed_anyway" != "yes" ]]; then
+                print_info "Destroy cancelled. Please manually drain/delete remaining nodes and retry."
+                exit 1
+            fi
+        fi
+    fi
 }
 
 # Initialize Terraform backend and select workspace (shared by disable_waf_and_ga + destroy)

--- a/frontend/src/components/DataManagementCard.vue
+++ b/frontend/src/components/DataManagementCard.vue
@@ -1,0 +1,303 @@
+<template>
+  <q-card>
+    <q-card-section>
+      <div class="text-h6 q-mb-md">Data Management</div>
+      <div class="text-caption text-grey q-mb-lg">
+        Export or import application configuration (users, teams, API tokens, alerts, Entra group mappings).
+      </div>
+
+      <!-- Export -->
+      <div class="q-mb-lg">
+        <div class="text-subtitle2 q-mb-sm">Export Configuration</div>
+        <div class="text-body2 text-grey q-mb-sm">
+          Download a JSON file containing all application settings and data.
+        </div>
+        <q-btn
+          label="Download Export"
+          icon="download"
+          color="grey-8"
+          unelevated
+          :loading="exporting"
+          @click="handleExport"
+        />
+      </div>
+
+      <q-separator class="q-mb-lg" />
+
+      <!-- Import -->
+      <div>
+        <div class="text-subtitle2 q-mb-sm">Import Configuration</div>
+        <div class="text-body2 text-grey q-mb-md">
+          Upload a previously exported JSON file to restore configuration.
+        </div>
+
+        <div class="row q-col-gutter-md items-end">
+          <div class="col-12 col-sm-6">
+            <q-file
+              v-model="importFile"
+              label="Select JSON file"
+              outlined
+              dense
+              accept=".json"
+              clearable
+            >
+              <template v-slot:prepend>
+                <q-icon name="attach_file" />
+              </template>
+            </q-file>
+          </div>
+
+          <div class="col-12 col-sm-4">
+            <q-select
+              v-model="conflictStrategy"
+              :options="strategyOptions"
+              label="Conflict Strategy"
+              outlined
+              dense
+              emit-value
+              map-options
+            />
+          </div>
+
+          <div class="col-12 col-sm-2">
+            <q-btn
+              label="Import"
+              icon="upload"
+              color="grey-8"
+              unelevated
+              :loading="importing"
+              :disable="!importFile"
+              @click="handleImport"
+            />
+          </div>
+        </div>
+      </div>
+    </q-card-section>
+
+    <!-- Import Results Dialog -->
+    <q-dialog v-model="showResults" persistent>
+      <q-card style="min-width: 600px; max-width: 800px;">
+        <q-card-section>
+          <div class="text-h6">Import Results</div>
+        </q-card-section>
+
+        <q-card-section class="q-pt-none">
+          <q-list dense separator>
+            <q-item v-for="(result, section) in importResults" :key="section">
+              <q-item-section>
+                <q-item-label>{{ sectionLabels[section] || section }}</q-item-label>
+              </q-item-section>
+              <q-item-section side>
+                <div class="row q-gutter-sm">
+                  <q-badge v-if="result.created" color="positive" :label="`+${result.created}`" />
+                  <q-badge v-if="result.skipped" color="grey" :label="`skipped ${result.skipped}`" />
+                  <q-badge v-if="result.overwritten" color="warning" text-color="dark" :label="`updated ${result.overwritten}`" />
+                  <q-badge v-if="result.errors?.length" color="negative" :label="`${result.errors.length} errors`" />
+                </div>
+              </q-item-section>
+            </q-item>
+          </q-list>
+
+          <!-- Failed entries — must be reconfigured manually -->
+          <div v-if="hasErrors" class="q-mt-md">
+            <q-banner class="bg-negative text-white q-mb-sm" dense rounded>
+              <template v-slot:avatar>
+                <q-icon name="error" />
+              </template>
+              {{ errorCount }} entr{{ errorCount === 1 ? 'y' : 'ies' }} failed to import and
+              must be reconfigured manually.
+            </q-banner>
+            <q-list dense bordered class="rounded-borders">
+              <template v-for="(result, section) in importResults" :key="'err-'+section">
+                <q-item
+                  v-for="(err, i) in (result.errors || [])"
+                  :key="section + '-' + i"
+                >
+                  <q-item-section avatar>
+                    <q-icon name="warning" color="negative" size="xs" />
+                  </q-item-section>
+                  <q-item-section>
+                    <q-item-label caption class="text-grey-7">
+                      {{ sectionLabels[section] || section }}
+                    </q-item-label>
+                    <q-item-label class="text-negative">{{ err }}</q-item-label>
+                  </q-item-section>
+                </q-item>
+              </template>
+            </q-list>
+          </div>
+
+          <!-- Generated Tokens -->
+          <div v-if="generatedKeys.length" class="q-mt-lg">
+            <q-banner class="bg-warning text-dark q-mb-sm" dense rounded>
+              <template v-slot:avatar>
+                <q-icon name="warning" />
+              </template>
+              Save these API tokens now — they cannot be shown again.
+            </q-banner>
+
+            <q-table
+              :rows="generatedKeys"
+              :columns="tokenColumns"
+              flat
+              dense
+              hide-bottom
+              :pagination="{ rowsPerPage: 0 }"
+            >
+              <template v-slot:body-cell-token="props">
+                <q-td :props="props">
+                  <code class="text-caption">{{ props.row.token }}</code>
+                  <q-btn
+                    flat
+                    dense
+                    round
+                    icon="content_copy"
+                    size="xs"
+                    class="q-ml-xs"
+                    @click="copyToken(props.row.token)"
+                  />
+                </q-td>
+              </template>
+            </q-table>
+          </div>
+        </q-card-section>
+
+        <q-card-actions align="right">
+          <q-btn flat label="Close" color="grey-8" @click="showResults = false" />
+        </q-card-actions>
+      </q-card>
+    </q-dialog>
+  </q-card>
+</template>
+
+<script setup lang="ts">
+import { ref, computed } from 'vue';
+import { Notify, copyToClipboard } from 'quasar';
+import { api } from 'src/boot/axios';
+import { extractErrorMessage } from 'src/utils/error';
+
+interface SectionResult {
+  created: number;
+  skipped: number;
+  overwritten: number;
+  errors: string[];
+  generated_keys?: { name: string; user_email: string; token: string }[];
+}
+
+const exporting = ref(false);
+const importing = ref(false);
+const importFile = ref<File | null>(null);
+const conflictStrategy = ref('skip');
+const showResults = ref(false);
+const importResults = ref<Record<string, SectionResult>>({});
+
+const strategyOptions = [
+  { label: 'Skip existing', value: 'skip' },
+  { label: 'Overwrite existing', value: 'overwrite' },
+];
+
+const sectionLabels: Record<string, string> = {
+  users: 'Users',
+  teams: 'Teams',
+  tokens: 'API Tokens',
+  team_members: 'Team Members',
+  alert_rules: 'Alert Rules',
+  entra_group_mappings: 'Entra Group Mappings',
+};
+
+const tokenColumns = [
+  { name: 'name', label: 'Name', field: 'name', align: 'left' as const },
+  { name: 'user_email', label: 'User', field: 'user_email', align: 'left' as const },
+  { name: 'token', label: 'Token', field: 'token', align: 'left' as const },
+];
+
+const generatedKeys = computed(() => {
+  return importResults.value.tokens?.generated_keys || [];
+});
+
+const errorCount = computed(() => {
+  return Object.values(importResults.value).reduce(
+    (sum, r) => sum + (r.errors?.length || 0),
+    0,
+  );
+});
+
+const hasErrors = computed(() => errorCount.value > 0);
+
+async function handleExport() {
+  exporting.value = true;
+  try {
+    const response = await api.get('/admin/data-management/export', {
+      responseType: 'blob',
+    });
+
+    const disposition = response.headers['content-disposition'] || '';
+    const match = disposition.match(/filename="(.+)"/);
+    const filename = match ? match[1] : 'config_export.json';
+
+    const blob = new Blob([response.data], { type: 'application/json' });
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement('a');
+    link.href = url;
+    link.download = filename;
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+    URL.revokeObjectURL(url);
+
+    Notify.create({ type: 'positive', message: 'Export downloaded', position: 'top' });
+  } catch (error: unknown) {
+    Notify.create({
+      type: 'negative',
+      message: extractErrorMessage(error, 'Export failed'),
+      position: 'top',
+    });
+  } finally {
+    exporting.value = false;
+  }
+}
+
+async function handleImport() {
+  if (!importFile.value) return;
+
+  importing.value = true;
+  try {
+    const formData = new FormData();
+    formData.append('file', importFile.value);
+    formData.append('conflict_strategy', conflictStrategy.value);
+
+    const { data } = await api.post('/admin/data-management/import', formData, {
+      headers: { 'Content-Type': 'multipart/form-data' },
+    });
+
+    importResults.value = data;
+    showResults.value = true;
+    importFile.value = null;
+
+    if (hasErrors.value) {
+      Notify.create({
+        type: 'warning',
+        message: `Import completed with ${errorCount.value} failed entr${errorCount.value === 1 ? 'y' : 'ies'} — see details`,
+        position: 'top',
+        timeout: 6000,
+      });
+    } else {
+      Notify.create({ type: 'positive', message: 'Import completed', position: 'top' });
+    }
+  } catch (error: unknown) {
+    Notify.create({
+      type: 'negative',
+      message: extractErrorMessage(error, 'Import failed'),
+      position: 'top',
+    });
+  } finally {
+    importing.value = false;
+  }
+}
+
+function copyToken(token: string) {
+  void copyToClipboard(token).then(() => {
+    Notify.create({ type: 'positive', message: 'Copied to clipboard', position: 'top' });
+  });
+}
+</script>

--- a/frontend/src/pages/ModelsPage.vue
+++ b/frontend/src/pages/ModelsPage.vue
@@ -23,7 +23,7 @@
         </div>
         <q-select
           v-model="selectedTokenId"
-          :options="tokenOptions"
+          :options="filteredTokenOptions"
           option-value="id"
           option-label="label"
           outlined
@@ -33,6 +33,9 @@
           emit-value
           map-options
           clearable
+          use-input
+          input-debounce="200"
+          @filter="filterTokens"
           @update:model-value="onTokenChange"
           :loading="tokensStore.loading"
           class="q-mb-md"
@@ -309,6 +312,18 @@ const tokenOptions = computed(() => {
     value: token.id,
   }));
 });
+
+// Client-side search for the API Key dropdown (use-input + @filter)
+const filteredTokenOptions = ref<{ id: string; label: string; value: string }[]>([]);
+
+function filterTokens(needle: string, update: (cb: () => void) => void) {
+  update(() => {
+    const term = needle.toLowerCase();
+    filteredTokenOptions.value = term
+      ? tokenOptions.value.filter(o => o.label.toLowerCase().includes(term))
+      : tokenOptions.value;
+  });
+}
 
 const currentToken = computed(() => {
   if (!selectedTokenId.value) return null;

--- a/frontend/src/pages/SettingsPage.vue
+++ b/frontend/src/pages/SettingsPage.vue
@@ -57,6 +57,11 @@
 
 
 
+      <!-- Data Management (super-admin only) -->
+      <div class="col-12" v-if="authStore.isSuperAdmin">
+        <DataManagementCard />
+      </div>
+
       <!-- Observability -->
       <div class="col-12">
         <q-card>
@@ -121,6 +126,7 @@ import { ref, computed, onMounted } from 'vue';
 import { useAuthStore } from 'src/stores/auth';
 import { Notify } from 'quasar';
 import { api } from 'src/boot/axios';
+import DataManagementCard from 'src/components/DataManagementCard.vue';
 
 const authStore = useAuthStore();
 

--- a/iac/README.md
+++ b/iac/README.md
@@ -90,6 +90,7 @@ After Terraform completes, proceed to Kubernetes add-ons and application deploym
 | <a name="input_eks_version"></a> [eks\_version](#input\_eks\_version) | EKS Kubernetes version | `string` | `"1.35"` | no |
 | <a name="input_enable_cognito"></a> [enable\_cognito](#input\_enable\_cognito) | Enable AWS Cognito for user authentication | `bool` | `true` | no |
 | <a name="input_enable_global_accelerator"></a> [enable\_global\_accelerator](#input\_enable\_global\_accelerator) | Enable AWS Global Accelerator for reduced latency | `bool` | `false` | no |
+| <a name="input_enable_microsoft"></a> [enable\_microsoft](#input\_enable\_microsoft) | Enable Microsoft Entra ID authentication (consumed by deploy-all.sh, not Terraform) | `bool` | `false` | no |
 | <a name="input_enable_waf"></a> [enable\_waf](#input\_enable\_waf) | Enable AWS WAF for rate limiting and security protection on ALBs | `bool` | `false` | no |
 | <a name="input_frontend_domain"></a> [frontend\_domain](#input\_frontend\_domain) | Frontend domain (e.g. kbp.kolya.fun) | `string` | `""` | no |
 | <a name="input_ga_api_alb_name"></a> [ga\_api\_alb\_name](#input\_ga\_api\_alb\_name) | Name of the API ALB for Global Accelerator (auto-discovery) | `string` | `"kolya-br-proxy-api-alb"` | no |

--- a/iac/main.tf
+++ b/iac/main.tf
@@ -34,6 +34,15 @@ module "vpc" {
   cluster_name = local.cluster_name
 }
 
+# Existing deployments created the VPC before it became count-indexed (when
+# egress_mode/byovpc was introduced). Without this, Terraform would destroy the
+# old un-indexed VPC and recreate it at index 0 — tearing down the network that
+# EKS and RDS run in. This block migrates the state address in place (no-op plan).
+moved {
+  from = module.vpc
+  to   = module.vpc[0]
+}
+
 # Unified network values (regardless of egress_mode)
 locals {
   vpc_id             = var.egress_mode == "byovpc" ? var.vpc_id : module.vpc[0].vpc_id

--- a/iac/modules/eks-addons/main.tf
+++ b/iac/modules/eks-addons/main.tf
@@ -152,6 +152,12 @@ resource "aws_secretsmanager_secret" "backend_secrets" {
   name       = "${local.resource_prefix}-backend-secrets"
   kms_key_id = aws_kms_key.secrets.arn
 
+  # Delete immediately on destroy (no recovery window) so a subsequent deploy can
+  # recreate the same-named secret without hitting "scheduled for deletion" — the
+  # value here is a placeholder ("{}") populated at runtime by External Secrets
+  # Operator, so there is nothing to recover. Mirrors the RDS password secret.
+  recovery_window_in_days = 0
+
   tags = var.default_tags
 }
 

--- a/iac/modules/eks-karpenter/eks.tf
+++ b/iac/modules/eks-karpenter/eks.tf
@@ -187,3 +187,11 @@ resource "aws_iam_role_policy_attachment" "node_group_ebs_csi_policy" {
   role       = module.eks.eks_managed_node_groups["core_node_group"].iam_role_name
   policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonEBSCSIDriverPolicy"
 }
+
+# This attachment became count-indexed when Auto Mode was introduced. Migrate
+# existing state from the un-indexed address so standard-mode upgrades see a
+# no-op instead of a destroy/recreate.
+moved {
+  from = aws_iam_role_policy_attachment.node_group_ebs_csi_policy
+  to   = aws_iam_role_policy_attachment.node_group_ebs_csi_policy[0]
+}

--- a/iac/variables.tf
+++ b/iac/variables.tf
@@ -107,11 +107,18 @@ variable "public_subnet_ids" {
   default     = []
 }
 
-# Cognito configuration
+# Authentication configuration
 variable "enable_cognito" {
   description = "Enable AWS Cognito for user authentication"
   type        = bool
   default     = true
+}
+
+# tflint-ignore: terraform_unused_declarations
+variable "enable_microsoft" {
+  description = "Enable Microsoft Entra ID authentication (consumed by deploy-all.sh, not Terraform)"
+  type        = bool
+  default     = false
 }
 
 variable "cognito_callback_urls" {

--- a/k8s/infrastructure/helm-installations/install.sh
+++ b/k8s/infrastructure/helm-installations/install.sh
@@ -44,24 +44,62 @@ if [[ "${EKS_MODE}" == "auto" ]]; then
     SKIP_KARPENTER=true
     SKIP_METRICS_SERVER=true
 
-    # Patch general-purpose nodepool: arm64 (Graviton) + resource limits
-    info "Patching general-purpose nodepool (arch=arm64, limits)..."
-    if kubectl get nodepool general-purpose &>/dev/null; then
-        kubectl patch nodepool general-purpose --type='merge' -p='
-        {
-          "spec": {
-            "limits": {"cpu": "1000", "memory": "1000Gi"},
-            "template": {"spec": {"requirements": [
-              {"key": "karpenter.sh/capacity-type", "operator": "In", "values": ["on-demand"]},
-              {"key": "eks.amazonaws.com/instance-category", "operator": "In", "values": ["c", "m", "r"]},
-              {"key": "eks.amazonaws.com/instance-generation", "operator": "Gt", "values": ["4"]},
-              {"key": "kubernetes.io/arch", "operator": "In", "values": ["arm64"]},
-              {"key": "kubernetes.io/os", "operator": "In", "values": ["linux"]}
-            ]}}
-          }
-        }' \
-            && success "NodePool patched: arch=arm64, limits=1000cpu/1000Gi" \
-            || warning "Failed to patch nodepool (may already be configured)"
+    # Ensure ALB IngressClass exists (EKS Auto Mode's built-in ALBC needs it)
+    if ! kubectl get ingressclass alb &>/dev/null; then
+        info "Creating IngressClass 'alb' for EKS Auto Mode..."
+        kubectl apply -f - <<'INGRESSCLASS'
+apiVersion: networking.k8s.io/v1
+kind: IngressClass
+metadata:
+  name: alb
+  annotations:
+    ingressclass.kubernetes.io/is-default-class: "true"
+spec:
+  controller: eks.amazonaws.com/alb
+INGRESSCLASS
+        info "IngressClass 'alb' created"
+    else
+        info "IngressClass 'alb' already exists"
+    fi
+
+    # Create custom arm64 NodePool (built-in "general-purpose" is immutable and locked to amd64)
+    if kubectl get nodepool graviton-pool &>/dev/null; then
+        info "NodePool 'graviton-pool' already exists"
+    else
+        info "Creating custom NodePool 'graviton-pool' (arm64/Graviton)..."
+        kubectl apply -f - <<'NODEPOOL'
+apiVersion: karpenter.sh/v1
+kind: NodePool
+metadata:
+  name: graviton-pool
+spec:
+  template:
+    spec:
+      nodeClassRef:
+        group: eks.amazonaws.com
+        kind: NodeClass
+        name: default
+      requirements:
+        - key: karpenter.sh/capacity-type
+          operator: In
+          values: ["on-demand"]
+        - key: eks.amazonaws.com/instance-category
+          operator: In
+          values: ["c", "m", "r"]
+        - key: eks.amazonaws.com/instance-generation
+          operator: Gt
+          values: ["4"]
+        - key: kubernetes.io/arch
+          operator: In
+          values: ["arm64"]
+        - key: kubernetes.io/os
+          operator: In
+          values: ["linux"]
+  limits:
+    cpu: "1000"
+    memory: 1000Gi
+NODEPOOL
+        info "NodePool 'graviton-pool' created"
     fi
 fi
 


### PR DESCRIPTION
## Summary

Two independent workstreams bundled here:

### 1. Data management — super-admin config export/import
- New `/admin/data-management/export` and `/import` endpoints (JSON, `skip`/`overwrite` conflict strategies), backed by `DataManagementService`.
- Covers users, teams, API tokens, team members, alert rules, and Entra group mappings.
- **Token security**: keys are regenerated on import (cross-environment `JWT_SECRET_KEY` differs); export never includes `token_hash`/`encrypted_token`.
- Failed entries surface per-row in the UI so they can be reconfigured manually.
- `DataManagementCard` added to the Settings page; new `DATA_EXPORTED`/`DATA_IMPORTED` audit actions.

### 2. EKS Auto Mode / deployment fixes
- **`deploy-all.sh`**: stream `terraform apply` via `tee` for real-time progress while keeping the log for Secrets Manager conflict auto-recovery (previously the redirect-to-file approach hid all progress).
- **`backend_secrets`** (`eks-addons`): `recovery_window_in_days = 0` so destroy → redeploy no longer collides with a pending-deletion secret (mirrors the RDS module).
- **`destroy.sh`**: match Karpenter nodes by label key (covers both `graviton-pool` in Auto Mode and `common-nodepool` otherwise); `exit 1` when the user declines teardown.
- **`install.sh`**: create a dedicated arm64 `graviton-pool` NodePool and the `alb` IngressClass for Auto Mode.

## Test
- `pre-commit run --all-files` — all hooks pass (terraform fmt/docs/validate/tflint, ruff, ESLint, detect-secrets).
- Deployed to prod (Auto Mode): cluster + addons healthy, backend/frontend pods Running, ingress ALBs provisioned, DNS resolving.