### PR TITLE
feat: email API keys to associated recipients

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -25,6 +25,9 @@ __pycache__
 .pytest_cache
 .mypy_cache
 .ruff_cache
+.venv
+venv/
+*.egg-info
 
 # Node
 node_modules
@@ -35,6 +38,15 @@ iac-*/
 k8s/
 .github/
 docs/
+
+# Large subtrees the backend image doesn't need (it only COPYs backend/ + deps).
+# Frontend builds use frontend/ as their own context, so excluding it here
+# only affects the root-context backend build.
+frontend/
+kolya-br-proxy-arch/
+benchmark/
+assets/
+graphify-out/
 
 # Other
 .claude/

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -184,7 +184,7 @@
         "filename": "deploy-all.sh",
         "hashed_secret": "5ffe533b830f08a0326348a9160afafc8ada44db",
         "is_verified": false,
-        "line_number": 2709
+        "line_number": 2705
       }
     ],
     "frontend/src/pages/EntraGroupsPage.vue": [
@@ -3881,5 +3881,5 @@
       }
     ]
   },
-  "generated_at": "2026-05-31T12:41:33Z"
+  "generated_at": "2026-05-31T15:03:44Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -193,7 +193,7 @@
         "filename": "frontend/src/pages/EntraGroupsPage.vue",
         "hashed_secret": "d87c448044defb778f33158d8ccf94a20531d600",
         "is_verified": false,
-        "line_number": 142
+        "line_number": 146
       }
     ],
     "kolya-br-proxy-arch/pnpm-lock.yaml": [
@@ -3881,5 +3881,5 @@
       }
     ]
   },
-  "generated_at": "2026-05-31T15:03:44Z"
+  "generated_at": "2026-06-01T00:10:29Z"
 }

--- a/backend/alembic/versions/v3w4x5y6z7a8_add_notify_emails_to_api_tokens.py
+++ b/backend/alembic/versions/v3w4x5y6z7a8_add_notify_emails_to_api_tokens.py
@@ -1,0 +1,28 @@
+"""add notify_emails to api_tokens
+
+Revision ID: v3w4x5y6z7a8
+Revises: u2v3w4x5y6z7
+Create Date: 2026-05-31
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision = "v3w4x5y6z7a8"
+down_revision = "u2v3w4x5y6z7"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "api_tokens",
+        sa.Column("notify_emails", postgresql.ARRAY(sa.String()), nullable=True),
+    )
+    op.execute("ALTER TYPE auditaction ADD VALUE IF NOT EXISTS 'API_KEY_NOTIFIED'")
+
+
+def downgrade() -> None:
+    op.drop_column("api_tokens", "notify_emails")

--- a/backend/app/api/admin/endpoints/tokens.py
+++ b/backend/app/api/admin/endpoints/tokens.py
@@ -2,6 +2,7 @@
 API Token management endpoints.
 """
 
+import asyncio
 import calendar
 import csv
 import io
@@ -34,6 +35,7 @@ from app.models.usage import UsageRecord
 from app.models.user import User, UserRole
 from app.services.audit_log import AuditLogService
 from app.services.auth import AuthService
+from app.services.notification import send_email
 from app.services.token import TokenService
 
 router = APIRouter()
@@ -127,6 +129,7 @@ class UpdateTokenRequest(BaseModel):
     monthly_quota_usd: Decimal | None = None
     monthly_reset_policy: str | None = None
     allowed_ips: List[str] | None = None
+    notify_emails: List[str] | None = None
     is_active: bool | None = None
     token_metadata: dict | None = None
 
@@ -148,6 +151,7 @@ class TokenResponse(BaseModel):
     daily_used_usd: str | None = None
     remaining_quota: str | None
     allowed_ips: List[str]
+    notify_emails: List[str]
     is_active: bool
     is_expired: bool
     is_quota_exceeded: bool
@@ -277,6 +281,7 @@ def build_token_response(
         daily_used_usd=str(daily_used_usd) if daily_used_usd is not None else None,
         remaining_quota=str(token.remaining_quota) if token.remaining_quota else None,
         allowed_ips=token.allowed_ips or [],
+        notify_emails=token.notify_emails or [],
         is_active=token.is_active,
         is_expired=token.is_expired,
         is_quota_exceeded=token.is_quota_exceeded,
@@ -754,6 +759,8 @@ async def update_token(
         token.monthly_reset_policy = request.monthly_reset_policy
     if request.allowed_ips is not None:
         token.allowed_ips = request.allowed_ips
+    if request.notify_emails is not None:
+        token.notify_emails = request.notify_emails
     if request.is_active is not None:
         token.is_active = request.is_active
     if request.token_metadata is not None:
@@ -935,6 +942,119 @@ async def get_plain_token(
         )
 
     return {"token": plain_token}
+
+
+class NotifyKeyRequest(BaseModel):
+    """Email this key's value to its associated users.
+
+    If ``emails`` is provided it overrides the token's stored notify_emails
+    for this send (without persisting). Otherwise the stored list is used.
+    """
+
+    emails: List[str] | None = None
+
+
+class NotifyKeyResponse(BaseModel):
+    """Result of a notify-key send."""
+
+    sent: bool
+    recipients: List[str]
+
+
+@router.post("/{token_id}/notify", response_model=NotifyKeyResponse)
+async def notify_token(
+    token_id: str,
+    request: NotifyKeyRequest,
+    current_user: User = Depends(require_permission("manage_api_keys")),
+    token_service: TokenService = Depends(get_token_service),
+    audit_service: AuditLogService = Depends(get_audit_log_service),
+):
+    """
+    Email the plain key value to its associated users.
+
+    - **token_id**: Token UUID
+    - **emails**: Optional recipient override; defaults to the token's stored
+      ``notify_emails``.
+
+    Sends the decrypted key to every recipient (one key may serve many users).
+    """
+    check_resource_scope(current_user, "manage_api_keys", token_id)
+
+    try:
+        token_uuid = UUID(token_id)
+    except ValueError:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Invalid token ID format",
+        )
+
+    token = await token_service.get_token_by_id(token_uuid)
+    if not token:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Token not found",
+        )
+
+    if token.user_id != current_user.id:
+        allowed = get_allowed_resource_ids(current_user, "manage_api_keys")
+        if allowed is not None and str(token.id) not in allowed:
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="Access denied",
+            )
+
+    recipients = [
+        e.strip()
+        for e in (request.emails or token.notify_emails or [])
+        if e and e.strip()
+    ]
+    if not recipients:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="No recipient emails configured for this key",
+        )
+
+    # Decrypt the already-loaded token directly — avoids a second DB round-trip
+    # that get_plain_token() would incur re-fetching the same row.
+    try:
+        plain_token = (
+            decrypt_token(token.encrypted_token) if token.encrypted_token else None
+        )
+    except Exception:
+        plain_token = None
+    if not plain_token:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Failed to decrypt token",
+        )
+
+    subject = f"Your API Key: {token.name}"
+    body = (
+        f"Hello,\n\n"
+        f'You have been granted access to the API key "{token.name}".\n\n'
+        f"API Key: {plain_token}\n\n"
+        f"Keep this key secret. Do not share it outside your team.\n\n"
+        f"— Kolya BR Proxy"
+    )
+
+    sent = await asyncio.to_thread(send_email, subject, body, recipients)
+    if not sent:
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail=(
+                "Email delivery failed or is not configured (ALERT_SES_SENDER_EMAIL)."
+            ),
+        )
+
+    await audit_service.log(
+        action=AuditAction.API_KEY_NOTIFIED,
+        user=current_user,
+        resource_type="api_token",
+        resource_id=str(token.id),
+        details={"name": token.name, "recipient_count": len(recipients)},
+    )
+
+    return NotifyKeyResponse(sent=True, recipients=recipients)
 
 
 class AdjustBalanceRequest(BaseModel):

--- a/backend/app/models/audit_log.py
+++ b/backend/app/models/audit_log.py
@@ -35,6 +35,7 @@ class AuditAction(enum.Enum):
     # API Token Management
     API_TOKEN_CREATED = "api_token_created"
     API_TOKEN_REVOKED = "api_token_revoked"
+    API_KEY_NOTIFIED = "api_key_notified"  # pragma: allowlist secret  # nosemgrep
 
     # User Management
     USER_CREATED = "user_created"

--- a/backend/app/models/token.py
+++ b/backend/app/models/token.py
@@ -38,6 +38,9 @@ class APIToken(Base):
     # Access control
     allowed_ips = Column(ARRAY(String), nullable=True)
 
+    # Email addresses to notify with this key's value (one key, many users)
+    notify_emails = Column(ARRAY(String), nullable=True)
+
     # Status
     is_active = Column(Boolean, default=True, nullable=False)
     is_deleted = Column(Boolean, default=False, nullable=False)

--- a/backend/app/services/data_management.py
+++ b/backend/app/services/data_management.py
@@ -170,6 +170,7 @@ class DataManagementService:
                     else None,
                     "monthly_reset_policy": t.monthly_reset_policy,
                     "allowed_ips": t.allowed_ips or [],
+                    "notify_emails": t.notify_emails or [],
                     "is_active": t.is_active,
                     "token_metadata": t.token_metadata,
                     "allowed_models": model_names,
@@ -418,6 +419,8 @@ class DataManagementService:
                     )
                     if "allowed_ips" in item:
                         existing.allowed_ips = item["allowed_ips"]
+                    if "notify_emails" in item:
+                        existing.notify_emails = item["notify_emails"]
                     if "token_metadata" in item:
                         existing.token_metadata = item["token_metadata"]
                     if "is_active" in item:
@@ -450,6 +453,7 @@ class DataManagementService:
                     if item.get("monthly_quota_usd")
                     else None,
                     allowed_ips=item.get("allowed_ips", []),
+                    notify_emails=item.get("notify_emails", []),
                     token_metadata=item.get("token_metadata"),
                     is_active=item.get("is_active", True),
                 )

--- a/backend/app/services/notification.py
+++ b/backend/app/services/notification.py
@@ -21,27 +21,40 @@ def _get_ses_client():
     return _ses_client
 
 
-def dispatch_alert(message: str, notify_email: str) -> None:
-    """Send alert email. Called via asyncio.to_thread to avoid blocking."""
+def send_email(subject: str, body: str, recipients: list[str]) -> bool:
+    """Send a plain-text email to one or more recipients via SES.
+
+    Returns True if the message was handed to SES, False if skipped (sender
+    not configured / no recipients) or if SES rejected it. Call via
+    asyncio.to_thread to avoid blocking the event loop.
+    """
     settings = get_settings()
     sender = settings.ALERT_SES_SENDER_EMAIL
     if not sender:
-        logger.debug("SES sender not configured, skipping email")
-        return
+        logger.warning("SES sender not configured, cannot send email")
+        return False
 
-    addresses = [e.strip() for e in notify_email.split(",") if e.strip()]
+    addresses = [e.strip() for e in recipients if e and e.strip()]
     if not addresses:
-        return
+        return False
 
     try:
         _get_ses_client().send_email(
             Source=sender,
             Destination={"ToAddresses": addresses},
             Message={
-                "Subject": {"Data": "KBP Alert Notification", "Charset": "UTF-8"},
-                "Body": {"Text": {"Data": message, "Charset": "UTF-8"}},
+                "Subject": {"Data": subject, "Charset": "UTF-8"},
+                "Body": {"Text": {"Data": body, "Charset": "UTF-8"}},
             },
         )
-        logger.info("Alert email sent to %s", addresses)
+        logger.info("Email '%s' sent to %s", subject, addresses)
+        return True
     except ClientError:
-        logger.warning("Failed to send alert email to %s", addresses, exc_info=True)
+        logger.warning("Failed to send email to %s", addresses, exc_info=True)
+        return False
+
+
+def dispatch_alert(message: str, notify_email: str) -> None:
+    """Send alert email. Called via asyncio.to_thread to avoid blocking."""
+    addresses = [e.strip() for e in notify_email.split(",") if e.strip()]
+    send_email("KBP Alert Notification", message, addresses)

--- a/docs/alerts.md
+++ b/docs/alerts.md
@@ -56,6 +56,10 @@ Each rule independently configures notification delivery:
 - **In-app** (default: enabled) — Creates `AlertNotification` record, visible via bell icon in header
 - **Email** (optional) — Sends via AWS SES to comma-separated addresses
 
+Email is also used by the **API Key delivery** feature (Tokens page → email action),
+which sends a key's plaintext value to its associated recipients. Both share the same
+SES configuration documented below.
+
 ## Cooldown
 
 Each rule has a `cooldown_hours` setting (default: 24h). After firing, the same rule won't fire again until the cooldown expires. This prevents notification floods when spending stays above threshold.
@@ -139,4 +143,97 @@ async def check_alerts_for_usage(token_id, user_id, db):
 | `KBR_ALERT_SES_SENDER_EMAIL` | SES verified sender (e.g. `noreply@kbp.kolya.fun`) |
 | `KBR_ALERT_SES_REGION` | AWS region for SES (defaults to `AWS_REGION`) |
 
-If `ALERT_SES_SENDER_EMAIL` is not configured, email notifications are silently skipped.
+If `ALERT_SES_SENDER_EMAIL` is not configured, email notifications are silently skipped
+(the backend logs `SES sender not configured, cannot send email` and the API key
+notify endpoint returns `502`).
+
+## Enabling Email Delivery (SES Setup)
+
+All commands below target the backend's region (`us-east-1` in prod). Set
+`export AWS_PROFILE=<admin-profile>` first. Steps 1–3 are one-time per AWS account/region;
+step 4 is per deployment.
+
+### 1. Move SES out of the sandbox (production access)
+
+A fresh SES account is in **sandbox** mode — it can only send to pre-verified
+addresses. Request production access once per region:
+
+```bash
+aws sesv2 put-account-details \
+  --production-access-enabled \
+  --mail-type TRANSACTIONAL \
+  --website-url "https://kbp.kolya.icu" \
+  --contact-language EN \
+  --use-case-description "Internal transactional emails: delivering API keys to colleagues and usage/quota alerts. Internal recipients only, <50 emails/day." \
+  --region us-east-1
+```
+
+Check status (AWS review takes a few hours to ~1 business day):
+
+```bash
+aws sesv2 get-account --region us-east-1 \
+  --query '{ProductionAccessEnabled:ProductionAccessEnabled,SendingEnabled:SendingEnabled,ReviewStatus:Details.ReviewDetails.Status}'
+```
+
+Approved when `ProductionAccessEnabled: true` and `ReviewStatus: GRANTED`.
+
+> Sandbox mode is **not** required for testing — if you only ever send to a verified
+> address (step 2), you can skip production access. It's needed to email arbitrary recipients.
+
+### 2. Verify a sender identity
+
+The `From` address (`KBR_ALERT_SES_SENDER_EMAIL`) must be a verified SES identity,
+even after production access is granted:
+
+```bash
+aws ses verify-email-identity --email-address <sender@example.com> --region us-east-1
+```
+
+This sends a confirmation email — click the link in it. Then confirm:
+
+```bash
+aws sesv2 get-email-identity --email-identity <sender@example.com> --region us-east-1 \
+  --query '{Type:IdentityType,Verified:VerifiedForSendingStatus}'
+```
+
+Ready when `Verified: true`. (Verifying a whole domain instead of a single address is
+also supported via `verify-domain-identity` + DNS records.)
+
+> Corporate domains (e.g. `@amazon.com`) may have mail gateways that quarantine AWS
+> verification emails — check spam, or use an address you control externally.
+
+### 3. Confirm IAM permissions
+
+The backend pod's role (EKS Pod Identity, SA `backend` in namespace `kbp`) needs
+`ses:SendEmail` / `ses:SendRawEmail`. In this project it's already in the
+`*-backend-bedrock` policy. To verify:
+
+```bash
+ASSOC=$(aws eks list-pod-identity-associations --cluster-name <cluster> --region us-east-1 \
+  --query "associations[?serviceAccount=='backend'&&namespace=='kbp'].associationId | [0]" --output text)
+ROLE=$(aws eks describe-pod-identity-association --cluster-name <cluster> --region us-east-1 \
+  --association-id "$ASSOC" --query 'association.roleArn' --output text)
+# inspect the attached policy for ses:SendEmail
+```
+
+### 4. Configure the backend and restart
+
+Add the verified sender to the backend ConfigMap source
+(`k8s/application/backend-configmap.yaml`):
+
+```yaml
+data:
+  KBR_ALERT_SES_SENDER_EMAIL: "<sender@example.com>"
+```
+
+Apply and roll the deployment:
+
+```bash
+kubectl apply -f k8s/application/backend-configmap.yaml
+kubectl rollout restart deploy/backend -n kbp
+kubectl rollout status deploy/backend -n kbp
+# verify the var landed in the new pods
+kubectl exec -n kbp deploy/backend -- printenv KBR_ALERT_SES_SENDER_EMAIL
+```
+
+Email delivery is now live. Trigger an alert or use the Tokens page email action to test.

--- a/docs/alerts.zh.md
+++ b/docs/alerts.zh.md
@@ -56,6 +56,9 @@ API 请求 → record_usage() → check_alerts_for_usage() → AlertNotification
 - **应用内通知**（默认启用）— 创建 `AlertNotification` 记录，通过顶部铃铛图标查看
 - **邮件**（可选）— 通过 AWS SES 发送到逗号分隔的邮箱地址列表
 
+邮件同样用于 **API Key 分发** 功能（Tokens 页面 → 邮件动作），把某个 Key 的明文值
+发送给其关联收件人。两者共用下方的同一套 SES 配置。
+
 ## 冷却机制
 
 每条规则有 `cooldown_hours` 设置（默认 24 小时）。触发后，同一规则在冷却期内不会重复触发，防止通知风暴。
@@ -139,4 +142,96 @@ async def check_alerts_for_usage(token_id, user_id, db):
 | `KBR_ALERT_SES_SENDER_EMAIL` | SES 验证发件人（如 `noreply@kbp.kolya.fun`） |
 | `KBR_ALERT_SES_REGION` | SES 的 AWS 区域（默认使用 `AWS_REGION`） |
 
-如果未配置 `ALERT_SES_SENDER_EMAIL`，邮件通知会静默跳过。
+如果未配置 `ALERT_SES_SENDER_EMAIL`，邮件通知会静默跳过（后端日志打印
+`SES sender not configured, cannot send email`，API Key 通知接口返回 `502`）。
+
+## 开启邮件发送（SES 配置）
+
+以下命令均针对后端所在区域（生产环境为 `us-east-1`）。先执行
+`export AWS_PROFILE=<admin-profile>`。步骤 1–3 每个 AWS 账号/区域只需做一次，
+步骤 4 每次部署执行。
+
+### 1. 将 SES 移出 sandbox（申请 production access）
+
+新的 SES 账号处于 **sandbox** 模式 —— 只能发给预先验证过的地址。每个区域申请一次
+production access：
+
+```bash
+aws sesv2 put-account-details \
+  --production-access-enabled \
+  --mail-type TRANSACTIONAL \
+  --website-url "https://kbp.kolya.icu" \
+  --contact-language EN \
+  --use-case-description "Internal transactional emails: delivering API keys to colleagues and usage/quota alerts. Internal recipients only, <50 emails/day." \
+  --region us-east-1
+```
+
+查看状态（AWS 审核需几小时到约一个工作日）：
+
+```bash
+aws sesv2 get-account --region us-east-1 \
+  --query '{ProductionAccessEnabled:ProductionAccessEnabled,SendingEnabled:SendingEnabled,ReviewStatus:Details.ReviewDetails.Status}'
+```
+
+`ProductionAccessEnabled: true` 且 `ReviewStatus: GRANTED` 即通过。
+
+> 测试**不一定**需要 production access —— 如果只发给已验证的地址（步骤 2），可以跳过此步。
+> 要给任意收件人发邮件时才需要。
+
+### 2. 验证发件身份
+
+发件地址（`KBR_ALERT_SES_SENDER_EMAIL`）必须是已验证的 SES 身份，即使 production
+access 已通过也是如此：
+
+```bash
+aws ses verify-email-identity --email-address <sender@example.com> --region us-east-1
+```
+
+该命令会发一封确认邮件 —— 点击其中的链接。然后确认：
+
+```bash
+aws sesv2 get-email-identity --email-identity <sender@example.com> --region us-east-1 \
+  --query '{Type:IdentityType,Verified:VerifiedForSendingStatus}'
+```
+
+`Verified: true` 即就绪。（也支持用 `verify-domain-identity` + DNS 记录验证整个域名，
+而非单个地址。）
+
+> 企业域名（如 `@amazon.com`）的邮件网关可能拦截 AWS 验证邮件 —— 留意垃圾箱，
+> 或改用你能在外部收信的地址。
+
+### 3. 确认 IAM 权限
+
+后端 pod 的角色（EKS Pod Identity，命名空间 `kbp` 下的 SA `backend`）需要
+`ses:SendEmail` / `ses:SendRawEmail`。本项目中它已包含在 `*-backend-bedrock` 策略里。
+验证方式：
+
+```bash
+ASSOC=$(aws eks list-pod-identity-associations --cluster-name <cluster> --region us-east-1 \
+  --query "associations[?serviceAccount=='backend'&&namespace=='kbp'].associationId | [0]" --output text)
+ROLE=$(aws eks describe-pod-identity-association --cluster-name <cluster> --region us-east-1 \
+  --association-id "$ASSOC" --query 'association.roleArn' --output text)
+# 检查该角色附加的策略中是否含 ses:SendEmail
+```
+
+### 4. 配置后端并重启
+
+把已验证的发件人加到后端 ConfigMap 源文件
+（`k8s/application/backend-configmap.yaml`）：
+
+```yaml
+data:
+  KBR_ALERT_SES_SENDER_EMAIL: "<sender@example.com>"
+```
+
+应用并滚动重启：
+
+```bash
+kubectl apply -f k8s/application/backend-configmap.yaml
+kubectl rollout restart deploy/backend -n kbp
+kubectl rollout status deploy/backend -n kbp
+# 确认变量进入新 pod
+kubectl exec -n kbp deploy/backend -- printenv KBR_ALERT_SES_SENDER_EMAIL
+```
+
+邮件发送即生效。触发一条告警，或用 Tokens 页面的邮件动作测试。

--- a/frontend/.dockerignore
+++ b/frontend/.dockerignore
@@ -1,0 +1,32 @@
+# Dependencies — reinstalled inside the image via `npm ci`
+node_modules
+
+# Build output — regenerated inside the image via `npm run build`
+dist
+.quasar
+
+# Environment files (secrets must not be baked into images)
+.env
+.env.*
+!.env.example
+
+# Git / VCS
+.git
+.gitignore
+
+# IDE / editor
+.idea
+.vscode
+*.swp
+*.swo
+
+# OS cruft
+.DS_Store
+
+# Logs and caches
+*.log
+.npm
+.eslintcache
+
+# Docs / misc not needed for the build
+*.md

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -3024,13 +3024,16 @@
       "license": "MIT"
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.8.31",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.8.31.tgz",
-      "integrity": "sha512-a28v2eWrrRWPpJSzxc+mKwm0ZtVx/G8SepdQZDArnXYU/XS+IF6mp8aB/4E+hH1tyGCoDo3KlUCdlSxGDsRkAw==",
+      "version": "2.10.33",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.33.tgz",
+      "integrity": "sha512-bA6+tcSLpz2tIEdDXZPpPTIuxBcC4+w6SieaYyfigIa4h8GlFxbA17v22Vx3JUtuZQj9SgOsnbK+aTBzyDyEuw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
-        "baseline-browser-mapping": "dist/cli.js"
+        "baseline-browser-mapping": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/birpc": {
@@ -3236,9 +3239,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001757",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001757.tgz",
-      "integrity": "sha512-r0nnL/I28Zi/yjk1el6ilj27tKcdjLsNqAOZr0yVjWPrSQyHgKI2INaEWw21bAQSv2LXRt1XuCS/GomNpWOxsQ==",
+      "version": "1.0.30001793",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001793.tgz",
+      "integrity": "sha512-iwSsYWaCOoh26cV8NwNRViHlrfUvYsHDfRVcbtmw0Kg6PJIZZXwMkj1442FYLBGkeUf1juAsU3DTfxW579mrPA==",
       "dev": true,
       "funding": [
         {

--- a/frontend/src/css/app.scss
+++ b/frontend/src/css/app.scss
@@ -1,1 +1,18 @@
 // app global css in SCSS form
+//
+// Sizing here only touches buttons. Form controls are made compact by adding
+// Quasar's native `dense` prop on each field (40px, with the floating label
+// positioned correctly by Quasar) — NOT by overriding heights in CSS, which
+// breaks the floating-label geometry and overlaps the label with the value.
+
+// Default text/standard buttons match the dense-field height (40px) so a row
+// of "input + button" lines up. Round/fab/dense buttons keep their own sizing.
+.q-btn:not(.q-btn--round):not(.q-btn--fab):not(.q-btn--fab-mini):not(.q-btn--dense) {
+  min-height: 40px;
+  font-size: 13px;
+  padding: 0 14px;
+
+  .q-btn__content .q-icon {
+    font-size: 1.3em;
+  }
+}

--- a/frontend/src/layouts/MainLayout.vue
+++ b/frontend/src/layouts/MainLayout.vue
@@ -460,7 +460,9 @@ onUnmounted(() => {
   color: #e8eaed;
 }
 
-:deep(.q-btn) {
+// Standard (labelled) buttons only. Round/fab icon buttons must keep their
+// square aspect — adding horizontal padding here stretches them into ovals.
+:deep(.q-btn:not(.q-btn--round):not(.q-btn--fab):not(.q-btn--fab-mini)) {
   border-radius: 24px;
   text-transform: none;
   font-weight: 500;

--- a/frontend/src/pages/ActivityPage.vue
+++ b/frontend/src/pages/ActivityPage.vue
@@ -11,7 +11,7 @@
         @update:model-value="fetchActivity"
       />
       <q-space />
-      <q-btn flat icon="refresh" @click="fetchActivity" />
+      <q-btn flat dense round icon="refresh" @click="fetchActivity" />
     </div>
 
     <q-table

--- a/frontend/src/pages/AdminUsersPage.vue
+++ b/frontend/src/pages/AdminUsersPage.vue
@@ -100,7 +100,7 @@
           <p>Share this link with the invited admin:</p>
           <q-input :model-value="inviteLink" readonly outlined dense dark>
             <template v-slot:append>
-              <q-btn flat dense icon="content_copy" @click="copyInviteLink" />
+              <q-btn flat dense round icon="content_copy" @click="copyInviteLink" />
             </template>
           </q-input>
         </q-card-section>

--- a/frontend/src/pages/EntraGroupsPage.vue
+++ b/frontend/src/pages/EntraGroupsPage.vue
@@ -57,6 +57,7 @@
             v-model="form.entra_group_id"
             label="Entra Group ID"
             outlined
+            dense
             dark
             class="q-mb-md"
             hint="Azure AD security group object ID"
@@ -66,6 +67,7 @@
             v-model="form.group_name"
             label="Group Name"
             outlined
+            dense
             dark
             class="q-mb-md"
             hint="Display name for this group"
@@ -75,6 +77,7 @@
             :options="roleOptions"
             label="Role"
             outlined
+            dense
             dark
             class="q-mb-md"
           />
@@ -83,6 +86,7 @@
             label="Priority"
             type="number"
             outlined
+            dense
             dark
             class="q-mb-md"
             hint="Higher priority wins when user is in multiple groups"

--- a/frontend/src/pages/ModelsPage.vue
+++ b/frontend/src/pages/ModelsPage.vue
@@ -27,6 +27,7 @@
           option-value="id"
           option-label="label"
           outlined
+          dense
           rounded
           dark
           label="Select API Key"
@@ -160,6 +161,7 @@
             option-value="friendly_name"
             :label="selectedProvider === 'google' ? 'Select Gemini Model' : 'Select Model from AWS Bedrock'"
             outlined
+            dense
             dark
             :loading="loadingAwsModels"
             use-input

--- a/frontend/src/pages/MonitorPage.vue
+++ b/frontend/src/pages/MonitorPage.vue
@@ -196,6 +196,7 @@
             <q-btn
               flat
               dense
+              round
               icon="refresh"
               color="primary"
               :loading="monitorStore.loadingPricing"

--- a/frontend/src/pages/PlaygroundPage.vue
+++ b/frontend/src/pages/PlaygroundPage.vue
@@ -15,6 +15,7 @@
               label="API Key"
               outlined
               rounded
+              dense
               dark
               class="q-mb-lg"
               emit-value
@@ -30,6 +31,7 @@
               label="Model"
               outlined
               rounded
+              dense
               dark
               class="q-mb-lg"
               emit-value
@@ -61,6 +63,7 @@
               label="Temperature"
               outlined
               rounded
+              dense
               dark
               type="number"
               step="0.1"
@@ -75,6 +78,7 @@
               label="Max Tokens"
               outlined
               rounded
+              dense
               dark
               type="number"
               class="q-mb-lg"
@@ -171,6 +175,7 @@
               <q-input
                 v-model="userMessage"
                 outlined
+                dense
                 rounded
                 dark
                 placeholder="Enter message..."

--- a/frontend/src/pages/SettingsPage.vue
+++ b/frontend/src/pages/SettingsPage.vue
@@ -13,6 +13,7 @@
                 v-model="user.email"
                 label="Email"
                 outlined
+                dense
                 readonly
                 class="q-mb-md"
               />
@@ -21,6 +22,7 @@
                 v-model="user.first_name"
                 label="First Name"
                 outlined
+                dense
                 class="q-mb-md"
               />
 
@@ -28,6 +30,7 @@
                 v-model="user.last_name"
                 label="Last Name"
                 outlined
+                dense
                 class="q-mb-md"
               />
 

--- a/frontend/src/pages/TeamsPage.vue
+++ b/frontend/src/pages/TeamsPage.vue
@@ -279,6 +279,7 @@
               v-model="createForm.name"
               label="Team Name"
               outlined
+              dense
               rounded
               dark
               :rules="[(val) => !!val || 'Required']"
@@ -288,6 +289,7 @@
               v-model="createForm.monthly_budget_usd"
               label="Monthly Budget (USD)"
               outlined
+              dense
               rounded
               dark
               type="text"
@@ -299,6 +301,7 @@
               :options="policyOptions"
               label="Reset Policy"
               outlined
+              dense
               rounded
               dark
               emit-value
@@ -341,6 +344,7 @@
               v-model="editForm.name"
               label="Team Name"
               outlined
+              dense
               rounded
               dark
               class="q-mb-md"
@@ -349,6 +353,7 @@
               v-model="editForm.monthly_budget_usd"
               label="Monthly Budget (USD)"
               outlined
+              dense
               rounded
               dark
               type="text"
@@ -359,6 +364,7 @@
               :options="policyOptions"
               label="Reset Policy"
               outlined
+              dense
               rounded
               dark
               emit-value
@@ -412,6 +418,7 @@
             v-model="adjustForm.new_amount"
             label="New Allocation (USD)"
             outlined
+            dense
             rounded
             dark
             type="text"
@@ -443,6 +450,7 @@
               :options="memberOptions"
               label="From"
               outlined
+              dense
               rounded
               dark
               emit-value
@@ -457,6 +465,7 @@
               :options="memberOptions"
               label="To"
               outlined
+              dense
               rounded
               dark
               emit-value
@@ -470,6 +479,7 @@
               v-model="transferForm.amount"
               label="Amount (USD)"
               outlined
+              dense
               rounded
               dark
               type="text"
@@ -506,6 +516,7 @@
               v-model="batchForm.names"
               label="Names"
               outlined
+              dense
               rounded
               dark
               type="textarea"
@@ -518,6 +529,7 @@
               :model-value="computedPerMemberAllocation"
               label="Allocation per Member (USD)"
               outlined
+              dense
               rounded
               dark
               readonly
@@ -529,6 +541,7 @@
               :model-value="computedPerMemberDaily"
               label="Daily Limit per Member (USD)"
               outlined
+              dense
               rounded
               dark
               readonly
@@ -540,6 +553,7 @@
               :options="availableModelOptions"
               label="Models (optional)"
               outlined
+              dense
               rounded
               dark
               multiple

--- a/frontend/src/pages/TokensPage.vue
+++ b/frontend/src/pages/TokensPage.vue
@@ -110,66 +110,64 @@
                   />
                 </template>
                 <template v-else-if="col.name === 'actions'">
-                  <q-btn
-                    flat
-                    dense
-                    round
-                    size="xs"
-                    icon="settings"
-                    color="grey-7"
-                    @click.stop="openSettings(props.row)"
-                    class="q-mr-xs"
-                  >
-                    <q-tooltip>Cache Settings</q-tooltip>
-                  </q-btn>
-                  <q-btn
-                    flat
-                    dense
-                    round
-                    size="xs"
-                    icon="account_balance_wallet"
-                    color="positive"
-                    @click.stop="rechargeToken(props.row)"
-                    class="q-mr-xs"
-                  >
-                    <q-tooltip>Recharge</q-tooltip>
-                  </q-btn>
-                  <q-btn
-                    flat
-                    dense
-                    round
-                    size="xs"
-                    icon="notifications"
-                    color="warning"
-                    @click.stop="openAlertDialog(props.row)"
-                    class="q-mr-xs"
-                  >
-                    <q-tooltip>Alerts</q-tooltip>
-                  </q-btn>
-                  <q-btn
-                    flat
-                    dense
-                    round
-                    size="xs"
-                    icon="email"
-                    color="info"
-                    @click.stop="openNotifyDialog(props.row)"
-                    class="q-mr-xs"
-                  >
-                    <q-tooltip>Email this key to users</q-tooltip>
-                  </q-btn>
-                  <q-btn
-                    flat
-                    dense
-                    round
-                    size="xs"
-                    icon="delete"
-                    color="negative"
-                    @click.stop="deleteToken(props.row)"
-                    :loading="deletingTokenId === props.row.id"
-                  >
-                    <q-tooltip>Delete</q-tooltip>
-                  </q-btn>
+                  <div class="row no-wrap items-center action-btns">
+                    <q-btn
+                      flat
+                      dense
+                      round
+                      size="xs"
+                      icon="settings"
+                      color="grey-7"
+                      @click.stop="openSettings(props.row)"
+                    >
+                      <q-tooltip>Cache Settings</q-tooltip>
+                    </q-btn>
+                    <q-btn
+                      flat
+                      dense
+                      round
+                      size="xs"
+                      icon="account_balance_wallet"
+                      color="positive"
+                      @click.stop="rechargeToken(props.row)"
+                    >
+                      <q-tooltip>Recharge</q-tooltip>
+                    </q-btn>
+                    <q-btn
+                      flat
+                      dense
+                      round
+                      size="xs"
+                      icon="notifications"
+                      color="warning"
+                      @click.stop="openAlertDialog(props.row)"
+                    >
+                      <q-tooltip>Alerts</q-tooltip>
+                    </q-btn>
+                    <q-btn
+                      flat
+                      dense
+                      round
+                      size="xs"
+                      icon="email"
+                      color="info"
+                      @click.stop="openNotifyDialog(props.row)"
+                    >
+                      <q-tooltip>Email this key to users</q-tooltip>
+                    </q-btn>
+                    <q-btn
+                      flat
+                      dense
+                      round
+                      size="xs"
+                      icon="delete"
+                      color="negative"
+                      @click.stop="deleteToken(props.row)"
+                      :loading="deletingTokenId === props.row.id"
+                    >
+                      <q-tooltip>Delete</q-tooltip>
+                    </q-btn>
+                  </div>
                 </template>
                 <template v-else>
                   {{ col.value }}
@@ -711,7 +709,7 @@
               dense
               round
               icon="add"
-              color="info"
+              color="grey-6"
               @click="addNotifyEmail"
               class="q-ml-xs"
             >
@@ -722,7 +720,7 @@
               dense
               round
               icon="remove"
-              color="negative"
+              color="grey-6"
               :disable="notifyEmails.length === 1"
               @click="removeNotifyEmail(idx)"
             >
@@ -735,7 +733,6 @@
         </q-card-section>
 
         <q-card-actions align="right">
-          <q-btn label="Cancel" flat v-close-popup />
           <q-btn
             label="Save"
             color="grey-8"
@@ -746,7 +743,6 @@
           />
           <q-btn
             label="Send"
-            icon="send"
             color="info"
             @click="sendNotify"
             :loading="sendingNotify"
@@ -1382,6 +1378,18 @@ onMounted(async () => {
   font-family: 'Courier New', monospace;
   font-size: 13px;
   color: #9aa0a6;
+}
+
+// Compact, perfectly-circular action buttons (override any pill/min-width styling)
+.action-btns {
+  gap: 2px;
+
+  .q-btn {
+    min-width: 0;
+    min-height: 0;
+    border-radius: 50%;
+    aspect-ratio: 1;
+  }
 }
 </style>
 

--- a/frontend/src/pages/TokensPage.vue
+++ b/frontend/src/pages/TokensPage.vue
@@ -151,6 +151,18 @@
                     dense
                     round
                     size="xs"
+                    icon="email"
+                    color="info"
+                    @click.stop="openNotifyDialog(props.row)"
+                    class="q-mr-xs"
+                  >
+                    <q-tooltip>Email this key to users</q-tooltip>
+                  </q-btn>
+                  <q-btn
+                    flat
+                    dense
+                    round
+                    size="xs"
                     icon="delete"
                     color="negative"
                     @click.stop="deleteToken(props.row)"
@@ -666,6 +678,81 @@
 
         <q-card-actions align="right" class="q-pt-none">
           <q-btn label="Close" flat v-close-popup size="sm" />
+        </q-card-actions>
+      </q-card>
+    </q-dialog>
+
+    <!-- Notify (email key to users) Dialog -->
+    <q-dialog v-model="showNotifyDialog">
+      <q-card dark style="min-width: 500px">
+        <q-card-section>
+          <div class="text-h6">Email Key — {{ notifyTokenRow?.name }}</div>
+        </q-card-section>
+
+        <q-card-section class="q-pt-none">
+          <div
+            v-for="(email, idx) in notifyEmails"
+            :key="idx"
+            class="row items-center no-wrap q-mb-sm"
+          >
+            <q-input
+              v-model="notifyEmails[idx]"
+              label="Email address"
+              type="email"
+              outlined
+              rounded
+              dark
+              dense
+              class="col"
+              @keyup.enter="addNotifyEmail"
+            />
+            <q-btn
+              flat
+              dense
+              round
+              icon="add"
+              color="info"
+              @click="addNotifyEmail"
+              class="q-ml-xs"
+            >
+              <q-tooltip>Add another</q-tooltip>
+            </q-btn>
+            <q-btn
+              flat
+              dense
+              round
+              icon="remove"
+              color="negative"
+              :disable="notifyEmails.length === 1"
+              @click="removeNotifyEmail(idx)"
+            >
+              <q-tooltip>Remove</q-tooltip>
+            </q-btn>
+          </div>
+          <div class="text-caption text-warning q-mt-sm">
+            The email contains the plain API key. Make sure the recipients are correct.
+          </div>
+        </q-card-section>
+
+        <q-card-actions align="right">
+          <q-btn label="Cancel" flat v-close-popup />
+          <q-btn
+            label="Save"
+            color="grey-8"
+            @click="saveNotifyEmails"
+            :loading="savingNotify"
+            :disable="!hasValidNotifyEmail"
+            unelevated
+          />
+          <q-btn
+            label="Send"
+            icon="send"
+            color="info"
+            @click="sendNotify"
+            :loading="sendingNotify"
+            :disable="!hasValidNotifyEmail"
+            unelevated
+          />
         </q-card-actions>
       </q-card>
     </q-dialog>
@@ -1215,6 +1302,73 @@ async function deleteAlertRule(ruleId: string) {
   const deleted = await alertsStore.deleteRule(ruleId);
   if (deleted && alertDialogToken.value) {
     await alertsStore.fetchRules(alertDialogToken.value.id);
+  }
+}
+
+// --- Notify (email key to users) ---
+const showNotifyDialog = ref(false);
+const notifyTokenRow = ref<APIToken | null>(null);
+const notifyEmails = ref<string[]>([]);
+const savingNotify = ref(false);
+const sendingNotify = ref(false);
+
+// At least one row is always shown so the user has somewhere to type.
+const hasValidNotifyEmail = computed(() =>
+  notifyEmails.value.some((e) => e.trim().length > 0),
+);
+
+function openNotifyDialog(token: APIToken) {
+  notifyTokenRow.value = token;
+  const saved = (token.notify_emails || []).filter((e) => e.trim());
+  notifyEmails.value = saved.length > 0 ? saved : [''];
+  showNotifyDialog.value = true;
+}
+
+function addNotifyEmail() {
+  notifyEmails.value.push('');
+}
+
+function removeNotifyEmail(idx: number) {
+  notifyEmails.value.splice(idx, 1);
+  if (notifyEmails.value.length === 0) notifyEmails.value = [''];
+}
+
+function cleanedNotifyEmails(): string[] {
+  return notifyEmails.value.map((e) => e.trim()).filter((e) => e.length > 0);
+}
+
+async function persistNotifyEmails(): Promise<boolean> {
+  if (!notifyTokenRow.value) return false;
+  return tokensStore.updateToken(
+    notifyTokenRow.value.id,
+    { notify_emails: cleanedNotifyEmails() },
+  );
+}
+
+async function saveNotifyEmails() {
+  savingNotify.value = true;
+  try {
+    if (await persistNotifyEmails()) {
+      showNotifyDialog.value = false;
+      Notify.create({ type: 'positive', message: 'Recipients saved', position: 'top' });
+    }
+  } finally {
+    savingNotify.value = false;
+  }
+}
+
+async function sendNotify() {
+  if (!notifyTokenRow.value) return;
+  sendingNotify.value = true;
+  try {
+    // Send implies save — persist the recipients, then email the key.
+    if (!(await persistNotifyEmails())) return;
+    const sent = await tokensStore.notifyToken(notifyTokenRow.value.id, cleanedNotifyEmails());
+    if (sent) {
+      showNotifyDialog.value = false;
+    }
+  } finally {
+    sendingNotify.value = false;
   }
 }
 

--- a/frontend/src/pages/TokensPage.vue
+++ b/frontend/src/pages/TokensPage.vue
@@ -223,6 +223,7 @@
             v-model.number="rechargeAmount"
             label="Recharge Amount (USD)"
             outlined
+            dense
             rounded
             dark
             type="text"
@@ -261,6 +262,7 @@
               v-model="newToken.name"
               label="Key Name"
               outlined
+              dense
               rounded
               dark
               :rules="[(val) => !!val || 'Please enter name']"
@@ -271,6 +273,7 @@
               v-model="newToken.description"
               label="Description (optional)"
               outlined
+              dense
               rounded
               dark
               class="q-mb-md"
@@ -280,6 +283,7 @@
               v-model.number="newToken.quota_usd"
               label="Quota (USD)"
               outlined
+              dense
               rounded
               dark
               type="text"
@@ -291,6 +295,7 @@
               v-model="newToken.expires_at"
               label="Expiration Time"
               outlined
+              dense
               rounded
               dark
               hint="Leave empty for never expires"
@@ -365,6 +370,7 @@
           <q-input
             v-model="displayKey"
             outlined
+            dense
             rounded
             readonly
             type="textarea"
@@ -449,6 +455,7 @@
               v-model="batchForm.names"
               label="Names"
               outlined
+              dense
               rounded
               dark
               type="textarea"
@@ -462,6 +469,7 @@
               v-model.number="batchForm.quota_usd"
               label="Quota per Key (USD)"
               outlined
+              dense
               rounded
               dark
               type="text"
@@ -473,6 +481,7 @@
               v-model="batchForm.expires_at"
               label="Expiration Time"
               outlined
+              dense
               rounded
               dark
               hint="Leave empty for never expires"
@@ -500,6 +509,7 @@
               :options="availableModelOptions"
               label="Models (optional)"
               outlined
+              dense
               rounded
               dark
               multiple
@@ -1380,15 +1390,21 @@ onMounted(async () => {
   color: #9aa0a6;
 }
 
-// Compact, perfectly-circular action buttons (override any pill/min-width styling)
+// Tight spacing between the round action buttons
 .action-btns {
-  gap: 2px;
+  gap: 4px;
 
   .q-btn {
-    min-width: 0;
-    min-height: 0;
+    width: 30px;
+    height: 30px;
+    min-width: 30px;
+    min-height: 30px;
+    padding: 0;
     border-radius: 50%;
-    aspect-ratio: 1;
+
+    .q-icon {
+      font-size: 16px;
+    }
   }
 }
 </style>

--- a/frontend/src/stores/tokens.ts
+++ b/frontend/src/stores/tokens.ts
@@ -17,6 +17,7 @@ export interface APIToken {
   used_usd: string;
   remaining_quota: string | null;
   allowed_ips: string[];
+  notify_emails: string[];
   allowed_models: string[];
   is_active: boolean;
   is_expired: boolean;
@@ -39,6 +40,7 @@ export interface CreateTokenRequest {
   expires_at?: string;
   quota_usd?: number;
   allowed_ips?: string[];
+  notify_emails?: string[];
   allowed_models?: string[];
   token_metadata?: TokenMetadata | null;
 }
@@ -222,6 +224,32 @@ export const useTokensStore = defineStore('tokens', {
         const message = error && typeof error === 'object' && 'response' in error
           ? (error.response as { data?: { detail?: string } })?.data?.detail || 'Failed to revoke token'
           : 'Failed to revoke token';
+        Notify.create({
+          type: 'negative',
+          message,
+          position: 'top',
+        });
+        return false;
+      }
+    },
+
+    async notifyToken(tokenId: string, emails?: string[]): Promise<boolean> {
+      try {
+        const response = await api.post<{ sent: boolean; recipients: string[] }>(
+          `/admin/tokens/${tokenId}/notify`,
+          emails !== undefined ? { emails } : {},
+        );
+
+        Notify.create({
+          type: 'positive',
+          message: `Key emailed to ${response.data.recipients.length} recipient(s)`,
+          position: 'top',
+        });
+        return true;
+      } catch (error: unknown) {
+        const message = error && typeof error === 'object' && 'response' in error
+          ? (error.response as { data?: { detail?: string } })?.data?.detail || 'Failed to send notification'
+          : 'Failed to send notification';
         Notify.create({
           type: 'negative',
           message,


### PR DESCRIPTION
## What

Adds a per-key **email association** so an API key can be shared with multiple users (one-to-many), and a Tokens-page action that emails the key's plaintext value to those recipients via SES.

## Changes

- **Model**: `notify_emails ARRAY(String)` on `api_tokens` (+ Alembic migration `v3w4x5y6z7a8`, which also adds the `API_KEY_NOTIFIED` enum value)
- **Service**: extracted a generic `send_email()`; `dispatch_alert()` now delegates to it
- **Endpoint**: `POST /admin/tokens/{id}/notify`; `notify_emails` accepted on update and returned in the token response
- **Audit**: new `API_KEY_NOTIFIED` action
- **Export/Import**: `notify_emails` round-trips with the rest of a token's config
- **Frontend**: email action on the Tokens page opens a dialog with dynamic add/remove email rows; `notifyToken` store action
- **Docs**: `docs/alerts.md` / `alerts.zh.md` gain a full SES email-setup section (sandbox→production access, verify sender identity, IAM check, configmap + rollout)

## Notes / deploy steps

- Run `alembic upgrade head` before deploying — the `notify_emails` column and `API_KEY_NOTIFIED` enum value must exist.
- Email delivery requires `KBR_ALERT_SES_SENDER_EMAIL` set to a verified SES sender; if unset, sends are skipped and `/notify` returns 502 (documented).
- Export still never includes `token_hash`/`encrypted_token`; only the `notify_emails` config is added.

## Testing

- Verified end-to-end against the prod cluster: `/notify` returns 200 and SES logs `Email '...' sent to [...]`.