### PR TITLE
feat: 下拉多选增加全选/取消全选

### DIFF
--- a/frontend/src/pages/ModelsPage.vue
+++ b/frontend/src/pages/ModelsPage.vue
@@ -155,21 +155,46 @@
           />
 
           <q-select
-            v-model="selectedAwsModel"
+            v-model="selectedAwsModels"
             :options="filteredAwsModels"
             option-label="friendly_name"
             option-value="friendly_name"
-            :label="selectedProvider === 'google' ? 'Select Gemini Model' : 'Select Model from AWS Bedrock'"
+            :label="selectedProvider === 'google' ? 'Select Gemini Model(s)' : 'Select Model(s) from AWS Bedrock'"
             outlined
             dense
             dark
+            multiple
             :loading="loadingAwsModels"
             use-input
             input-debounce="300"
             @filter="filterModels"
           >
+            <template v-slot:before-options>
+              <q-item v-if="filteredAwsModels.length > 0" clickable @click.stop="toggleSelectAllModels">
+                <q-item-section side>
+                  <q-checkbox
+                    :model-value="allModelsSelected"
+                    dense
+                    dark
+                    @click.stop="toggleSelectAllModels"
+                  />
+                </q-item-section>
+                <q-item-section>
+                  <q-item-label class="text-weight-medium">Select All</q-item-label>
+                </q-item-section>
+              </q-item>
+              <q-separator dark />
+            </template>
             <template v-slot:option="scope">
               <q-item v-bind="scope.itemProps">
+                <q-item-section side>
+                  <q-checkbox
+                    :model-value="scope.selected"
+                    dense
+                    dark
+                    @click.stop="scope.toggleOption(scope.opt)"
+                  />
+                </q-item-section>
                 <q-item-section>
                   <q-item-label>
                     {{ scope.opt.friendly_name }}
@@ -200,7 +225,7 @@
             color="grey-8"
             @click="addModel"
             :loading="adding"
-            :disable="!selectedAwsModel"
+            :disable="selectedAwsModels.length === 0"
             unelevated
           />
         </q-card-actions>
@@ -276,7 +301,7 @@ const selectedProvider = ref<'bedrock' | 'google'>('bedrock');
 const awsModels = ref<AwsModel[]>([]);
 const filteredAwsModels = ref<AwsModel[]>([]);
 const loadingAwsModels = ref(false);
-const selectedAwsModel = ref<AwsModel | null>(null);
+const selectedAwsModels = ref<AwsModel[]>([]);
 const adding = ref(false);
 const deletingModelId = ref<string | null>(null);
 const selectedTokenId = ref<string | null>(null);
@@ -334,7 +359,7 @@ const currentToken = computed(() => {
 
 function openAddDialog() {
   selectedProvider.value = 'bedrock';
-  selectedAwsModel.value = null;
+  selectedAwsModels.value = [];
   filteredAwsModels.value = _modelsForProvider();
   showAddDialog.value = true;
 }
@@ -366,7 +391,7 @@ function _modelsForProvider(): AwsModel[] {
 
 function onProviderChange() {
   // Clear selection when switching provider
-  selectedAwsModel.value = null;
+  selectedAwsModels.value = [];
   filteredAwsModels.value = _modelsForProvider();
 }
 
@@ -386,32 +411,58 @@ function filterModels(val: string, update: (fn: () => void) => void) {
   });
 }
 
+const allModelsSelected = computed(
+  () =>
+    filteredAwsModels.value.length > 0 &&
+    selectedAwsModels.value.length === filteredAwsModels.value.length,
+);
+
+function toggleSelectAllModels() {
+  selectedAwsModels.value = allModelsSelected.value ? [] : [...filteredAwsModels.value];
+}
+
 async function addModel() {
-  if (!selectedAwsModel.value || !selectedTokenId.value) return;
+  if (selectedAwsModels.value.length === 0 || !selectedTokenId.value) return;
 
   adding.value = true;
   try {
     // Use model_id as-is from backend (already has correct prefix:
     // cross-region models have geographic prefix e.g. "us.", standard models have no prefix)
-    await api.post('/admin/models', {
-      token_id: selectedTokenId.value,
-      model_name: selectedAwsModel.value.model_id,
-    });
+    const results = await Promise.allSettled(
+      selectedAwsModels.value.map((m) =>
+        api.post('/admin/models', {
+          token_id: selectedTokenId.value,
+          model_name: m.model_id,
+        }),
+      ),
+    );
 
-    Notify.create({
-      type: 'positive',
-      message: 'Model added successfully',
-      position: 'top',
-    });
+    const succeeded = results.filter((r) => r.status === 'fulfilled').length;
+    const failed = results.length - succeeded;
+
+    if (succeeded > 0) {
+      Notify.create({
+        type: 'positive',
+        message: `Added ${succeeded} model(s)${failed > 0 ? `, ${failed} failed` : ''}`,
+        position: 'top',
+      });
+    }
+    if (failed > 0 && succeeded === 0) {
+      Notify.create({
+        type: 'negative',
+        message: 'Failed to add models',
+        position: 'top',
+      });
+    }
 
     showAddDialog.value = false;
-    selectedAwsModel.value = null;
+    selectedAwsModels.value = [];
     // Refresh models for the selected token only
     await modelsStore.fetchModels(selectedTokenId.value);
   } catch {
     Notify.create({
       type: 'negative',
-      message: 'Failed to add model',
+      message: 'Failed to add models',
       position: 'top',
     });
   } finally {

--- a/frontend/src/pages/MonitorPage.vue
+++ b/frontend/src/pages/MonitorPage.vue
@@ -26,6 +26,22 @@
                 </span>
               </div>
             </template>
+            <template v-slot:before-options>
+              <q-item v-if="tokenOptions.length > 0" clickable @click.stop="toggleSelectAllTokens">
+                <q-item-section side>
+                  <q-checkbox
+                    :model-value="allTokensSelected"
+                    dense
+                    dark
+                    @click.stop="toggleSelectAllTokens"
+                  />
+                </q-item-section>
+                <q-item-section>
+                  <q-item-label class="text-weight-medium">Select All</q-item-label>
+                </q-item-section>
+              </q-item>
+              <q-separator dark />
+            </template>
             <template v-slot:option="scope">
               <q-item v-bind="scope.itemProps">
                 <q-item-section side>
@@ -773,6 +789,18 @@ const toggleToken = (tokenId: string) => {
   } else {
     monitorStore.selectedTokenIds.push(tokenId);
   }
+};
+
+const allTokensSelected = computed(
+  () =>
+    tokenOptions.value.length > 0 &&
+    monitorStore.selectedTokenIds.length === tokenOptions.value.length,
+);
+
+const toggleSelectAllTokens = () => {
+  monitorStore.selectedTokenIds = allTokensSelected.value
+    ? []
+    : tokenOptions.value.map((opt) => opt.value);
 };
 
 function applyDatePreset(preset: string) {


### PR DESCRIPTION
## 改动

为两处多选下拉增加「全选 / 取消全选」。

### Monitor 页 — API Keys 下拉
- 下拉选项顶部新增 `Select All` 条目 + 复选框 + 分隔线
- 已全选时再点即取消全选

### Models 页 — Add Model 对话框
- 原为**单选**，本次升级为**多选**以支持全选
- 顶部新增 `Select All`（针对当前过滤/搜索结果）
- 每个选项前增加复选框
- `addModel` 改为 `Promise.allSettled` 批量提交，结果提示「Added N 个，M 个失败」
- ADD 按钮未选时禁用

## 验证
- [x] pre-commit 全过（ESLint / ruff / format / detect-secrets）
- [x] vue-tsc 类型检查无报错
- [ ] Monitor：API Keys 下拉顶部 Select All 可用
- [ ] Models：Add 对话框可多选 + Select All + 批量添加