### PR TITLE
feat: 接入 Bedrock mantle 上的 OpenAI GPT-5.5/5.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 <h1 align="center">Kolya BR Proxy</h1>
 
 <p align="center">
-  <strong>AI Gateway providing OpenAI & Anthropic compatible APIs backed by AWS Bedrock and Google Gemini</strong>
+  <strong>AI Gateway providing OpenAI & Anthropic compatible APIs backed by AWS Bedrock, Google Gemini, and OpenAI GPT-5.5 / 5.4 (via AWS mantle)</strong>
 </p>
 
 <p align="center">
@@ -21,6 +21,7 @@
   <img src="https://img.shields.io/badge/Vue-3-4FC08D?logo=vuedotjs&logoColor=white" alt="Vue 3" />
   <img src="https://img.shields.io/badge/AWS_Bedrock-FF9900?logo=amazonaws&logoColor=white" alt="AWS Bedrock" />
   <img src="https://img.shields.io/badge/Google_Gemini-4285F4?logo=google&logoColor=white" alt="Google Gemini" />
+  <img src="https://img.shields.io/badge/OpenAI_GPT--5.5-412991?logo=openai&logoColor=white" alt="OpenAI GPT-5.5" />
   <img src="https://img.shields.io/badge/license-MIT-green" alt="License" />
 </p>
 
@@ -31,7 +32,7 @@
 | | |
 |---|---|
 | **Dual API, one key** | Both OpenAI (`/v1/chat/completions`) and Anthropic (`/v1/messages`) endpoints. Same `sk-ant-api03_` key works everywhere — Cursor, Cline, Claude Code, OpenAI SDK. |
-| **Multi-cloud LLM routing** | AWS Bedrock (Claude, Nova, DeepSeek, Mistral, Llama, 19+ providers) + Google Gemini (native `generateContent` API). One proxy, all models. |
+| **Multi-cloud LLM routing** | AWS Bedrock (Claude, Nova, DeepSeek, Mistral, Llama, 19+ providers) + Google Gemini (native `generateContent` API) + OpenAI GPT-5.5 / 5.4 (native Responses API via AWS mantle). One proxy, all models. |
 | **Up to 90% cost savings** | Prompt caching reads at 0.1x price. Agent loops save ~60% after just 2 requests. |
 | **Enterprise security** | 3-layer CSRF, AWS WAF, SHA256 + AES-128 token protection, OAuth SSO (Cognito / Entra ID). |
 | **Production-ready** | Distributed Redis rate limiting, HPA autoscaling (1-10 Pods), streaming heartbeat, Karpenter node scaling. |
@@ -65,6 +66,7 @@ graph LR
     Backend -->|InvokeModel - Claude| Bedrock["AWS Bedrock"]
     Backend -->|Converse API - Nova / DeepSeek / Llama| Bedrock
     Backend -->|generateContent native API| Gemini["Google Gemini"]
+    Backend -->|Responses API + SigV4| Mantle["AWS mantle (OpenAI GPT-5.5 / 5.4)"]
     Backend -->|asyncpg| DB[(PostgreSQL)]
     Backend -.->|Cache + Rate Limit| Redis[(Redis)]
     subgraph AWS EKS
@@ -79,9 +81,10 @@ graph LR
 |----------|------|--------|---------|
 | `POST /v1/chat/completions` | `Authorization: Bearer` | OpenAI | Cursor, Cline, OpenAI SDK |
 | `POST /v1/messages` | `x-api-key` | Anthropic Messages | Claude Code, Anthropic SDK |
+| `POST /v1/responses` | Both | OpenAI Responses | OpenAI SDK (native passthrough) |
 | `GET /v1/models` | Both | OpenAI | All clients |
 
-Model routing is automatic — `gemini-*` models go to Google Gemini via the native `generateContent` API; all other models go to AWS Bedrock. Both routes share the same token validation, quota tracking, and usage recording pipeline.
+Model routing is automatic — `gemini-*` models go to Google Gemini via the native `generateContent` API; `openai.gpt-5.5` / `openai.gpt-5.4` go to AWS mantle's native OpenAI Responses API (SigV4 over the existing AWS credential chain, no new secret); all other models go to AWS Bedrock. All routes share the same token validation, quota tracking, and usage recording pipeline.
 
 ---
 
@@ -211,11 +214,12 @@ print(message.content[0].text)
 - **Anthropic Claude** via native InvokeModel API (thinking, effort, prompt caching)
 - **Amazon Nova, DeepSeek, Mistral, Llama** via Converse API
 - **Google Gemini** via native `generateContent` / `streamGenerateContent` API (image generation 🍌, tool calling, implicit caching)
+- **OpenAI GPT-5.5 / 5.4** via AWS mantle native Responses API — reachable through `/v1/chat/completions` (ChatCompletions↔Responses), `/v1/messages` (Anthropic↔Responses), or `/v1/responses` (zero-conversion passthrough)
 - 19+ providers through unified translation layer
 
 ### Cost Optimization
 - **Prompt caching** — 90% discount on reads, auto-injection of cache breakpoints (up to 4 per request)
-- **Per-token billing** — Dynamic pricing from AWS API (181+ regional pricing records) + Gemini 3-tier pricing (Google official page → LiteLLM JSON → static legacy table)
+- **Per-token billing** — Dynamic pricing from AWS API (181+ regional pricing records) + Gemini 3-tier pricing (Google official page → LiteLLM JSON → static legacy table) + per-region OpenAI mantle pricing scraped from the AWS pricing page
 - **Real-time tracking** — Background async usage recording with per-token quota limits
 
 ### Security
@@ -242,7 +246,7 @@ print(message.content[0].text)
 | **Database** | PostgreSQL (Aurora in prod), asyncpg |
 | **Cache** | Redis (rate limiting, token caching) |
 | **Auth** | JWT, AWS Cognito, Microsoft OAuth |
-| **Cloud** | AWS Bedrock, EKS, ECR, WAF, Secrets Manager, Google Gemini API |
+| **Cloud** | AWS Bedrock, AWS mantle (OpenAI GPT-5.5 / 5.4), EKS, ECR, WAF, Secrets Manager, Google Gemini API |
 | **IaC** | Terraform, Karpenter, External Secrets Operator |
 
 ---

--- a/README.zh.md
+++ b/README.zh.md
@@ -5,7 +5,7 @@
 <h1 align="center">Kolya BR Proxy</h1>
 
 <p align="center">
-  <strong>AI 网关 — 提供兼容 OpenAI 和 Anthropic 的 API，后端接入 AWS Bedrock 和 Google Gemini</strong>
+  <strong>AI 网关 — 提供兼容 OpenAI 和 Anthropic 的 API，后端接入 AWS Bedrock、Google Gemini 以及 OpenAI GPT-5.5 / 5.4（经 AWS mantle）</strong>
 </p>
 
 <p align="center">
@@ -21,6 +21,7 @@
   <img src="https://img.shields.io/badge/Vue-3-4FC08D?logo=vuedotjs&logoColor=white" alt="Vue 3" />
   <img src="https://img.shields.io/badge/AWS_Bedrock-FF9900?logo=amazonaws&logoColor=white" alt="AWS Bedrock" />
   <img src="https://img.shields.io/badge/Google_Gemini-4285F4?logo=google&logoColor=white" alt="Google Gemini" />
+  <img src="https://img.shields.io/badge/OpenAI_GPT--5.5-412991?logo=openai&logoColor=white" alt="OpenAI GPT-5.5" />
   <img src="https://img.shields.io/badge/license-MIT-green" alt="License" />
 </p>
 
@@ -31,7 +32,7 @@
 | | |
 |---|---|
 | **双 API，一个 Key** | 同时支持 OpenAI (`/v1/chat/completions`) 和 Anthropic (`/v1/messages`) 端点。同一个 `sk-ant-api03_` 格式的 Key 可用于 Cursor、Cline、Claude Code、OpenAI SDK。 |
-| **多云 LLM 路由** | AWS Bedrock（Claude、Nova、DeepSeek、Mistral、Llama，19+ 厂商）+ Google Gemini（原生 `generateContent` API）。一个代理，所有模型。 |
+| **多云 LLM 路由** | AWS Bedrock（Claude、Nova、DeepSeek、Mistral、Llama，19+ 厂商）+ Google Gemini（原生 `generateContent` API）+ OpenAI GPT-5.5 / 5.4（经 AWS mantle 的原生 Responses API）。一个代理，所有模型。 |
 | **最高 90% 成本节省** | Prompt Cache 读取按 0.1 倍计费；Agent 循环仅 2 次请求即可回本，10+ 轮节省约 60%。 |
 | **企业级安全** | 三层 CSRF 防御、AWS WAF、SHA256 + AES-128 Token 双重保护、OAuth SSO（Cognito / Entra ID）。 |
 | **生产就绪** | 分布式 Redis 限流、HPA 自动扩缩（1-10 Pods）、流式心跳、Karpenter 节点伸缩。 |
@@ -65,6 +66,7 @@ graph LR
     Backend -->|InvokeModel - Claude| Bedrock["AWS Bedrock"]
     Backend -->|Converse API - Nova / DeepSeek / Llama| Bedrock
     Backend -->|原生 generateContent API| Gemini["Google Gemini"]
+    Backend -->|Responses API + SigV4| Mantle["AWS mantle (OpenAI GPT-5.5 / 5.4)"]
     Backend -->|asyncpg| DB[(PostgreSQL)]
     Backend -.->|缓存 + 限流| Redis[(Redis)]
     subgraph AWS EKS
@@ -79,9 +81,10 @@ graph LR
 |------|---------|------|--------|
 | `POST /v1/chat/completions` | `Authorization: Bearer` | OpenAI | Cursor, Cline, OpenAI SDK |
 | `POST /v1/messages` | `x-api-key` | Anthropic Messages | Claude Code, Anthropic SDK |
+| `POST /v1/responses` | 两种均可 | OpenAI Responses | OpenAI SDK（原生透传） |
 | `GET /v1/models` | 两种均可 | OpenAI | 所有客户端 |
 
-模型路由自动完成 — `gemini-*` 模型通过原生 `generateContent` API 路由到 Google Gemini；其他模型路由到 AWS Bedrock。两条路由共享同一套 Token 验证、配额追踪和使用量记录管线。
+模型路由自动完成 — `gemini-*` 模型通过原生 `generateContent` API 路由到 Google Gemini；`openai.gpt-5.5` / `openai.gpt-5.4` 路由到 AWS mantle 的原生 OpenAI Responses API（SigV4 复用现有 AWS 凭证链，无需新增 secret）；其他模型路由到 AWS Bedrock。所有路由共享同一套 Token 验证、配额追踪和使用量记录管线。
 
 ---
 
@@ -211,11 +214,12 @@ print(message.content[0].text)
 - **Anthropic Claude** 使用原生 InvokeModel API（thinking、effort、prompt caching）
 - **Amazon Nova、DeepSeek、Mistral、Llama** 通过 Converse API
 - **Google Gemini** 通过原生 `generateContent` / `streamGenerateContent` API（图片生成 🍌、工具调用、隐式缓存）
+- **OpenAI GPT-5.5 / 5.4** 经 AWS mantle 原生 Responses API — 可通过 `/v1/chat/completions`（ChatCompletions↔Responses）、`/v1/messages`（Anthropic↔Responses）或 `/v1/responses`（零转换透传）三条路径调用
 - 统一转换层支持 19+ 家厂商
 
 ### 成本优化
 - **Prompt Cache** — 读取 90% 折扣，自动注入缓存断点（每请求最多 4 个）
-- **按模型按 Token 计费** — AWS 动态定价（181+ 个地区价格记录）+ Gemini 三级价格策略（Google 官方页面 → LiteLLM JSON → 静态历史表）
+- **按模型按 Token 计费** — AWS 动态定价（181+ 个地区价格记录）+ Gemini 三级价格策略（Google 官方页面 → LiteLLM JSON → 静态历史表）+ 从 AWS 定价页解析的 OpenAI mantle 分地区价格
 - **实时追踪** — 后台异步记录使用量，每个 API Token 配额限制
 
 ### 安全
@@ -242,7 +246,7 @@ print(message.content[0].text)
 | **数据库** | PostgreSQL（生产环境 Aurora），asyncpg |
 | **缓存** | Redis（限流、Token 缓存） |
 | **认证** | JWT, AWS Cognito, Microsoft OAuth |
-| **云服务** | AWS Bedrock, EKS, ECR, WAF, Secrets Manager, Google Gemini API |
+| **云服务** | AWS Bedrock, AWS mantle (OpenAI GPT-5.5 / 5.4), EKS, ECR, WAF, Secrets Manager, Google Gemini API |
 | **IaC** | Terraform, Karpenter, External Secrets Operator |
 
 ---

--- a/backend/app/api/admin/endpoints/models.py
+++ b/backend/app/api/admin/endpoints/models.py
@@ -18,6 +18,7 @@ from app.core.database import get_db
 from app.models.model import Model
 from app.services.bedrock import BedrockClient
 from app.services.gemini_client import GeminiClient, is_gemini_configured
+from app.services.mantle_models import get_mantle_models
 
 router = APIRouter()
 logger = logging.getLogger(__name__)
@@ -163,6 +164,11 @@ async def list_aws_available_models(
                 )
             except Exception as e:
                 logger.warning(f"Failed to fetch Gemini models (non-fatal): {e}")
+
+        # Inject OpenAI GPT-5.5/5.4 (mantle) — not discoverable via Bedrock APIs
+        mantle_models = get_mantle_models()
+        models.extend(mantle_models)
+        logger.info(f"Added {len(mantle_models)} mantle models to available list")
 
         # Cache the results
         _set_aws_models_cache(models)

--- a/backend/app/api/anthropic/endpoints/messages.py
+++ b/backend/app/api/anthropic/endpoints/messages.py
@@ -27,6 +27,7 @@ from app.services.background_tasks import BackgroundTaskManager
 from app.core.metrics import emit_request_metrics
 from app.services.bedrock import BedrockClient, get_fallback_models
 from app.services.gemini_client import is_gemini_model as _is_gemini_model
+from app.services.mantle_models import is_openai_mantle_model as _is_mantle_model
 from app.services.pricing import ModelPricing
 
 router = APIRouter()
@@ -121,6 +122,15 @@ async def create_message(
         # Route Gemini models to Google API
         if _is_gemini_model(request_data.model):
             return await _handle_gemini_via_anthropic(
+                request_data=request_data,
+                request_id=request_id,
+                token=token,
+                start_time=start_time,
+            )
+
+        # Route OpenAI GPT-5.5/5.4 (mantle) to the Responses API
+        if _is_mantle_model(request_data.model):
+            return await _handle_mantle_via_anthropic(
                 request_data=request_data,
                 request_id=request_id,
                 token=token,
@@ -783,6 +793,277 @@ async def _stream_gemini_as_anthropic(
     duration = time.time() - start_time
     logger.info(
         f"Anthropic→Gemini streaming done: request_id={request_id}, "
+        f"duration={round(duration, 3)}s, "
+        f"prompt={non_cached_prompt}, completion={total_completion_tokens}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# OpenAI GPT-5.5/5.4 (mantle) routing via Anthropic Messages endpoint
+# ---------------------------------------------------------------------------
+
+
+def _anthropic_to_openai_messages(
+    request_data: "AnthropicMessagesRequest",
+) -> list[dict]:
+    """Flatten Anthropic-format messages to OpenAI-style messages.
+
+    Mirrors the conversion used by the Gemini path: system prompt → system
+    message, and each message's text content blocks are joined into a single
+    string. The MantleClient handles the OpenAI→Responses translation downstream.
+    """
+    openai_messages: list[dict] = []
+    if request_data.system:
+        system_text = (
+            request_data.system
+            if isinstance(request_data.system, str)
+            else " ".join(b.text for b in request_data.system if hasattr(b, "text"))
+        )
+        if system_text:
+            openai_messages.append({"role": "system", "content": system_text})
+
+    for msg in request_data.messages:
+        content = msg.content
+        if isinstance(content, list):
+            texts = []
+            for block in content:
+                if hasattr(block, "text"):
+                    texts.append(block.text)
+                elif isinstance(block, dict) and block.get("type") == "text":
+                    texts.append(block.get("text", ""))
+            content = "\n".join(texts) if texts else ""
+        openai_messages.append({"role": msg.role, "content": content})
+
+    return openai_messages
+
+
+async def _handle_mantle_via_anthropic(
+    request_data: "AnthropicMessagesRequest",
+    request_id: str,
+    token: APIToken,
+    start_time: float,
+):
+    """
+    Forward a GPT-5.5/5.4 (mantle) request received on the Anthropic endpoint.
+
+    Converts Anthropic-format messages to OpenAI-style messages, calls the
+    MantleClient (which translates to the Responses API and signs with SigV4),
+    and converts the OpenAI-format response back to Anthropic format.
+    """
+    import httpx
+
+    from app.services.mantle_client import (
+        MantleClient,
+        extract_cached_tokens,
+    )
+
+    openai_messages = _anthropic_to_openai_messages(request_data)
+
+    payload = {
+        "model": request_data.model,
+        "messages": openai_messages,
+    }
+    if request_data.temperature is not None:
+        payload["temperature"] = request_data.temperature
+    if request_data.max_tokens:
+        payload["max_tokens"] = request_data.max_tokens
+
+    if request_data.stream:
+        return StreamingResponse(
+            _stream_mantle_as_anthropic(
+                payload=payload,
+                request_id=request_id,
+                model=request_data.model,
+                token=token,
+                start_time=start_time,
+            ),
+            media_type="text/event-stream",
+            headers={
+                "Cache-Control": "no-cache",
+                "Connection": "keep-alive",
+            },
+        )
+
+    # Non-streaming
+    try:
+        response_data = await MantleClient.invoke(payload)
+    except httpx.HTTPStatusError as e:
+        raise HTTPException(
+            status_code=e.response.status_code,
+            detail=f"mantle API error: status {e.response.status_code}",
+        )
+
+    choices = response_data.get("choices", [])
+    usage = response_data.get("usage", {})
+    content_text = ""
+    if choices:
+        msg = choices[0].get("message", {})
+        content_text = msg.get("content", "") or ""
+
+    cached_tokens = extract_cached_tokens(response_data)
+    prompt_tokens = usage.get("prompt_tokens", 0)
+    completion_tokens = usage.get("completion_tokens", 0)
+    non_cached_prompt = max(0, prompt_tokens - cached_tokens)
+
+    background_tasks.create_task(
+        record_usage(
+            token_id=token.id,
+            user_id=token.user_id,
+            model=request_data.model,
+            request_id=request_id,
+            prompt_tokens=non_cached_prompt,
+            completion_tokens=completion_tokens,
+            cache_read_input_tokens=cached_tokens,
+        ),
+        task_name=f"record_usage_{request_id}",
+    )
+
+    duration = time.time() - start_time
+    logger.info(
+        f"Anthropic→mantle non-streaming done: request_id={request_id}, "
+        f"duration={round(duration, 3)}s, "
+        f"prompt={non_cached_prompt}, completion={completion_tokens}"
+    )
+
+    return {
+        "id": request_id,
+        "type": "message",
+        "role": "assistant",
+        "content": [{"type": "text", "text": content_text}],
+        "model": request_data.model,
+        "stop_reason": "end_turn",
+        "usage": {
+            "input_tokens": non_cached_prompt,
+            "output_tokens": completion_tokens,
+        },
+    }
+
+
+async def _stream_mantle_as_anthropic(
+    payload: dict,
+    request_id: str,
+    model: str,
+    token: APIToken,
+    start_time: float,
+) -> AsyncGenerator[str, None]:
+    """
+    Stream a mantle (GPT-5.5/5.4) response converted to Anthropic SSE format.
+
+    MantleClient.invoke_stream yields OpenAI-format SSE chunks; we convert each
+    to Anthropic streaming events (mirrors the Gemini streaming bridge).
+    """
+    import json as _json
+
+    from app.services.mantle_client import (
+        MantleClient,
+        extract_cached_tokens_from_chunk,
+    )
+
+    total_prompt_tokens = 0
+    total_completion_tokens = 0
+    total_cached_tokens = 0
+    block_started = False
+
+    try:
+        # Send message_start event
+        yield (
+            "event: message_start\n"
+            f"data: {_json.dumps({'type': 'message_start', 'message': {'id': request_id, 'type': 'message', 'role': 'assistant', 'content': [], 'model': model, 'usage': {'input_tokens': 0, 'output_tokens': 0}}})}\n\n"
+        )
+
+        async for chunk in MantleClient.invoke_stream(payload):
+            for line in chunk.splitlines():
+                if not line.startswith("data: ") or line.strip() == "data: [DONE]":
+                    continue
+
+                try:
+                    data = _json.loads(line[6:])
+                except (ValueError, TypeError):
+                    continue
+
+                # Extract usage
+                usage = data.get("usage")
+                if usage:
+                    total_prompt_tokens = usage.get(
+                        "prompt_tokens", total_prompt_tokens
+                    )
+                    total_completion_tokens = usage.get(
+                        "completion_tokens", total_completion_tokens
+                    )
+                    cached = extract_cached_tokens_from_chunk(data)
+                    if cached is not None:
+                        total_cached_tokens = cached
+
+                # Extract text delta
+                choices = data.get("choices", [])
+                if not choices:
+                    continue
+                delta = choices[0].get("delta", {})
+                text = delta.get("content")
+                if not isinstance(text, str) or not text:
+                    continue
+
+                # Send content_block_start on first text
+                if not block_started:
+                    yield (
+                        "event: content_block_start\n"
+                        f"data: {_json.dumps({'type': 'content_block_start', 'index': 0, 'content_block': {'type': 'text', 'text': ''}})}\n\n"
+                    )
+                    block_started = True
+
+                # Send content_block_delta
+                yield (
+                    "event: content_block_delta\n"
+                    f"data: {_json.dumps({'type': 'content_block_delta', 'index': 0, 'delta': {'type': 'text_delta', 'text': text}})}\n\n"
+                )
+
+        # Close content block
+        if block_started:
+            yield (
+                "event: content_block_stop\n"
+                f"data: {_json.dumps({'type': 'content_block_stop', 'index': 0})}\n\n"
+            )
+
+        # Send message_delta with usage
+        yield (
+            "event: message_delta\n"
+            f"data: {_json.dumps({'type': 'message_delta', 'delta': {'stop_reason': 'end_turn'}, 'usage': {'output_tokens': total_completion_tokens}})}\n\n"
+        )
+
+        # Send message_stop
+        yield (
+            f"event: message_stop\ndata: {_json.dumps({'type': 'message_stop'})}\n\n"
+        )
+
+    except Exception as e:
+        logger.error(
+            f"Anthropic→mantle streaming failed: model={model}, "
+            f"request_id={request_id}, error={e}",
+            exc_info=True,
+        )
+        yield (
+            "event: error\n"
+            f"data: {_json.dumps({'type': 'error', 'error': {'type': 'server_error', 'message': 'Internal server error'}})}\n\n"
+        )
+
+    # Record usage
+    non_cached_prompt = max(0, total_prompt_tokens - total_cached_tokens)
+    background_tasks.create_task(
+        record_usage(
+            token_id=token.id,
+            user_id=token.user_id,
+            model=model,
+            request_id=request_id,
+            prompt_tokens=non_cached_prompt,
+            completion_tokens=total_completion_tokens,
+            cache_read_input_tokens=total_cached_tokens,
+        ),
+        task_name=f"record_usage_{request_id}",
+    )
+
+    duration = time.time() - start_time
+    logger.info(
+        f"Anthropic→mantle streaming done: request_id={request_id}, "
         f"duration={round(duration, 3)}s, "
         f"prompt={non_cached_prompt}, completion={total_completion_tokens}"
     )

--- a/backend/app/api/v1/endpoints/chat.py
+++ b/backend/app/api/v1/endpoints/chat.py
@@ -33,6 +33,12 @@ from app.services.gemini_client import (
     extract_cached_tokens,
     extract_cached_tokens_from_chunk,
 )
+from app.services.mantle_client import (
+    MantleClient,
+    extract_cached_tokens as _mantle_extract_cached_tokens,
+    extract_cached_tokens_from_chunk as _mantle_extract_cached_tokens_from_chunk,
+)
+from app.services.mantle_models import is_openai_mantle_model
 from app.core.metrics import emit_request_metrics
 from app.services.pricing import ModelPricing
 from app.services.translator import RequestTranslator, ResponseTranslator
@@ -216,6 +222,15 @@ async def create_chat_completion(
         # Route Gemini models to Google API directly
         if _is_gemini_model(request_data.model):
             return await _handle_gemini_request(
+                request_data=request_data,
+                request_id=request_id,
+                token=token,
+                start_time=start_time,
+            )
+
+        # Route OpenAI GPT-5.5/5.4 (mantle) to the Responses API directly
+        if is_openai_mantle_model(request_data.model):
+            return await _handle_mantle_request(
                 request_data=request_data,
                 request_id=request_id,
                 token=token,
@@ -536,6 +551,181 @@ async def stream_gemini_completion(
     cache_info = f", cached={total_cached_tokens}" if total_cached_tokens else ""
     logger.info(
         f"Gemini streaming successful: request_id={request_id}, "
+        f"duration={round(duration, 3)}s, "
+        f"prompt={non_cached_prompt}, completion={total_completion_tokens}{cache_info}"
+    )
+
+
+async def _handle_mantle_request(
+    request_data: ChatCompletionRequest,
+    request_id: str,
+    token: APIToken,
+    start_time: float,
+):
+    """
+    Forward a chat completion request to AWS mantle (OpenAI GPT-5.5/5.4).
+
+    Converts the OpenAI ChatCompletions payload to the Responses API internally;
+    the request is routed (and SigV4-signed) to the model's region automatically.
+    """
+    payload = request_data.model_dump(exclude_none=True)
+
+    if request_data.stream:
+        return StreamingResponse(
+            stream_mantle_completion(
+                payload=payload,
+                request_id=request_id,
+                model=request_data.model,
+                token=token,
+                start_time=start_time,
+            ),
+            media_type="text/event-stream",
+        )
+
+    # Non-streaming
+    try:
+        response_data = await MantleClient.invoke(payload)
+    except httpx.HTTPStatusError as e:
+        logger.error(f"mantle API error: {e}")
+        raise HTTPException(
+            status_code=e.response.status_code,
+            detail=f"mantle API error: status {e.response.status_code}",
+        )
+
+    # Extract usage including cached tokens for billing.
+    usage = response_data.get("usage", {})
+    prompt_tokens = usage.get("prompt_tokens", 0)
+    completion_tokens = usage.get("completion_tokens", 0)
+    cached_tokens = _mantle_extract_cached_tokens(response_data)
+    # Responses reports input_tokens as the total including cached; bill only non-cached.
+    non_cached_prompt = max(0, prompt_tokens - cached_tokens)
+
+    background_tasks.create_task(
+        record_usage(
+            token_id=token.id,
+            user_id=token.user_id,
+            model=request_data.model,
+            request_id=request_id,
+            prompt_tokens=non_cached_prompt,
+            completion_tokens=completion_tokens,
+            cache_read_input_tokens=cached_tokens,
+        ),
+        task_name=f"record_usage_{request_id}",
+    )
+
+    duration = time.time() - start_time
+    cache_info = f", cached={cached_tokens}" if cached_tokens else ""
+    logger.info(
+        f"mantle completion successful: request_id={request_id}, "
+        f"duration={round(duration, 3)}s, "
+        f"prompt={non_cached_prompt}, completion={completion_tokens}{cache_info}"
+    )
+
+    return response_data
+
+
+async def stream_mantle_completion(
+    payload: dict,
+    request_id: str,
+    model: str,
+    token: APIToken,
+    start_time: float,
+) -> AsyncGenerator[str, None]:
+    """
+    Stream a mantle (GPT-5.5/5.4) completion via the Responses API.
+
+    MantleClient.invoke_stream yields OpenAI-format SSE chunks; we forward them
+    verbatim and extract usage from any chunk that carries a usage object.
+    """
+    import json as _json
+
+    settings = get_settings()
+    total_prompt_tokens = 0
+    total_completion_tokens = 0
+    total_cached_tokens = 0
+    last_heartbeat = time.time()
+
+    try:
+        async for chunk in MantleClient.invoke_stream(payload):
+            current_time = time.time()
+
+            # Send heartbeat if idle too long
+            if current_time - last_heartbeat > settings.STREAM_HEARTBEAT_INTERVAL:
+                yield ": heartbeat\n\n"
+                last_heartbeat = current_time
+
+            # Forward OpenAI-format SSE chunk produced by invoke_stream
+            yield chunk
+            last_heartbeat = current_time
+
+            # Extract usage for billing (appears on the final chunk)
+            for line in chunk.splitlines():
+                if line.startswith("data: ") and line.strip() != "data: [DONE]":
+                    try:
+                        data = _json.loads(line[6:])
+                        usage = data.get("usage")
+                        if usage:
+                            total_prompt_tokens = usage.get(
+                                "prompt_tokens", total_prompt_tokens
+                            )
+                            total_completion_tokens = usage.get(
+                                "completion_tokens", total_completion_tokens
+                            )
+                            cached = _mantle_extract_cached_tokens_from_chunk(data)
+                            if cached is not None:
+                                total_cached_tokens = cached
+                    except Exception:
+                        pass
+
+    except httpx.HTTPStatusError as e:
+        logger.error(
+            f"mantle stream error: model={model}, request_id={request_id}, "
+            f"status={e.response.status_code}",
+            exc_info=True,
+        )
+        error_response = ErrorResponse(
+            error=ErrorDetail(
+                message=f"mantle API error: status {e.response.status_code}",
+                type="server_error",
+                code=str(e.response.status_code),
+            )
+        )
+        yield f"data: {error_response.model_dump_json()}\n\n"
+    except Exception as e:
+        logger.error(
+            f"mantle streaming failed: model={model}, request_id={request_id}, error={e}",
+            exc_info=True,
+        )
+        error_response = ErrorResponse(
+            error=ErrorDetail(
+                message="Internal server error",
+                type="server_error",
+                code="internal_error",
+            )
+        )
+        yield f"data: {error_response.model_dump_json()}\n\n"
+
+    # Adjust prompt tokens to exclude cached
+    non_cached_prompt = max(0, total_prompt_tokens - total_cached_tokens)
+
+    # Record usage
+    background_tasks.create_task(
+        record_usage(
+            token_id=token.id,
+            user_id=token.user_id,
+            model=model,
+            request_id=request_id,
+            prompt_tokens=non_cached_prompt,
+            completion_tokens=total_completion_tokens,
+            cache_read_input_tokens=total_cached_tokens,
+        ),
+        task_name=f"record_usage_{request_id}",
+    )
+
+    duration = time.time() - start_time
+    cache_info = f", cached={total_cached_tokens}" if total_cached_tokens else ""
+    logger.info(
+        f"mantle streaming successful: request_id={request_id}, "
         f"duration={round(duration, 3)}s, "
         f"prompt={non_cached_prompt}, completion={total_completion_tokens}{cache_info}"
     )

--- a/backend/app/api/v1/endpoints/responses.py
+++ b/backend/app/api/v1/endpoints/responses.py
@@ -1,0 +1,279 @@
+"""
+OpenAI Responses API endpoint (native passthrough for AWS mantle).
+
+GPT-5.5 / GPT-5.4 are served by AWS's "mantle" inference engine through the
+**OpenAI Responses API**. The OpenAI-compatible ``/v1/chat/completions`` and the
+Anthropic ``/v1/messages`` endpoints translate to/from the Responses format,
+which necessarily flattens Responses-only features (built-in tools, multimodal
+output, etc.).
+
+This endpoint instead forwards a *native* Responses request body to mantle
+verbatim and returns the native response, so clients that speak the Responses
+API get mantle's full capability surface with no lossy conversion. It is the
+only path that will transparently gain new mantle features (e.g. image
+generation) the moment AWS enables them — no code change required.
+
+The request body is accepted as an open JSON object (not a strict schema) for
+exactly that reason: unknown/new Responses fields pass straight through.
+"""
+
+import json
+import logging
+import time
+import uuid
+from typing import Any, AsyncGenerator, Dict
+
+import httpx
+from fastapi import APIRouter, Depends, HTTPException, Request
+from fastapi.responses import JSONResponse, StreamingResponse
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.api.deps import get_current_token
+from app.api.v1.endpoints.chat import record_usage
+from app.core.config import get_settings
+from app.core.database import get_db
+from app.models.model import Model
+from app.models.token import APIToken
+from app.services.background_tasks import BackgroundTaskManager
+from app.services.mantle_client import MantleClient
+from app.services.mantle_models import is_openai_mantle_model
+
+router = APIRouter()
+logger = logging.getLogger(__name__)
+background_tasks = BackgroundTaskManager()
+
+
+def _usage_from_response(usage: Dict[str, Any]) -> Dict[str, int]:
+    """Extract billing token counts from a Responses ``usage`` object.
+
+    Returns (non_cached_prompt, completion, cached) — input_tokens reported by
+    the Responses API includes cached tokens, so bill only the non-cached part.
+    """
+    prompt = usage.get("input_tokens", 0) or 0
+    completion = usage.get("output_tokens", 0) or 0
+    cached = (usage.get("input_tokens_details") or {}).get("cached_tokens", 0) or 0
+    return {
+        "non_cached_prompt": max(0, prompt - cached),
+        "completion": completion,
+        "cached": cached,
+    }
+
+
+@router.post("/responses")
+async def create_response(
+    http_request: Request,
+    token: APIToken = Depends(get_current_token),
+    db: AsyncSession = Depends(get_db),
+):
+    """
+    Create a model response (OpenAI Responses API, native passthrough).
+
+    Only mantle-served models (GPT-5.5/5.4) are accepted here — other models do
+    not have a Responses API backend. The request body is forwarded to mantle
+    verbatim and the native response is returned unchanged.
+    """
+    request_id = f"resp_{uuid.uuid4().hex[:24]}"
+    start_time = time.time()
+
+    # Parse the raw JSON body (open schema — forward unknown fields verbatim)
+    try:
+        body: Dict[str, Any] = await http_request.json()
+    except Exception:
+        raise HTTPException(status_code=400, detail="Invalid JSON request body")
+    if not isinstance(body, dict):
+        raise HTTPException(
+            status_code=400, detail="Request body must be a JSON object"
+        )
+
+    model = body.get("model")
+    if not model or not isinstance(model, str):
+        raise HTTPException(status_code=400, detail="Missing 'model' in request body")
+
+    stream = bool(body.get("stream", False))
+
+    logger.info(
+        f"Responses request: model={model}, stream={stream}, "
+        f"request_id={request_id}, token_id={token.id}",
+    )
+
+    # Only mantle models have a Responses backend.
+    if not is_openai_mantle_model(model):
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                f"Model '{model}' is not available on the Responses API. "
+                "This endpoint serves OpenAI GPT-5.5/5.4 (mantle) only; "
+                "use /v1/chat/completions for other models."
+            ),
+        )
+
+    # Quota + model access (same checks as the other gateway endpoints)
+    from sqlalchemy import select
+    from app.services.quota import enforce_quota
+
+    await enforce_quota(token, db)
+
+    result = await db.execute(
+        select(Model).where(
+            Model.token_id == token.id,
+            Model.is_active,
+            ~Model.is_deleted,
+        )
+    )
+    allowed_model_names = [m.model_name for m in result.scalars().all()]
+    if model not in allowed_model_names:
+        raise HTTPException(
+            status_code=403,
+            detail=f"Token does not have access to model: {model}. "
+            f"Allowed models: {allowed_model_names}",
+        )
+
+    if stream:
+        return StreamingResponse(
+            _stream_responses(
+                body=body,
+                request_id=request_id,
+                model=model,
+                token=token,
+                start_time=start_time,
+            ),
+            media_type="text/event-stream",
+            headers={"Cache-Control": "no-cache", "Connection": "keep-alive"},
+        )
+
+    # Non-streaming passthrough
+    try:
+        response_data = await MantleClient.responses_passthrough(body)
+    except httpx.HTTPStatusError as e:
+        logger.error(f"mantle Responses error: {e}")
+        raise HTTPException(
+            status_code=e.response.status_code,
+            detail=f"mantle API error: status {e.response.status_code}",
+        )
+
+    usage = _usage_from_response(response_data.get("usage") or {})
+    background_tasks.create_task(
+        record_usage(
+            token_id=token.id,
+            user_id=token.user_id,
+            model=model,
+            request_id=request_id,
+            prompt_tokens=usage["non_cached_prompt"],
+            completion_tokens=usage["completion"],
+            cache_read_input_tokens=usage["cached"],
+        ),
+        task_name=f"record_usage_{request_id}",
+    )
+
+    duration = time.time() - start_time
+    cache_info = f", cached={usage['cached']}" if usage["cached"] else ""
+    logger.info(
+        f"Responses successful: request_id={request_id}, "
+        f"duration={round(duration, 3)}s, prompt={usage['non_cached_prompt']}, "
+        f"completion={usage['completion']}{cache_info}"
+    )
+
+    return JSONResponse(content=response_data)
+
+
+async def _stream_responses(
+    body: Dict[str, Any],
+    request_id: str,
+    model: str,
+    token: APIToken,
+    start_time: float,
+) -> AsyncGenerator[bytes, None]:
+    """Forward mantle's native Responses SSE verbatim, billing from usage events.
+
+    The raw SSE bytes are passed through unchanged; we also buffer line-by-line
+    to find the ``response.completed`` / ``response.incomplete`` event and read
+    its usage object for billing — without altering the client-facing stream.
+    """
+    settings = get_settings()
+    usage = {"non_cached_prompt": 0, "completion": 0, "cached": 0}
+    buffer = ""
+    last_heartbeat = time.time()
+
+    try:
+        async for raw in MantleClient.responses_passthrough_stream(body):
+            # Forward upstream bytes unchanged
+            yield raw
+            last_heartbeat = time.time()
+
+            # Sniff usage from completed/incomplete events without mutating output
+            try:
+                buffer += raw.decode("utf-8", errors="replace")
+            except Exception:
+                buffer = ""
+                continue
+            while "\n" in buffer:
+                line, buffer = buffer.split("\n", 1)
+                line = line.strip()
+                if not line.startswith("data:"):
+                    continue
+                data_str = line[5:].strip()
+                if not data_str or data_str == "[DONE]":
+                    continue
+                try:
+                    event = json.loads(data_str)
+                except json.JSONDecodeError:
+                    continue
+                etype = event.get("type")
+                if etype in ("response.completed", "response.incomplete"):
+                    resp_obj = event.get("response") or {}
+                    usage = _usage_from_response(resp_obj.get("usage") or {})
+
+            # Heartbeat to keep idle connections alive
+            if time.time() - last_heartbeat > settings.STREAM_HEARTBEAT_INTERVAL:
+                yield b": heartbeat\n\n"
+                last_heartbeat = time.time()
+
+    except httpx.HTTPStatusError as e:
+        logger.error(
+            f"mantle Responses stream error: model={model}, "
+            f"request_id={request_id}, status={e.response.status_code}",
+            exc_info=True,
+        )
+        err = {
+            "type": "error",
+            "error": {
+                "type": "server_error",
+                "message": f"mantle API error: status {e.response.status_code}",
+            },
+        }
+        yield f"event: error\ndata: {json.dumps(err)}\n\n".encode("utf-8")
+        return
+    except Exception as e:
+        logger.error(
+            f"mantle Responses streaming failed: model={model}, "
+            f"request_id={request_id}, error={e}",
+            exc_info=True,
+        )
+        err = {
+            "type": "error",
+            "error": {"type": "server_error", "message": "Internal server error"},
+        }
+        yield f"event: error\ndata: {json.dumps(err)}\n\n".encode("utf-8")
+        return
+
+    # Record usage after the stream completes
+    background_tasks.create_task(
+        record_usage(
+            token_id=token.id,
+            user_id=token.user_id,
+            model=model,
+            request_id=request_id,
+            prompt_tokens=usage["non_cached_prompt"],
+            completion_tokens=usage["completion"],
+            cache_read_input_tokens=usage["cached"],
+        ),
+        task_name=f"record_usage_{request_id}",
+    )
+
+    duration = time.time() - start_time
+    cache_info = f", cached={usage['cached']}" if usage["cached"] else ""
+    logger.info(
+        f"Responses streaming successful: request_id={request_id}, "
+        f"duration={round(duration, 3)}s, prompt={usage['non_cached_prompt']}, "
+        f"completion={usage['completion']}{cache_info}"
+    )

--- a/backend/app/api/v1/router.py
+++ b/backend/app/api/v1/router.py
@@ -5,12 +5,13 @@ All endpoints require API Token authentication.
 
 from fastapi import APIRouter
 
-from app.api.v1.endpoints import chat, models
+from app.api.v1.endpoints import chat, models, responses
 
 gateway_router = APIRouter()
 
 # Include AI Gateway endpoint routers
 gateway_router.include_router(chat.router, tags=["chat"])
+gateway_router.include_router(responses.router, tags=["responses"])
 gateway_router.include_router(models.router, tags=["models"])
 
 
@@ -23,6 +24,7 @@ async def gateway_root():
         "compatible_with": ["OpenAI API v1", "Anthropic Messages API"],
         "endpoints": {
             "chat_completions": "/v1/chat/completions",
+            "responses": "/v1/responses",
             "messages": "/v1/messages",
             "models": "/v1/models",
         },

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -70,6 +70,13 @@ class Settings(BaseSettings):
         description="Google Cloud region for Vertex AI",
     )
 
+    # OpenAI-on-Bedrock (mantle) settings — GPT-5.5 / GPT-5.4 via Responses API
+    MANTLE_SIGV4_SERVICE: str = Field(
+        default="bedrock",
+        description="SigV4 service name used to sign mantle (OpenAI Responses API) requests. "
+        "Override to 'bedrock-runtime' / 'bedrock-mantle' if signing is rejected.",
+    )
+
     # AWS Bedrock settings
     BEDROCK_MAX_CONCURRENT_REQUESTS: int = Field(
         default=50,

--- a/backend/app/schemas/anthropic.py
+++ b/backend/app/schemas/anthropic.py
@@ -4,10 +4,37 @@ Anthropic Messages API compatible request/response schemas.
 
 from typing import Any, Dict, List, Literal, Optional, Union
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, model_validator
 
 
 # --- Request schemas ---
+
+
+def _extract_text(content: Any) -> str:
+    """Flatten Anthropic content (str or list of text blocks) into plain text.
+
+    Used to hoist ``system`` messages — which may carry either a bare string or
+    a list of ``{"type": "text", "text": ...}`` blocks — into the top-level
+    ``system`` field. Non-text blocks are ignored.
+    """
+    if content is None:
+        return ""
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        texts: List[str] = []
+        for block in content:
+            if isinstance(block, dict):
+                if block.get("type", "text") == "text" and block.get("text"):
+                    texts.append(block["text"])
+            elif isinstance(block, str):
+                texts.append(block)
+            else:
+                text = getattr(block, "text", None)
+                if text:
+                    texts.append(text)
+        return "\n".join(texts)
+    return str(content)
 
 
 class AnthropicTextContent(BaseModel):
@@ -82,9 +109,17 @@ AnthropicContentBlock = Union[
 
 
 class AnthropicMessage(BaseModel):
-    """Message in Anthropic format."""
+    """Message in Anthropic format.
 
-    role: Literal["user", "assistant"]
+    The Anthropic spec only allows ``user``/``assistant`` here, but some clients
+    (notably Claude Code) inject a ``system`` message into the ``messages`` array
+    instead of the top-level ``system`` field. ``role`` accepts ``system`` so
+    those requests parse; ``AnthropicMessagesRequest`` then hoists any such
+    messages into the top-level ``system`` field before validation completes, so
+    downstream code never sees a ``system`` role in ``messages``.
+    """
+
+    role: Literal["user", "assistant", "system"]
     content: Union[str, List[AnthropicContentBlock]]
 
 
@@ -130,6 +165,42 @@ class AnthropicMessagesRequest(BaseModel):
     disable_parallel_tool_use: Optional[bool] = None
     metadata: Optional[Dict[str, Any]] = None
     thinking: Optional[AnthropicThinkingConfig] = None
+
+    @model_validator(mode="before")
+    @classmethod
+    def _hoist_system_messages(cls, data: Any) -> Any:
+        """Move any ``system`` role messages into the top-level ``system`` field.
+
+        Some clients (e.g. Claude Code) put a ``system`` message inside the
+        ``messages`` array rather than the top-level ``system`` field, which the
+        Anthropic spec disallows. To stay compatible, pull those out, prepend
+        their text to ``system``, and leave ``messages`` with only
+        ``user``/``assistant`` entries — transparent to all downstream logic.
+        """
+        if not isinstance(data, dict):
+            return data
+        messages = data.get("messages")
+        if not isinstance(messages, list):
+            return data
+
+        system_texts: List[str] = []
+        kept: List[Any] = []
+        for msg in messages:
+            if isinstance(msg, dict) and msg.get("role") == "system":
+                system_texts.append(_extract_text(msg.get("content")))
+            else:
+                kept.append(msg)
+        if not system_texts:
+            return data
+
+        # Prepend hoisted system text to any existing top-level system content.
+        existing = data.get("system")
+        parts = [t for t in system_texts if t]
+        if existing:
+            parts.append(_extract_text(existing))
+        data["system"] = "\n\n".join(p for p in parts if p)
+        data["messages"] = kept
+        return data
 
 
 # --- Response schemas ---

--- a/backend/app/schemas/openai.py
+++ b/backend/app/schemas/openai.py
@@ -51,6 +51,7 @@ class ChatCompletionRequest(BaseModel):
     user: Optional[str] = None
     tools: Optional[List[Dict[str, Any]]] = None
     tool_choice: Optional[Union[str, Dict[str, Any]]] = None
+    response_format: Optional[Dict[str, Any]] = None
     # Bedrock-specific extensions (bedrock_* prefix)
     bedrock_guardrail_config: Optional[Dict[str, Any]] = None
     bedrock_additional_model_request_fields: Optional[Dict[str, Any]] = None

--- a/backend/app/services/mantle_client.py
+++ b/backend/app/services/mantle_client.py
@@ -1,0 +1,651 @@
+"""
+OpenAI-on-Bedrock (mantle) API client service.
+
+GPT-5.5 / GPT-5.4 are served by AWS's "mantle" inference engine through the
+**OpenAI Responses API** (``https://bedrock-mantle.{region}.api.aws/openai/v1``
+→ ``/responses``), not through the boto3 ``converse`` / ``invoke_model`` paths.
+
+This client mirrors ``gemini_client.py``: it converts OpenAI ChatCompletions
+requests to the Responses API format and the responses back, so the rest of the
+pipeline (chat.py, usage recording, pricing) stays unchanged.
+
+Auth is SigV4 over the existing AWS credential chain (reused from BedrockClient's
+aioboto3 session — IRSA/STS on EKS, static keys / profile locally), so no new
+secret or bearer token is introduced.
+"""
+
+import json
+import logging
+import time
+import uuid
+from typing import Any, AsyncGenerator, Dict, List, Optional, Tuple
+
+import httpx
+from botocore.auth import SigV4Auth
+from botocore.awsrequest import AWSRequest
+
+from app.core.config import get_settings
+from app.services.mantle_models import MANTLE_BASE_URL, resolve_mantle_region
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# SigV4 signing
+# ---------------------------------------------------------------------------
+
+
+async def _signed_headers(
+    method: str, url: str, body_bytes: bytes, region: str
+) -> Dict[str, str]:
+    """Return SigV4-signed headers for a mantle request.
+
+    Credentials come from the shared BedrockClient aioboto3 session (reuses the
+    EKS Pod IRSA/STS chain, including a SessionToken → ``X-Amz-Security-Token``).
+    In aiobotocore both ``get_credentials`` and ``get_frozen_credentials`` are
+    coroutines and must be awaited (unlike sync botocore).
+
+    The signature is computed over the EXACT *body_bytes* that will be sent.
+    """
+    from app.services.bedrock import BedrockClient
+
+    session = BedrockClient.get_instance().session
+    creds = await session.get_credentials()
+    if creds is None:
+        raise RuntimeError("No AWS credentials available to sign mantle request")
+    frozen = await creds.get_frozen_credentials()
+
+    service = get_settings().MANTLE_SIGV4_SERVICE
+    aws_req = AWSRequest(
+        method=method,
+        url=url,
+        data=body_bytes,
+        headers={"Content-Type": "application/json"},
+    )
+    SigV4Auth(frozen, service, region).add_auth(aws_req)
+    return dict(aws_req.headers)
+
+
+# ---------------------------------------------------------------------------
+# Request conversion: OpenAI ChatCompletions → OpenAI Responses
+# ---------------------------------------------------------------------------
+
+
+def _content_part_to_responses(part: Dict[str, Any]) -> Dict[str, Any]:
+    """Convert one OpenAI ContentPart dict to a Responses API input part."""
+    ptype = part.get("type")
+    if ptype == "text":
+        return {"type": "input_text", "text": part.get("text", "")}
+    if ptype == "image_url":
+        url = (part.get("image_url") or {}).get("url", "")
+        # Responses API takes the data-URL / URL directly on input_image.
+        return {"type": "input_image", "image_url": url}
+    # Unknown type — best-effort text fallback
+    return {"type": "input_text", "text": str(part.get("text", ""))}
+
+
+def _msg_content_to_input_parts(content: Any, output: bool) -> List[Dict[str, Any]]:
+    """Convert an OpenAI message content value (str or list) to Responses parts.
+
+    *output* selects the text part type: assistant turns use ``output_text``,
+    everything else uses ``input_text``.
+    """
+    text_type = "output_text" if output else "input_text"
+    if content is None:
+        return []
+    if isinstance(content, str):
+        return [{"type": text_type, "text": content}] if content else []
+    if isinstance(content, list):
+        parts = []
+        for p in content:
+            if isinstance(p, dict):
+                # Assistant text parts must use output_text in the Responses API.
+                if output and p.get("type") == "text":
+                    parts.append({"type": "output_text", "text": p.get("text", "")})
+                else:
+                    parts.append(_content_part_to_responses(p))
+        return parts
+    return [{"type": text_type, "text": str(content)}]
+
+
+def _openai_messages_to_input(
+    messages: List[Dict[str, Any]],
+) -> List[Dict[str, Any]]:
+    """Convert an OpenAI messages array to a Responses API ``input`` list.
+
+    Roles:
+      system     → message with role "developer"
+      user       → message with role "user"
+      assistant  → message with role "assistant" (tool_calls → function_call items)
+      tool       → function_call_output item (keyed by call_id)
+    """
+    input_items: List[Dict[str, Any]] = []
+
+    for msg in messages:
+        role = msg.get("role", "user")
+        content = msg.get("content")
+        tool_calls = msg.get("tool_calls")
+
+        # ── tool result ─────────────────────────────────────────────────────
+        if role == "tool":
+            raw = content or ""
+            output_str = raw if isinstance(raw, str) else json.dumps(raw)
+            input_items.append(
+                {
+                    "type": "function_call_output",
+                    "call_id": msg.get("tool_call_id", ""),
+                    "output": output_str,
+                }
+            )
+            continue
+
+        # ── system → developer ──────────────────────────────────────────────
+        if role == "system":
+            parts = _msg_content_to_input_parts(content, output=False)
+            if parts:
+                input_items.append({"role": "developer", "content": parts})
+            continue
+
+        # ── user / assistant ─────────────────────────────────────────────────
+        is_assistant = role == "assistant"
+        parts = _msg_content_to_input_parts(content, output=is_assistant)
+        if parts:
+            input_items.append(
+                {"role": "assistant" if is_assistant else "user", "content": parts}
+            )
+
+        # Assistant tool calls → function_call items
+        for tc in tool_calls or []:
+            fn = tc.get("function") or {}
+            input_items.append(
+                {
+                    "type": "function_call",
+                    "call_id": tc.get("id", ""),
+                    "name": fn.get("name", ""),
+                    "arguments": fn.get("arguments", "{}"),
+                }
+            )
+
+    return input_items
+
+
+def _openai_tools_to_responses(
+    tools: Optional[List[Dict[str, Any]]],
+) -> Optional[List[Dict[str, Any]]]:
+    """Convert OpenAI ChatCompletions tools to Responses API tools.
+
+    Responses flattens the function spec (name/description/parameters live at the
+    top level of the tool, not nested under a ``function`` key).
+    """
+    if not tools:
+        return None
+    out = []
+    for tool in tools:
+        if tool.get("type") == "function":
+            fn = tool.get("function") or {}
+            decl: Dict[str, Any] = {"type": "function", "name": fn.get("name", "")}
+            if fn.get("description"):
+                decl["description"] = fn["description"]
+            if fn.get("parameters"):
+                decl["parameters"] = fn["parameters"]
+            out.append(decl)
+    return out or None
+
+
+def _openai_response_format_to_text_format(
+    response_format: Any,
+) -> Optional[Dict[str, Any]]:
+    """Convert OpenAI ``response_format`` to a Responses API ``text.format`` value.
+
+    OpenAI ChatCompletions nests the JSON schema under ``json_schema`` with the
+    spec inside; the Responses API flattens ``name``/``schema``/``strict`` to the
+    top level of ``text.format``.
+
+      {"type": "text"}                       → {"type": "text"}
+      {"type": "json_object"}                → {"type": "json_object"}
+      {"type": "json_schema",
+       "json_schema": {"name", "schema", "strict"}}
+                                             → {"type": "json_schema",
+                                                "name", "schema", "strict"}
+    """
+    if not isinstance(response_format, dict):
+        return None
+    rf_type = response_format.get("type")
+    if rf_type in ("text", "json_object"):
+        return {"type": rf_type}
+    if rf_type == "json_schema":
+        js = response_format.get("json_schema") or {}
+        fmt: Dict[str, Any] = {"type": "json_schema"}
+        if js.get("name"):
+            fmt["name"] = js["name"]
+        if js.get("schema") is not None:
+            fmt["schema"] = js["schema"]
+        if js.get("description"):
+            fmt["description"] = js["description"]
+        if js.get("strict") is not None:
+            fmt["strict"] = js["strict"]
+        return fmt
+    return None
+
+
+def _openai_tool_choice_to_responses(tool_choice: Any) -> Optional[Any]:
+    """Convert OpenAI tool_choice to a Responses API tool_choice value."""
+    if tool_choice is None:
+        return None
+    if tool_choice in ("none", "auto", "required"):
+        return tool_choice
+    if isinstance(tool_choice, dict) and tool_choice.get("type") == "function":
+        fn_name = (tool_choice.get("function") or {}).get("name")
+        if fn_name:
+            return {"type": "function", "name": fn_name}
+    return None
+
+
+def _openai_to_responses(payload: Dict[str, Any]) -> Dict[str, Any]:
+    """Convert a full OpenAI chat completion payload to a Responses request body.
+
+    Mappings:
+      model               → model
+      messages            → input  (system → developer role)
+      max_tokens          → max_output_tokens
+      temperature         → temperature
+      top_p               → top_p
+      tools               → tools  (flattened function spec)
+      tool_choice         → tool_choice
+      reasoning.effort    ← bedrock_additional_model_request_fields.reasoning.effort
+                            (no new schema field; reuse the existing passthrough)
+
+    OpenAI-only fields (frequency_penalty, n, presence_penalty, etc.) are
+    silently ignored.
+    """
+    messages = payload.get("messages") or []
+    body: Dict[str, Any] = {
+        "model": payload.get("model", ""),
+        "input": _openai_messages_to_input(messages),
+    }
+
+    if payload.get("max_tokens") is not None:
+        body["max_output_tokens"] = payload["max_tokens"]
+    if payload.get("temperature") is not None:
+        body["temperature"] = payload["temperature"]
+    if payload.get("top_p") is not None:
+        body["top_p"] = payload["top_p"]
+
+    tools = _openai_tools_to_responses(payload.get("tools"))
+    if tools:
+        body["tools"] = tools
+    tool_choice = _openai_tool_choice_to_responses(payload.get("tool_choice"))
+    if tool_choice is not None:
+        body["tool_choice"] = tool_choice
+
+    # response_format → text.format (structured / JSON output)
+    text_format = _openai_response_format_to_text_format(payload.get("response_format"))
+    if text_format is not None:
+        body["text"] = {"format": text_format}
+
+    # reasoning.effort rides the existing bedrock_additional_model_request_fields
+    # passthrough channel so no new request schema field is needed.
+    extra = payload.get("bedrock_additional_model_request_fields") or {}
+    reasoning = extra.get("reasoning")
+    if isinstance(reasoning, dict) and reasoning.get("effort"):
+        body["reasoning"] = {"effort": reasoning["effort"]}
+
+    return body
+
+
+# ---------------------------------------------------------------------------
+# Response conversion: OpenAI Responses → OpenAI ChatCompletions
+# ---------------------------------------------------------------------------
+
+
+def _build_usage(usage: Dict[str, Any]) -> Dict[str, Any]:
+    """Build an OpenAI ChatCompletions usage dict from a Responses usage object."""
+    prompt = usage.get("input_tokens", 0)
+    completion = usage.get("output_tokens", 0)
+    total = usage.get("total_tokens", prompt + completion)
+    cached = (usage.get("input_tokens_details") or {}).get("cached_tokens", 0)
+    out: Dict[str, Any] = {
+        "prompt_tokens": prompt,
+        "completion_tokens": completion,
+        "total_tokens": total,
+    }
+    if cached:
+        out["prompt_tokens_details"] = {"cached_tokens": cached}
+    return out
+
+
+def _output_to_message(
+    output: List[Dict[str, Any]],
+) -> Tuple[Optional[str], Optional[List[Dict]]]:
+    """Parse a Responses ``output`` array into (text, tool_calls).
+
+    ``reasoning`` items are skipped; ``message`` items contribute output_text;
+    ``function_call`` items become OpenAI tool_calls.
+    """
+    texts: List[str] = []
+    tool_calls: List[Dict[str, Any]] = []
+
+    for item in output:
+        itype = item.get("type")
+        if itype == "message":
+            for part in item.get("content") or []:
+                if part.get("type") == "output_text":
+                    texts.append(part.get("text", ""))
+        elif itype == "function_call":
+            tool_calls.append(
+                {
+                    "id": item.get("call_id") or f"call_{uuid.uuid4().hex[:16]}",
+                    "type": "function",
+                    "function": {
+                        "name": item.get("name", ""),
+                        "arguments": item.get("arguments", "{}"),
+                    },
+                }
+            )
+        # reasoning / other item types are intentionally ignored
+
+    return ("".join(texts) if texts else None, tool_calls or None)
+
+
+def _responses_to_openai(
+    resp: Dict[str, Any], model: str, request_id: str
+) -> Dict[str, Any]:
+    """Convert a full Responses API response to OpenAI ChatCompletions format."""
+    output = resp.get("output") or []
+    text, tool_calls = _output_to_message(output)
+
+    if tool_calls:
+        msg_content: Any = None  # OpenAI spec: null content when tool_calls present
+        finish_reason = "tool_calls"
+    else:
+        msg_content = text if text is not None else ""
+        finish_reason = "length" if resp.get("status") == "incomplete" else "stop"
+
+    message: Dict[str, Any] = {"role": "assistant", "content": msg_content}
+    if tool_calls:
+        message["tool_calls"] = tool_calls
+
+    return {
+        "id": request_id,
+        "object": "chat.completion",
+        "created": int(time.time()),
+        "model": model,
+        "choices": [{"index": 0, "message": message, "finish_reason": finish_reason}],
+        "usage": _build_usage(resp.get("usage") or {}),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Cached-token helpers (operate on already-converted OpenAI-format dicts)
+# ---------------------------------------------------------------------------
+
+
+def extract_cached_tokens(response: dict) -> int:
+    """Extract cached token count from an OpenAI-format response dict."""
+    usage = response.get("usage", {})
+    details = usage.get("prompt_tokens_details")
+    if not details:
+        return 0
+    if isinstance(details, dict):
+        return int(details.get("cached_tokens", 0))
+    if isinstance(details, list):
+        for item in details:
+            if isinstance(item, dict) and "cached_tokens" in item:
+                return int(item["cached_tokens"])
+    return 0
+
+
+def extract_cached_tokens_from_chunk(data: dict) -> Optional[int]:
+    """Extract cached token count from a streaming chunk's usage field."""
+    usage = data.get("usage")
+    if not usage:
+        return None
+    return extract_cached_tokens({"usage": usage})
+
+
+# ---------------------------------------------------------------------------
+# MantleClient
+# ---------------------------------------------------------------------------
+
+
+class MantleClient:
+    """Client for the OpenAI Responses API served by AWS mantle (GPT-5.5/5.4)."""
+
+    @staticmethod
+    def _endpoint(model: str) -> Tuple[str, str]:
+        """Return (url, region) for the /responses endpoint of *model*."""
+        region = resolve_mantle_region(model)
+        base = MANTLE_BASE_URL.format(region=region)
+        return f"{base}/responses", region
+
+    # ------------------------------------------------------------------
+    # Native Responses API passthrough (no protocol conversion)
+    #
+    # These methods forward a native OpenAI Responses request body to mantle
+    # verbatim and return the native response. Unlike invoke()/invoke_stream(),
+    # which translate to/from ChatCompletions, the passthrough preserves every
+    # Responses-only feature (built-in tools, multimodal output, etc.) so the
+    # /v1/responses endpoint exposes mantle's full capability surface.
+    # ------------------------------------------------------------------
+
+    @classmethod
+    async def responses_passthrough(cls, body: dict) -> dict:
+        """Non-streaming native Responses request — body forwarded verbatim."""
+        model = body.get("model", "")
+        url, region = cls._endpoint(model)
+        send_body = dict(body)
+        send_body["stream"] = False
+        body_bytes = json.dumps(send_body).encode("utf-8")
+        headers = await _signed_headers("POST", url, body_bytes, region)
+
+        async with httpx.AsyncClient(timeout=3600) as client:
+            resp = await client.post(url, headers=headers, content=body_bytes)
+
+        if resp.status_code != 200:
+            logger.error(
+                f"mantle Responses error: status={resp.status_code}, "
+                f"region={region}, body={resp.text[:500]}"
+            )
+            raise httpx.HTTPStatusError(
+                f"mantle API returned {resp.status_code}: {resp.text[:200]}",
+                request=resp.request,
+                response=resp,
+            )
+
+        return resp.json()
+
+    @classmethod
+    async def responses_passthrough_stream(
+        cls, body: dict
+    ) -> AsyncGenerator[bytes, None]:
+        """Streaming native Responses request — raw SSE bytes forwarded verbatim.
+
+        Yields the upstream SSE stream unchanged so the client receives mantle's
+        native Responses events. Usage for billing is extracted by the caller
+        from the ``response.completed`` / ``response.incomplete`` events.
+        """
+        model = body.get("model", "")
+        url, region = cls._endpoint(model)
+        send_body = dict(body)
+        send_body["stream"] = True
+        body_bytes = json.dumps(send_body).encode("utf-8")
+        headers = await _signed_headers("POST", url, body_bytes, region)
+        headers["Accept"] = "text/event-stream"
+
+        async with httpx.AsyncClient(timeout=3600) as client:
+            async with client.stream(
+                "POST", url, headers=headers, content=body_bytes
+            ) as resp:
+                if resp.status_code != 200:
+                    error_body = await resp.aread()
+                    raise httpx.HTTPStatusError(
+                        f"mantle stream error {resp.status_code}: "
+                        f"{error_body[:200].decode(errors='replace')}",
+                        request=resp.request,
+                        response=resp,
+                    )
+                async for raw in resp.aiter_raw():
+                    if raw:
+                        yield raw
+
+    @classmethod
+    async def invoke(cls, payload: dict) -> dict:
+        """Non-streaming request to the mantle /responses endpoint."""
+        model = payload.get("model", "")
+        url, region = cls._endpoint(model)
+        body = _openai_to_responses(payload)
+        body["stream"] = False
+        body_bytes = json.dumps(body).encode("utf-8")
+        headers = await _signed_headers("POST", url, body_bytes, region)
+        request_id = f"chatcmpl-{uuid.uuid4().hex}"
+
+        async with httpx.AsyncClient(timeout=3600) as client:
+            resp = await client.post(url, headers=headers, content=body_bytes)
+
+        if resp.status_code != 200:
+            logger.error(
+                f"mantle API error: status={resp.status_code}, "
+                f"region={region}, body={resp.text[:500]}"
+            )
+            raise httpx.HTTPStatusError(
+                f"mantle API returned {resp.status_code}: {resp.text[:200]}",
+                request=resp.request,
+                response=resp,
+            )
+
+        return _responses_to_openai(resp.json(), model, request_id)
+
+    @classmethod
+    async def invoke_stream(cls, payload: dict) -> AsyncGenerator[str, None]:
+        """Streaming request to the mantle /responses endpoint.
+
+        The Responses API streams *named* SSE events. We translate:
+          response.output_text.delta            → content delta
+          response.function_call_arguments.delta → tool_call argument delta
+          response.output_item.added (func call) → tool_call opener (id + name)
+          response.completed                     → usage + final stop
+        into OpenAI chat.completion.chunk SSE lines.
+        """
+        model = payload.get("model", "")
+        url, region = cls._endpoint(model)
+        body = _openai_to_responses(payload)
+        body["stream"] = True
+        body_bytes = json.dumps(body).encode("utf-8")
+        headers = await _signed_headers("POST", url, body_bytes, region)
+        headers["Accept"] = "text/event-stream"
+
+        chunk_id = f"chatcmpl-{uuid.uuid4().hex}"
+        created = int(time.time())
+        # Map Responses output_index → OpenAI tool_call index (function calls only)
+        tool_call_index: Dict[int, int] = {}
+
+        def _chunk(delta: Dict[str, Any], finish: Optional[str], usage=None) -> str:
+            obj: Dict[str, Any] = {
+                "id": chunk_id,
+                "object": "chat.completion.chunk",
+                "created": created,
+                "model": model,
+                "choices": [{"index": 0, "delta": delta, "finish_reason": finish}],
+            }
+            if usage is not None:
+                obj["usage"] = usage
+            return f"data: {json.dumps(obj)}\n\n"
+
+        async with httpx.AsyncClient(timeout=3600) as client:
+            async with client.stream(
+                "POST", url, headers=headers, content=body_bytes
+            ) as resp:
+                if resp.status_code != 200:
+                    error_body = await resp.aread()
+                    raise httpx.HTTPStatusError(
+                        f"mantle stream error {resp.status_code}: "
+                        f"{error_body[:200].decode(errors='replace')}",
+                        request=resp.request,
+                        response=resp,
+                    )
+
+                event_name: Optional[str] = None
+                async for line in resp.aiter_lines():
+                    if not line:
+                        event_name = None
+                        continue
+                    if line.startswith("event:"):
+                        event_name = line[6:].strip()
+                        continue
+                    if not line.startswith("data:"):
+                        continue
+                    data_str = line[5:].strip()
+                    if not data_str or data_str == "[DONE]":
+                        continue
+                    try:
+                        event = json.loads(data_str)
+                    except json.JSONDecodeError:
+                        continue
+
+                    etype = event.get("type") or event_name
+
+                    if etype == "response.output_text.delta":
+                        delta_text = event.get("delta", "")
+                        if delta_text:
+                            yield _chunk({"content": delta_text}, None)
+
+                    elif etype == "response.output_item.added":
+                        item = event.get("item") or {}
+                        if item.get("type") == "function_call":
+                            oidx = event.get("output_index", 0)
+                            tc_idx = len(tool_call_index)
+                            tool_call_index[oidx] = tc_idx
+                            yield _chunk(
+                                {
+                                    "tool_calls": [
+                                        {
+                                            "index": tc_idx,
+                                            "id": item.get("call_id")
+                                            or f"call_{uuid.uuid4().hex[:16]}",
+                                            "type": "function",
+                                            "function": {
+                                                "name": item.get("name", ""),
+                                                "arguments": "",
+                                            },
+                                        }
+                                    ]
+                                },
+                                None,
+                            )
+
+                    elif etype == "response.function_call_arguments.delta":
+                        oidx = event.get("output_index", 0)
+                        tc_idx = tool_call_index.get(oidx, 0)
+                        yield _chunk(
+                            {
+                                "tool_calls": [
+                                    {
+                                        "index": tc_idx,
+                                        "function": {
+                                            "arguments": event.get("delta", "")
+                                        },
+                                    }
+                                ]
+                            },
+                            None,
+                        )
+
+                    elif etype in ("response.completed", "response.incomplete"):
+                        resp_obj = event.get("response") or {}
+                        usage = _build_usage(resp_obj.get("usage") or {})
+                        finish = (
+                            "tool_calls"
+                            if tool_call_index
+                            else (
+                                "length" if etype == "response.incomplete" else "stop"
+                            )
+                        )
+                        yield _chunk({}, finish, usage=usage)
+
+                    elif etype == "response.failed" or etype == "error":
+                        resp_obj = event.get("response") or {}
+                        err = resp_obj.get("error") or event.get("error") or {}
+                        logger.error(f"mantle stream failed: {err}")
+                        yield _chunk({}, "stop")
+
+        yield "data: [DONE]\n\n"

--- a/backend/app/services/mantle_models.py
+++ b/backend/app/services/mantle_models.py
@@ -1,0 +1,86 @@
+"""
+OpenAI-on-Bedrock (mantle) model registry.
+
+GPT-5.5 / GPT-5.4 are served by AWS's "mantle" inference engine through the
+OpenAI Responses API (``https://bedrock-mantle.{region}.api.aws/openai/v1``),
+**not** through the standard boto3 ``converse`` / ``invoke_model`` paths.  They
+do not appear in ``list-foundation-models`` / ``list-inference-profiles`` or the
+Price List API, so they need their own static registry:
+
+  * routing — each model is only available in specific regions, and requests
+    must be sent to a region where the model lives (independent of the local
+    ``AWS_REGION``).
+  * model list — the admin "available models" endpoint injects these entries
+    since the profile cache cannot discover them.
+  * pricing — the price-page scraper maps display names back to these IDs.
+
+This module is the single source of truth shared by chat routing, pricing, and
+the admin model list.
+"""
+
+from typing import Dict, List
+
+from app.core.config import get_settings
+
+# Model ID → regions where it can be invoked (first entry is the preferred one).
+# Source: AWS "Get started with OpenAI GPT-5.5 / GPT-5.4 on Amazon Bedrock".
+MANTLE_MODEL_REGIONS: Dict[str, List[str]] = {
+    "openai.gpt-5.5": ["us-east-2"],
+    "openai.gpt-5.4": ["us-east-2", "us-west-2"],
+}
+
+# mantle OpenAI-compatible endpoint base URL (per region).
+MANTLE_BASE_URL = "https://bedrock-mantle.{region}.api.aws/openai/v1"
+
+# Display name on the AWS Bedrock pricing page → model ID (for the scraper).
+MANTLE_PRICING_NAMES: Dict[str, str] = {
+    "GPT-5.5": "openai.gpt-5.5",
+    "GPT-5.4": "openai.gpt-5.4",
+}
+
+
+def is_openai_mantle_model(model_id: str) -> bool:
+    """Return True if *model_id* is served via the mantle Responses API.
+
+    Exact-match against the registry on purpose — a prefix match on ``openai.``
+    would wrongly capture the open-weight ``openai.gpt-oss-*`` models, which run
+    through the standard Bedrock converse path.
+    """
+    return model_id in MANTLE_MODEL_REGIONS
+
+
+def resolve_mantle_region(model_id: str) -> str:
+    """Pick the region to route *model_id* to.
+
+    Prefer the local ``AWS_REGION`` when the model is available there (saves
+    cross-region latency); otherwise use the model's preferred region.  Raises
+    KeyError for non-mantle models — callers guard with is_openai_mantle_model.
+    """
+    regions = MANTLE_MODEL_REGIONS[model_id]
+    local = get_settings().AWS_REGION
+    return local if local in regions else regions[0]
+
+
+def get_mantle_models() -> List[Dict]:
+    """Return UI-compatible model entries for the admin "available models" list.
+
+    Shaped identically to the Bedrock / Gemini entries produced in
+    ``list_aws_available_models`` so the frontend renders them uniformly.
+    """
+    models: List[Dict] = []
+    for model_id in MANTLE_MODEL_REGIONS:
+        # "openai.gpt-5.5" → "GPT-5.5"
+        friendly_name = model_id.split(".", 1)[-1].upper()
+        models.append(
+            {
+                "model_id": model_id,
+                "model_name": friendly_name,
+                "friendly_name": friendly_name,
+                "provider": "openai-mantle",
+                "is_cross_region": False,
+                "cross_region_type": None,
+                "streaming_supported": True,
+                "is_fallback": False,
+            }
+        )
+    return models

--- a/backend/app/services/pricing.py
+++ b/backend/app/services/pricing.py
@@ -71,11 +71,19 @@ class ModelPricing:
             ValueError: If model pricing cannot be determined
         """
         from app.services.gemini_client import is_gemini_model
+        from app.services.mantle_models import (
+            is_openai_mantle_model,
+            resolve_mantle_region,
+        )
 
         # Determine region
         if region is None:
             if is_gemini_model(model):
                 region = "global"
+            elif is_openai_mantle_model(model):
+                # GPT-5.5/5.4 are billed in the region they're routed to —
+                # matches the routing in mantle_client.py.
+                region = resolve_mantle_region(model)
             else:
                 from app.services.bedrock import BedrockClient
 

--- a/backend/app/services/pricing_updater.py
+++ b/backend/app/services/pricing_updater.py
@@ -26,6 +26,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy import select
 from app.core.config import get_settings
 from app.models.model_pricing import ModelPricing
+from app.services.mantle_models import MANTLE_MODEL_REGIONS, MANTLE_PRICING_NAMES
 
 logger = logging.getLogger(__name__)
 
@@ -801,6 +802,84 @@ class PricingUpdater:
             f"(standard: {standard_count}, global: {global_count}, geo: {geo_count}) "
             f"for region {target_region}"
         )
+
+        # OpenAI GPT-5.5/5.4 (mantle) live in a separate plain-text table on the
+        # same page — not in the data-pricing-markup sections handled above.
+        # Fully additive: appends per-region rows without touching anything above.
+        try:
+            mantle_pricing = self._scrape_openai_text_pricing(html)
+            if mantle_pricing:
+                pricing_data.extend(mantle_pricing)
+                logger.info(
+                    f"Extracted {len(mantle_pricing)} OpenAI (mantle) pricing records "
+                    f"from the plain-text pricing table"
+                )
+        except Exception as e:
+            logger.warning(f"Failed to parse OpenAI (mantle) pricing table: {e}")
+
+        return pricing_data
+
+    def _scrape_openai_text_pricing(self, html: str) -> List[Dict]:
+        """Parse the OpenAI (GPT-5.5/5.4) plain-text pricing table.
+
+        These models are served by AWS mantle and do not appear in the
+        ``data-pricing-markup`` sections or the Price List API.  On the pricing
+        page they sit in an ordinary ``<table>`` with four columns::
+
+            OpenAI models | Price per 1M input tokens
+                          | Price per 1M cached output tokens
+                          | Price per 1M output tokens
+
+        Prices are identical across the model's regions, so rather than parse the
+        per-region table headers we map each display name via
+        ``MANTLE_PRICING_NAMES`` and write one row per region from
+        ``MANTLE_MODEL_REGIONS`` — keeping the pricing region keys exactly aligned
+        with ``resolve_mantle_region`` (used by calculate_cost) so every model in
+        the list can always look up a price.
+
+        The "cached output" price is stored in ``cached_input_price_per_token``
+        (the same column Gemini's implicit cache uses), so calculate_cost reads it
+        back uniformly.
+        """
+        # Locate every <tr> whose first cell is one of the known OpenAI names.
+        # The table uses plain text and "$ 5.50"-style values (space after $).
+        row_re = re.compile(
+            r"<tr>\s*<td>\s*([A-Za-z0-9.\- ]+?)\s*</td>"
+            r"\s*<td>\s*\$\s*([\d.]+)\s*</td>"  # input / 1M
+            r"\s*<td>\s*\$\s*([\d.]+)\s*</td>"  # cached output / 1M
+            r"\s*<td>\s*\$\s*([\d.]+)\s*</td>",  # output / 1M
+            re.IGNORECASE,
+        )
+
+        # Dedup: display names repeat across the per-region tables, but the prices
+        # are identical, so the first occurrence per model is authoritative.
+        seen_names: Set[str] = set()
+        pricing_data: List[Dict] = []
+
+        for match in row_re.finditer(html):
+            display_name = match.group(1).strip()
+            model_id = MANTLE_PRICING_NAMES.get(display_name)
+            if not model_id or display_name in seen_names:
+                continue
+            seen_names.add(display_name)
+
+            input_per_1m = Decimal(match.group(2))
+            cached_per_1m = Decimal(match.group(3))
+            output_per_1m = Decimal(match.group(4))
+
+            # Write one row per region the model can be invoked in, keyed by the
+            # same region resolve_mantle_region() will produce at billing time.
+            for region in MANTLE_MODEL_REGIONS.get(model_id, []):
+                pricing_data.append(
+                    {
+                        "model_id": model_id,
+                        "region": region,
+                        "input_price_per_token": input_per_1m / 1_000_000,
+                        "output_price_per_token": output_per_1m / 1_000_000,
+                        "cached_input_price_per_token": cached_per_1m / 1_000_000,
+                    }
+                )
+
         return pricing_data
 
     @staticmethod
@@ -853,15 +932,23 @@ class PricingUpdater:
                 result = await self.db.execute(stmt)
                 existing = result.scalar_one_or_none()
 
+                # Optional cached-input price (OpenAI mantle / Gemini-style rows).
+                # Bedrock API/scraper rows omit this key → column left untouched.
+                cached_price = data.get("cached_input_price_per_token")
+
                 if existing:
                     # Update existing record
                     existing.input_price_per_token = data["input_price_per_token"]
                     existing.output_price_per_token = data["output_price_per_token"]
+                    if cached_price is not None and hasattr(
+                        existing, "cached_input_price_per_token"
+                    ):
+                        existing.cached_input_price_per_token = cached_price
                     existing.source = source
                     existing.last_updated = now
                 else:
                     # Create new record
-                    new_pricing = ModelPricing(
+                    kwargs = dict(
                         model_id=data["model_id"],
                         region=data["region"],
                         input_price_per_token=data["input_price_per_token"],
@@ -871,6 +958,11 @@ class PricingUpdater:
                         last_updated=now,
                         created_at=now,
                     )
+                    if cached_price is not None and hasattr(
+                        ModelPricing, "cached_input_price_per_token"
+                    ):
+                        kwargs["cached_input_price_per_token"] = cached_price
+                    new_pricing = ModelPricing(**kwargs)
                     self.db.add(new_pricing)
 
                 updated_count += 1

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -6,6 +6,7 @@ Kolya BR Proxy exposes four API groups:
 |-------|--------|------|---------|
 | Gateway API (OpenAI) | `/v1` | `Authorization: Bearer` | OpenAI-compatible chat completions |
 | Gateway API (Anthropic) | `/v1` | `x-api-key` header | Anthropic Messages API compatible |
+| Gateway API (Responses) | `/v1` | `Authorization: Bearer` | Native OpenAI Responses API passthrough (mantle / GPT-5.5 / GPT-5.4) |
 | Admin API | `/admin` | Bearer JWT | User management, tokens, usage, audit |
 | Health API | `/health` | None | Load balancer probes |
 
@@ -438,6 +439,126 @@ List models the current token has access to. Returns OpenAI-compatible model lis
 }
 ```
 
+> **Dynamically listed models**: In addition to Bedrock models, both **Gemini models** (when `GEMINI_API_KEY` is configured) and **OpenAI GPT-5.5 / GPT-5.4** (served by AWS's "mantle" inference engine, `provider: openai-mantle`) appear dynamically. The mantle models are injected from a static registry because they are not discoverable via the Bedrock `list-foundation-models` / `list-inference-profiles` APIs.
+
+---
+
+## 1c. Gateway API (OpenAI Responses API — mantle passthrough)
+
+OpenAI **GPT-5.5** (`openai.gpt-5.5`) and **GPT-5.4** (`openai.gpt-5.4`) are served by AWS's "mantle" inference engine through the native **OpenAI Responses API** (`provider: openai-mantle`). These models can be reached three ways:
+
+| Path | Mode |
+|------|------|
+| `POST /v1/chat/completions` | OpenAI Chat Completions, translated to/from the Responses format |
+| `POST /v1/messages` | Anthropic Messages, translated to/from the Responses format |
+| `POST /v1/responses` | **Native Responses passthrough** — full mantle capability surface, no lossy conversion |
+
+The chat/messages paths translate to/from the Responses format and therefore flatten Responses-only features (built-in tools, multimodal output, etc.). The `/v1/responses` endpoint forwards a native Responses request body verbatim and returns the native response, so clients that speak the Responses API get the full mantle feature surface.
+
+### POST /v1/responses
+
+Create a model response using the native OpenAI Responses API. This endpoint is **mantle-only**: it accepts only GPT-5.5 / GPT-5.4 (validated via `is_openai_mantle_model`). Any other model returns **400** with a message like `Model '...' is not available on the Responses API`.
+
+Requires the same `Authorization: Bearer kbr_<token>` auth, token quota enforcement, and per-token model access checks as the other gateway endpoints.
+
+**Request body**: an **open JSON object** — forwarded to mantle verbatim. Unknown/new Responses fields pass straight through (no strict schema). Common native Responses fields:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `model` | string | *required* -- must be a mantle model (`openai.gpt-5.5` or `openai.gpt-5.4`) |
+| `input` | array | Input items; each has a `role` and a `content` array of parts (`input_text`, `output_text`, `input_image`) |
+| `stream` | boolean | Enable native Responses SSE streaming (default `false`) |
+| `max_output_tokens` | integer | Maximum output tokens to generate |
+| `temperature` | float | Sampling temperature |
+| `reasoning` | object | Optional reasoning config, e.g. `{"effort": "medium"}` |
+| `tools` | array | Optional tool definitions |
+| `text` | object | Optional output config, e.g. `{"format": {...}}` for structured output |
+
+**Billing**: derived from the response `usage` object. `usage.input_tokens` (which includes cached tokens) and `usage.output_tokens` are reported by mantle; `usage.input_tokens_details.cached_tokens` is billed separately. The proxy bills `(input_tokens - cached_tokens)` as prompt, `output_tokens` as completion, and `cached_tokens` at the cache-read rate.
+
+#### Non-streaming example
+
+```bash
+curl -X POST http://localhost:8000/v1/responses \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer kbr_your_token_here" \
+  -d '{
+    "model": "openai.gpt-5.5",
+    "input": [
+      {
+        "role": "user",
+        "content": [{"type": "input_text", "text": "Hello!"}]
+      }
+    ],
+    "max_output_tokens": 256
+  }'
+```
+
+**Response** (native Responses JSON, returned unchanged):
+
+```json
+{
+  "id": "resp_abc123...",
+  "object": "response",
+  "model": "openai.gpt-5.5",
+  "status": "completed",
+  "output": [
+    {
+      "type": "message",
+      "role": "assistant",
+      "content": [
+        {"type": "output_text", "text": "Hello! How can I help you?"}
+      ]
+    }
+  ],
+  "usage": {
+    "input_tokens": 10,
+    "output_tokens": 8,
+    "input_tokens_details": {"cached_tokens": 0}
+  }
+}
+```
+
+#### Streaming example
+
+```bash
+curl -X POST http://localhost:8000/v1/responses \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer kbr_your_token_here" \
+  -d '{
+    "model": "openai.gpt-5.5",
+    "input": [
+      {"role": "user", "content": [{"type": "input_text", "text": "Hello!"}]}
+    ],
+    "stream": true
+  }'
+```
+
+**Streaming response** (SSE `text/event-stream`, native Responses named events, passed through unchanged):
+
+```
+event: response.output_text.delta
+data: {"type":"response.output_text.delta","delta":"Hello"}
+
+event: response.output_text.delta
+data: {"type":"response.output_text.delta","delta":"!"}
+
+event: response.completed
+data: {"type":"response.completed","response":{"id":"resp_...","status":"completed","output":[...],"usage":{"input_tokens":10,"output_tokens":8,"input_tokens_details":{"cached_tokens":0}}}}
+```
+
+The proxy passes mantle's SSE bytes through verbatim and reads the `usage` object from the `response.completed` / `response.incomplete` event for billing. Heartbeat comments (`: heartbeat`) are sent to keep idle connections alive.
+
+#### Error responses
+
+Same status codes as `/v1/chat/completions`. Additionally, **400** is returned when the requested model is not a mantle model:
+
+```json
+{
+  "detail": "Model 'global.anthropic.claude-sonnet-4-5-20250929-v1:0' is not available on the Responses API. This endpoint serves OpenAI GPT-5.5/5.4 (mantle) only; use /v1/chat/completions for other models."
+}
+```
+
 ---
 
 ## 2. Admin API
@@ -733,6 +854,7 @@ The list includes:
 - **Inference profiles** available in the deployment region (e.g. `us.anthropic.claude-sonnet-4-6`, `global.anthropic.claude-sonnet-4-5-20250929-v1:0`)
 - **Foundation models** available only in the fallback region (e.g. `zai.glm-5`, `deepseek.v3.2`) — marked with `is_fallback: true`
 - **Gemini models** (if `GEMINI_API_KEY` is configured) — appended dynamically
+- **OpenAI GPT-5.5 / GPT-5.4** (`provider: openai-mantle`) — appended dynamically from a static registry, since they are served by AWS's "mantle" inference engine and are not discoverable via the Bedrock `list-foundation-models` / `list-inference-profiles` APIs (`openai.gpt-5.5` is available in `us-east-2`; `openai.gpt-5.4` in `us-east-2` and `us-west-2`)
 
 Only models actually callable from the deployment region are shown. For example, if deployed in `us-west-1` where `global.anthropic.claude-sonnet-4-20250514-v1:0` is not available, it will not appear in the list.
 

--- a/docs/api-reference.zh.md
+++ b/docs/api-reference.zh.md
@@ -6,6 +6,7 @@ Kolya BR Proxy 提供四组 API：
 |------|------|----------|------|
 | Gateway API (OpenAI) | `/v1` | `Authorization: Bearer` | OpenAI 兼容的聊天补全 |
 | Gateway API (Anthropic) | `/v1` | `x-api-key` 请求头 | Anthropic Messages API 兼容 |
+| Gateway API (Responses) | `/v1` | `Authorization: Bearer` | 原生 OpenAI Responses API 透传（mantle / GPT-5.5 / GPT-5.4） |
 | Admin API | `/admin` | Bearer JWT | 用户管理、令牌、用量、审计 |
 | Health API | `/health` | 无 | 负载均衡器探针 |
 
@@ -427,6 +428,126 @@ export CLAUDE_MODEL="us.anthropic.claude-sonnet-4-5-20250514-v1:0"
 }
 ```
 
+> **动态列出的模型**：除 Bedrock 模型外，**Gemini 模型**（配置了 `GEMINI_API_KEY` 时）和 **OpenAI GPT-5.5 / GPT-5.4**（由 AWS "mantle" 推理引擎提供，`provider: openai-mantle`）也会动态出现。mantle 模型来自静态注册表注入，因为它们无法通过 Bedrock 的 `list-foundation-models` / `list-inference-profiles` API 发现。
+
+---
+
+## 1c. Gateway API（OpenAI Responses API —— mantle 透传）
+
+OpenAI **GPT-5.5**（`openai.gpt-5.5`）和 **GPT-5.4**（`openai.gpt-5.4`）由 AWS "mantle" 推理引擎通过原生 **OpenAI Responses API** 提供（`provider: openai-mantle`）。这两个模型可通过三条路径访问：
+
+| 路径 | 模式 |
+|------|------|
+| `POST /v1/chat/completions` | OpenAI Chat Completions，与 Responses 格式相互转换 |
+| `POST /v1/messages` | Anthropic Messages，与 Responses 格式相互转换 |
+| `POST /v1/responses` | **原生 Responses 透传** —— 完整的 mantle 能力，无有损转换 |
+
+chat/messages 两条路径会与 Responses 格式相互转换，因此会"扁平化"掉 Responses 独有的特性（内置工具、多模态输出等）。`/v1/responses` 端点将原生 Responses 请求体原样转发，并返回原生响应，使用 Responses API 的客户端可获得完整的 mantle 能力。
+
+### POST /v1/responses
+
+使用原生 OpenAI Responses API 创建模型响应。该端点**仅限 mantle 模型**：只接受 GPT-5.5 / GPT-5.4（通过 `is_openai_mantle_model` 校验）。其他任何模型返回 **400**，提示类似 `Model '...' is not available on the Responses API`。
+
+需要与其他 gateway 端点一致的 `Authorization: Bearer kbr_<token>` 鉴权、Token 配额校验以及按 Token 的模型访问权限校验。
+
+**请求体**：一个**开放 JSON 对象** —— 原样转发给 mantle。未知/新增的 Responses 字段会直接透传（无严格 schema）。常见的原生 Responses 字段：
+
+| 字段 | 类型 | 说明 |
+|------|------|------|
+| `model` | string | *必填* —— 必须是 mantle 模型（`openai.gpt-5.5` 或 `openai.gpt-5.4`） |
+| `input` | array | 输入项数组；每项含 `role` 及 `content` parts 数组（`input_text`、`output_text`、`input_image`） |
+| `stream` | boolean | 启用原生 Responses SSE 流式输出（默认 `false`） |
+| `max_output_tokens` | integer | 最大输出 token 数 |
+| `temperature` | float | 采样温度 |
+| `reasoning` | object | 可选的推理配置，如 `{"effort": "medium"}` |
+| `tools` | array | 可选的工具定义 |
+| `text` | object | 可选的输出配置，如 `{"format": {...}}`（结构化输出） |
+
+**计费**：基于响应中的 `usage` 对象。mantle 返回 `usage.input_tokens`（含 cached tokens）和 `usage.output_tokens`；`usage.input_tokens_details.cached_tokens` 单独计费。代理将 `(input_tokens - cached_tokens)` 计为 prompt，`output_tokens` 计为 completion，`cached_tokens` 按缓存读取费率计费。
+
+#### 非流式示例
+
+```bash
+curl -X POST http://localhost:8000/v1/responses \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer kbr_your_token_here" \
+  -d '{
+    "model": "openai.gpt-5.5",
+    "input": [
+      {
+        "role": "user",
+        "content": [{"type": "input_text", "text": "Hello!"}]
+      }
+    ],
+    "max_output_tokens": 256
+  }'
+```
+
+**响应**（原生 Responses JSON，原样返回）：
+
+```json
+{
+  "id": "resp_abc123...",
+  "object": "response",
+  "model": "openai.gpt-5.5",
+  "status": "completed",
+  "output": [
+    {
+      "type": "message",
+      "role": "assistant",
+      "content": [
+        {"type": "output_text", "text": "Hello! How can I help you?"}
+      ]
+    }
+  ],
+  "usage": {
+    "input_tokens": 10,
+    "output_tokens": 8,
+    "input_tokens_details": {"cached_tokens": 0}
+  }
+}
+```
+
+#### 流式示例
+
+```bash
+curl -X POST http://localhost:8000/v1/responses \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer kbr_your_token_here" \
+  -d '{
+    "model": "openai.gpt-5.5",
+    "input": [
+      {"role": "user", "content": [{"type": "input_text", "text": "Hello!"}]}
+    ],
+    "stream": true
+  }'
+```
+
+**流式响应**（SSE `text/event-stream`，原生 Responses 具名事件，原样透传）：
+
+```
+event: response.output_text.delta
+data: {"type":"response.output_text.delta","delta":"Hello"}
+
+event: response.output_text.delta
+data: {"type":"response.output_text.delta","delta":"!"}
+
+event: response.completed
+data: {"type":"response.completed","response":{"id":"resp_...","status":"completed","output":[...],"usage":{"input_tokens":10,"output_tokens":8,"input_tokens_details":{"cached_tokens":0}}}}
+```
+
+代理将 mantle 的 SSE 字节原样透传，并从 `response.completed` / `response.incomplete` 事件中读取 `usage` 对象用于计费。期间会发送心跳注释（`: heartbeat`）以保持空闲连接。
+
+#### 错误响应
+
+状态码与 `/v1/chat/completions` 相同。此外，当请求的模型不是 mantle 模型时返回 **400**：
+
+```json
+{
+  "detail": "Model 'global.anthropic.claude-sonnet-4-5-20250929-v1:0' is not available on the Responses API. This endpoint serves OpenAI GPT-5.5/5.4 (mantle) only; use /v1/chat/completions for other models."
+}
+```
+
 ---
 
 ## 2. Admin API
@@ -742,6 +863,7 @@ Admin 用户有一个 `permissions` JSON 对象，控制其可管理的资源：
 - **Inference profiles** — 部署区域可用的推理配置（如 `us.anthropic.claude-sonnet-4-6`、`global.anthropic.claude-sonnet-4-5-20250929-v1:0`）
 - **Foundation models** — 仅在 fallback 区域可用的基础模型（如 `zai.glm-5`、`deepseek.v3.2`）— 标记为 `is_fallback: true`
 - **Gemini 模型**（如果配置了 `GEMINI_API_KEY`）— 动态追加
+- **OpenAI GPT-5.5 / GPT-5.4**（`provider: openai-mantle`）— 从静态注册表动态追加，因为它们由 AWS "mantle" 推理引擎提供，无法通过 Bedrock 的 `list-foundation-models` / `list-inference-profiles` API 发现（`openai.gpt-5.5` 仅在 `us-east-2` 可用；`openai.gpt-5.4` 在 `us-east-2` 和 `us-west-2` 可用）
 
 仅显示从部署区域实际可调用的模型。例如，如果部署在 `us-west-1`，而 `global.anthropic.claude-sonnet-4-20250514-v1:0` 在该区域不可用，则不会出现在列表中。
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,6 +1,6 @@
 # Architecture
 
-Comprehensive architecture documentation for Kolya BR Proxy -- an AI Gateway that provides both OpenAI-compatible and Anthropic Messages API access to AWS Bedrock models (Claude, Nova, DeepSeek, Mistral, Llama, etc.) and Google Gemini models via the native generateContent API.
+Comprehensive architecture documentation for Kolya BR Proxy -- an AI Gateway that provides both OpenAI-compatible and Anthropic Messages API access to AWS Bedrock models (Claude, Nova, DeepSeek, Mistral, Llama, etc.), Google Gemini models via the native generateContent API, and OpenAI GPT-5.5 / GPT-5.4 models served by the AWS "mantle" inference engine via the OpenAI Responses API.
 
 ---
 
@@ -56,6 +56,10 @@ graph LR
         Gemini["Google Gemini API<br/>(generateContent native)"]
     end
 
+    subgraph Mantle_Services ["AWS mantle (OpenAI models)"]
+        Mantle["mantle Inference Engine<br/>(OpenAI Responses API)<br/>(GPT-5.5, GPT-5.4)"]
+    end
+
     OAI -->|"HTTPS /v1/chat/*"| ALB
     Anthropic_SDK -->|"HTTPS /v1/messages"| ALB
     Browser -->|"HTTPS /*"| ALB
@@ -65,6 +69,7 @@ graph LR
     Uvicorn --> FastAPI
     FastAPI -->|"InvokeModel /<br/>Converse API"| Bedrock
     FastAPI -->|"generateContent /<br/>streamGenerateContent"| Gemini
+    FastAPI -->|"SigV4 POST /responses<br/>(OpenAI Responses API)"| Mantle
     FastAPI -->|"SQLAlchemy async"| PG
     FastAPI -.->|"Distributed rate limiting"| Redis
 ```
@@ -83,6 +88,8 @@ graph LR
 | Background usage recording | `record_usage` runs as a background task to avoid blocking responses |
 | Gemini native API (not OpenAI compat) | Uses `generateContent` / `streamGenerateContent` directly; avoids Gemini's OpenAI-compat layer which rejects fields like `frequency_penalty` |
 | Gemini format conversion in client layer | `GeminiClient` converts OpenAI ↔ Gemini natively; `chat.py` sees uniform OpenAI format regardless of backend |
+| mantle reuses the Gemini provider pattern | OpenAI GPT-5.5/5.4 (served by AWS mantle) are intercepted by early routing + a dedicated `MantleClient` + pricing short-circuit **before** reaching `BedrockClient`, exactly like Gemini; this leaves the existing Claude/Nova/Gemini paths untouched. `is_openai_mantle_model()` does an exact match on `openai.gpt-5.5` / `openai.gpt-5.4` (avoiding false hits on open-source `gpt-oss`) |
+| mantle uses the OpenAI Responses API over SigV4 | mantle is reached at `https://bedrock-mantle.{region}.api.aws/openai/v1` via `POST /responses` (not boto3 converse/invoke_model). Requests are SigV4-signed (botocore `SigV4Auth`/`AWSRequest`, service name `bedrock`) reusing the existing AWS credential chain (EKS Pod IRSA, incl. SessionToken); `MantleClient` converts OpenAI ChatCompletions ↔ Responses natively |
 
 ---
 
@@ -134,6 +141,7 @@ graph TD
         AnthResTranslator["AnthropicResponseTranslator<br/>(Bedrock -> Anthropic)"]
         GeminiSvc["GeminiClient<br/>(OpenAI ↔ Gemini native conversion)"]
         GeminiPricing["GeminiPricingUpdater<br/>(3-tier price fetch)"]
+        MantleSvc["MantleClient<br/>(SigV4; OpenAI ↔ Responses conversion;<br/>native /responses passthrough)"]
         TokenSvc["TokenService<br/>(validate, CRUD)"]
         AuthSvc["AuthService<br/>(OAuth user creation)"]
         RefreshSvc["RefreshTokenService<br/>(token rotation)"]
@@ -685,11 +693,15 @@ sequenceDiagram
 
 ## 7. Request Processing Flow
 
-This section details the full lifecycle of gateway requests. The proxy supports three API paths:
+This section details the full lifecycle of gateway requests. The proxy supports these API paths:
 
-- **OpenAI path → AWS Bedrock** (`/v1/chat/completions`, non-Gemini models): Full translation between OpenAI and Bedrock formats
+- **OpenAI path → AWS Bedrock** (`/v1/chat/completions`, non-Gemini / non-mantle models): Full translation between OpenAI and Bedrock formats
 - **OpenAI path → Google Gemini** (`/v1/chat/completions`, `gemini-*` models): `GeminiClient` converts OpenAI ↔ Gemini native format; `chat.py` is format-agnostic
+- **OpenAI path → AWS mantle** (`/v1/chat/completions` and `/v1/messages`, `openai.gpt-5.5` / `openai.gpt-5.4`): `is_openai_mantle_model()` routes the request to `MantleClient`, which converts OpenAI ChatCompletions ↔ OpenAI Responses (lossy) and calls mantle's `POST /responses` over SigV4
+- **mantle native passthrough** (`/v1/responses`): zero-conversion OpenAI Responses API forwarded directly to mantle
 - **Anthropic path** (`/v1/messages`): Near-passthrough since Bedrock InvokeModel natively uses Anthropic Messages API format
+
+OpenAI GPT-5.5/5.4 can therefore be reached via three access paths: `/v1/chat/completions` (lossy conversion), `/v1/messages` (lossy conversion), and `/v1/responses` (native, zero conversion).
 
 ### 7.1 OpenAI Path Sequence Diagram
 
@@ -846,7 +858,46 @@ sequenceDiagram
 | `usageMetadata.candidatesTokenCount` | `usage.completion_tokens` |
 | `usageMetadata.cachedContentTokenCount` | `usage.prompt_tokens_details.cached_tokens` |
 
-### 7.3 Anthropic Path Sequence Diagram
+### 7.3 mantle / Responses Path Sequence Diagram
+
+When the requested model matches `openai.gpt-5.5` / `openai.gpt-5.4` (exact match via `is_openai_mantle_model()`), `chat.py` (and `messages.py`) routes to `MantleClient` **before** `BedrockClient` is touched. `MantleClient` SigV4-signs the request (service `bedrock`, reusing the EKS Pod IRSA credential chain incl. SessionToken), resolves the region via `resolve_mantle_region()` (GPT-5.5 → `us-east-2` only; GPT-5.4 → `us-east-2` + `us-west-2`), and calls mantle's OpenAI Responses API. The `/v1/responses` endpoint forwards natively with zero conversion.
+
+```mermaid
+sequenceDiagram
+    participant Client as OpenAI Client
+    participant Chat as chat.py / responses.py
+    participant MC as MantleClient
+    participant Mantle as AWS mantle<br/>(bedrock-mantle.{region}.api.aws)
+
+    Client->>Chat: POST /v1/chat/completions<br/>model: "openai.gpt-5.5"
+    Chat->>Chat: is_openai_mantle_model() → true
+    Chat->>Chat: Quota + model access check
+    Chat->>MC: resolve_mantle_region(model)
+
+    alt ChatCompletions conversion (/v1/chat/completions, /v1/messages)
+        Chat->>MC: invoke / invoke_stream(payload)
+        MC->>MC: _openai_to_responses()<br/>system→developer role, max_tokens→max_output_tokens<br/>image→input_image, response_format→text.format<br/>reasoning.effort
+        MC->>MC: SigV4 sign (SigV4Auth/AWSRequest, service=bedrock)
+        MC->>Mantle: POST /openai/v1/responses (stream:true)
+        loop Named SSE events
+            Mantle-->>MC: response.output_text.delta / response.completed
+            MC->>MC: _responses_to_openai()<br/>→ chat.completion(.chunk) format
+            MC-->>Chat: OpenAI dict / SSE string
+        end
+        Chat-->>Client: JSON / SSE stream
+    else Native passthrough (/v1/responses)
+        Chat->>MC: responses_passthrough / responses_passthrough_stream(body)
+        MC->>MC: SigV4 sign (no conversion)
+        MC->>Mantle: POST /openai/v1/responses
+        Mantle-->>MC: Responses payload / named SSE events
+        MC-->>Chat: raw Responses payload / SSE
+        Chat-->>Client: native Responses response
+    end
+
+    Chat->>Chat: background: record_usage(...)
+```
+
+### 7.4 Anthropic Path Sequence Diagram
 
 The Anthropic path is a near-passthrough: since Bedrock's InvokeModel API natively accepts Anthropic Messages API format, minimal translation is needed. Key differences from the OpenAI path:
 
@@ -907,12 +958,13 @@ sequenceDiagram
     Msg->>BG: background: record_usage(...)
 ```
 
-### 7.4 Request/Response Translation Summary
+### 7.5 Request/Response Translation Summary
 
 | Path | Translation | Notes |
 |---|---|---|
 | **OpenAI → Bedrock** | Three-phase (OpenAI → `BedrockRequest` → Bedrock API → `BedrockResponse` → OpenAI) | Full translation; tool calls, images, Bedrock extensions |
 | **OpenAI → Gemini** | `GeminiClient` internal conversion (OpenAI → Gemini GenerateContentRequest / back) | Native `generateContent` API; no OpenAI-compat layer |
+| **OpenAI → mantle** | `MantleClient` internal conversion (OpenAI ChatCompletions ↔ OpenAI Responses) | SigV4 to `POST /responses`; lossy. Native `/v1/responses` is zero-conversion passthrough |
 | **Anthropic → Bedrock** | Near-passthrough (`invoke_model`) | Minimal translation; preserves `cache_control`, thinking blocks |
 
 For non-Anthropic Bedrock models (Nova, DeepSeek, Mistral, Llama, etc.), the Bedrock path uses the Converse API via `converse`/`converse_stream`.

--- a/docs/architecture.zh.md
+++ b/docs/architecture.zh.md
@@ -1,6 +1,6 @@
 # 架构文档
 
-Kolya BR Proxy 综合架构文档 -- 一个提供 OpenAI 兼容 API 和 Anthropic Messages API 访问 AWS Bedrock 模型（Claude、Nova、DeepSeek、Mistral、Llama 等）以及通过原生 generateContent API 访问 Google Gemini 模型的 AI 网关。
+Kolya BR Proxy 综合架构文档 -- 一个提供 OpenAI 兼容 API 和 Anthropic Messages API 访问 AWS Bedrock 模型（Claude、Nova、DeepSeek、Mistral、Llama 等）、通过原生 generateContent API 访问 Google Gemini 模型，以及通过 OpenAI Responses API 访问由 AWS "mantle" 推理引擎服务的 OpenAI GPT-5.5 / GPT-5.4 模型的 AI 网关。
 
 ---
 
@@ -56,6 +56,10 @@ graph LR
         Gemini["Google Gemini API<br/>(原生 generateContent)"]
     end
 
+    subgraph Mantle_Services ["AWS mantle (OpenAI 模型)"]
+        Mantle["mantle 推理引擎<br/>(OpenAI Responses API)<br/>(GPT-5.5, GPT-5.4)"]
+    end
+
     OAI -->|"HTTPS /v1/chat/*"| ALB
     Anthropic_SDK -->|"HTTPS /v1/messages"| ALB
     Browser -->|"HTTPS /*"| ALB
@@ -65,6 +69,7 @@ graph LR
     Uvicorn --> FastAPI
     FastAPI -->|"InvokeModel /<br/>Converse API"| Bedrock
     FastAPI -->|"generateContent /<br/>streamGenerateContent"| Gemini
+    FastAPI -->|"SigV4 POST /responses<br/>(OpenAI Responses API)"| Mantle
     FastAPI -->|"SQLAlchemy async"| PG
     FastAPI -.->|"分布式限流"| Redis
 ```
@@ -83,6 +88,8 @@ graph LR
 | 后台使用量记录 | `record_usage` 作为后台任务运行，避免阻塞响应 |
 | Gemini 使用原生 API（非 OpenAI 兼容层）| 直接调用 `generateContent` / `streamGenerateContent`，避免 Gemini OpenAI 兼容层拒绝 `frequency_penalty` 等字段 |
 | Gemini 格式转换在 Client 层完成 | `GeminiClient` 负责 OpenAI ↔ Gemini 的格式互转；`chat.py` 始终看到统一的 OpenAI 格式，与处理 Bedrock 响应对称 |
+| mantle 照搬 Gemini 的 provider 模式 | OpenAI GPT-5.5/5.4（由 AWS mantle 服务）通过提前路由 + 独立的 `MantleClient` + pricing 短路，在进入 `BedrockClient` **之前**被截走，与 Gemini 完全一致；因此天然不影响现有 Claude/Nova/Gemini 路径。`is_openai_mantle_model()` 对 `openai.gpt-5.5` / `openai.gpt-5.4` 做精确匹配（避免误伤开源 `gpt-oss`） |
+| mantle 走 OpenAI Responses API + SigV4 | mantle 端点为 `https://bedrock-mantle.{region}.api.aws/openai/v1`，通过 `POST /responses` 访问（不是 boto3 converse/invoke_model）。请求经 SigV4 签名（botocore `SigV4Auth`/`AWSRequest`，service name `bedrock`），复用现有 AWS 凭证链（EKS Pod IRSA，含 SessionToken）；`MantleClient` 负责 OpenAI ChatCompletions ↔ Responses 的原生互转 |
 
 ---
 
@@ -132,6 +139,7 @@ graph TD
         ResTranslator["ResponseTranslator<br/>(Bedrock -> OpenAI)"]
         AnthReqTranslator["AnthropicRequestTranslator<br/>(Anthropic -> Bedrock)"]
         AnthResTranslator["AnthropicResponseTranslator<br/>(Bedrock -> Anthropic)"]
+        MantleSvc["MantleClient<br/>(SigV4; OpenAI ↔ Responses 转换;<br/>原生 /responses 透传)"]
         TokenSvc["TokenService<br/>(validate, CRUD)"]
         AuthSvc["AuthService<br/>(OAuth user creation)"]
         RefreshSvc["RefreshTokenService<br/>(token rotation)"]
@@ -675,11 +683,15 @@ sequenceDiagram
 
 ## 7. 请求处理流程
 
-本节详细描述网关请求的完整生命周期。代理支持三条 API 路径：
+本节详细描述网关请求的完整生命周期。代理支持以下 API 路径：
 
-- **OpenAI 路径 → AWS Bedrock**（`/v1/chat/completions`，非 Gemini 模型）：在 OpenAI 和 Bedrock 格式之间进行完整转换
+- **OpenAI 路径 → AWS Bedrock**（`/v1/chat/completions`，非 Gemini / 非 mantle 模型）：在 OpenAI 和 Bedrock 格式之间进行完整转换
 - **OpenAI 路径 → Google Gemini**（`/v1/chat/completions`，`gemini-*` 模型）：`GeminiClient` 在内部完成 OpenAI ↔ Gemini 原生格式转换；`chat.py` 格式无感知
+- **OpenAI 路径 → AWS mantle**（`/v1/chat/completions` 和 `/v1/messages`，`openai.gpt-5.5` / `openai.gpt-5.4`）：`is_openai_mantle_model()` 将请求路由到 `MantleClient`，由其完成 OpenAI ChatCompletions ↔ OpenAI Responses 转换（有损），并通过 SigV4 调用 mantle 的 `POST /responses`
+- **mantle 原生透传**（`/v1/responses`）：零转换的 OpenAI Responses API，直接转发给 mantle
 - **Anthropic 路径**（`/v1/messages`）：近乎直通，因为 Bedrock InvokeModel 原生使用 Anthropic Messages API 格式
+
+因此 OpenAI GPT-5.5/5.4 有三条访问路径：`/v1/chat/completions`（有损转换）、`/v1/messages`（有损转换）、`/v1/responses`（原生，零转换）。
 
 ### 7.1 OpenAI 路径时序图
 
@@ -806,7 +818,46 @@ sequenceDiagram
     Chat->>Chat: 后台：record_usage（从 usage 中提取缓存 token）
 ```
 
-### 7.3 Anthropic 路径时序图
+### 7.3 mantle / Responses 路径时序图
+
+当请求的模型精确匹配 `openai.gpt-5.5` / `openai.gpt-5.4`（通过 `is_openai_mantle_model()` 精确匹配）时，`chat.py`（以及 `messages.py`）在触及 `BedrockClient` **之前** 就路由到 `MantleClient`。`MantleClient` 对请求做 SigV4 签名（service `bedrock`，复用 EKS Pod IRSA 凭证链，含 SessionToken），通过 `resolve_mantle_region()` 解析区域（GPT-5.5 → 仅 `us-east-2`；GPT-5.4 → `us-east-2` + `us-west-2`），并调用 mantle 的 OpenAI Responses API。`/v1/responses` 端点则零转换原生转发。
+
+```mermaid
+sequenceDiagram
+    participant Client as OpenAI Client
+    participant Chat as chat.py / responses.py
+    participant MC as MantleClient
+    participant Mantle as AWS mantle<br/>(bedrock-mantle.{region}.api.aws)
+
+    Client->>Chat: POST /v1/chat/completions<br/>model: "openai.gpt-5.5"
+    Chat->>Chat: is_openai_mantle_model() → true
+    Chat->>Chat: 配额 + 模型权限检查
+    Chat->>MC: resolve_mantle_region(model)
+
+    alt ChatCompletions 转换（/v1/chat/completions、/v1/messages）
+        Chat->>MC: invoke / invoke_stream(payload)
+        MC->>MC: _openai_to_responses()<br/>system→developer role, max_tokens→max_output_tokens<br/>image→input_image, response_format→text.format<br/>reasoning.effort
+        MC->>MC: SigV4 签名 (SigV4Auth/AWSRequest, service=bedrock)
+        MC->>Mantle: POST /openai/v1/responses (stream:true)
+        loop 具名 SSE 事件
+            Mantle-->>MC: response.output_text.delta / response.completed
+            MC->>MC: _responses_to_openai()<br/>→ chat.completion(.chunk) 格式
+            MC-->>Chat: OpenAI dict / SSE 字符串
+        end
+        Chat-->>Client: JSON / SSE 流
+    else 原生透传（/v1/responses）
+        Chat->>MC: responses_passthrough / responses_passthrough_stream(body)
+        MC->>MC: SigV4 签名（无转换）
+        MC->>Mantle: POST /openai/v1/responses
+        Mantle-->>MC: Responses 载荷 / 具名 SSE 事件
+        MC-->>Chat: 原始 Responses 载荷 / SSE
+        Chat-->>Client: 原生 Responses 响应
+    end
+
+    Chat->>Chat: 后台：record_usage(...)
+```
+
+### 7.4 Anthropic 路径时序图
 
 Anthropic 路径是近乎直通的：由于 Bedrock 的 InvokeModel API 原生接受 Anthropic Messages API 格式，只需极少转换。与 OpenAI 路径的关键区别：
 
@@ -867,12 +918,13 @@ sequenceDiagram
     Msg->>BG: background: record_usage(...)
 ```
 
-### 7.4 请求/响应转换汇总
+### 7.5 请求/响应转换汇总
 
 | 路径 | 转换方式 | 说明 |
 |---|---|---|
 | **OpenAI → Bedrock** | 三阶段（OpenAI → `BedrockRequest` → Bedrock API → `BedrockResponse` → OpenAI）| 完整转换；支持工具调用、图片、Bedrock 扩展字段 |
 | **OpenAI → Gemini** | `GeminiClient` 内部转换（OpenAI → Gemini GenerateContentRequest / 反向）| 原生 `generateContent` API；不经过 OpenAI 兼容层 |
+| **OpenAI → mantle** | `MantleClient` 内部转换（OpenAI ChatCompletions ↔ OpenAI Responses）| SigV4 调用 `POST /responses`；有损。原生 `/v1/responses` 为零转换透传 |
 | **Anthropic → Bedrock** | 近乎直通（`invoke_model`）| 最小转换；保留 `cache_control`、thinking blocks |
 
 代理在客户端 API 格式和 Bedrock 之间执行转换：

--- a/docs/pricing-system.md
+++ b/docs/pricing-system.md
@@ -5,7 +5,7 @@
 This system implements dynamic fetching of model pricing from multiple sources and automatic database updates. Pricing data is used to calculate API call costs.
 
 Two independent pricing subsystems run in parallel:
-- **AWS Bedrock pricing** — for all models accessed via AWS Bedrock
+- **AWS Bedrock pricing** — for all models accessed via AWS Bedrock. This also covers OpenAI GPT-5.5/5.4 served through the AWS "mantle" inference engine, scraped from the same AWS pricing page (see **OpenAI mantle Pricing** below).
 - **Google Gemini pricing** — for models accessed directly via the Gemini API (stored with `region="global"`)
 
 ---
@@ -16,11 +16,11 @@ Stores model pricing information:
 
 | Column | Description |
 |--------|-------------|
-| `model_id` | Model identifier (e.g. `amazon.nova-lite-v1:0`, `gemini-2.5-pro`) |
-| `region` | AWS region, cross-region prefix (`us.`, `global.`), or `"global"` for Gemini |
+| `model_id` | Model identifier (e.g. `amazon.nova-lite-v1:0`, `gemini-2.5-pro`, `openai.gpt-5.5`) |
+| `region` | AWS region, cross-region prefix (`us.`, `global.`), or `"global"` for Gemini. mantle models use plain AWS regions (e.g. `us-east-2`, `us-west-2`) with no prefix |
 | `input_price_per_token` | Input token unit price (USD) |
 | `output_price_per_token` | Output token unit price (USD) |
-| `cached_input_price_per_token` | Context cache read price (USD), NULL if not supported |
+| `cached_input_price_per_token` | Context cache read price (USD), NULL if not supported. Reused by Gemini caching price and by mantle's cached-output price |
 | `currency` | Currency (USD) |
 | `source` | Data source — see values below |
 | `last_updated` | Last update timestamp |
@@ -32,6 +32,7 @@ Stores model pricing information:
 |-------|---------|
 | `api` | AWS Price List API |
 | `aws-scraper` | AWS Bedrock pricing page scraper |
+| `scraper` | OpenAI mantle (GPT-5.5/5.4) entries from the AWS pricing page — same label as the Bedrock scrape because it is the same page |
 | `gemini-scraper` | Any of the three Gemini pricing tiers (unified label) |
 
 ---
@@ -80,7 +81,7 @@ This ensures API data always takes priority and scraped data only fills in the g
 }
 ```
 
-### Supported Providers (19 total)
+### Supported Providers (20 total)
 
 | Provider | Price List API | Page Scraper | Notes |
 |----------|:-:|:-:|-------|
@@ -97,6 +98,7 @@ This ensures API data always takes priority and scraped data only fills in the g
 | Moonshot AI | Yes | — | Kimi K2 Thinking |
 | NVIDIA | Yes | — | Nemotron Nano 2, 3 |
 | OpenAI | Yes | Yes | gpt-oss-20b, gpt-oss-120b |
+| OpenAI (mantle) | — | Yes | GPT-5.5, GPT-5.4 via the AWS "mantle" inference engine — see **OpenAI mantle Pricing** below |
 | Qwen | Yes | Yes | Qwen3, Qwen3 Coder, Qwen3 VL |
 | Stability AI | — | — | Image generation (per-image pricing) |
 | TwelveLabs | — | — | Video understanding (per-second pricing) |
@@ -152,6 +154,53 @@ Gemini pricing tier-1 (Google):           17 models
 Gemini pricing tier-2 (LiteLLM):          17 new models added
 Gemini pricing tier-3 (static legacy):     3 models added
 Gemini pricing saved:                      37 models total
+```
+
+---
+
+## OpenAI mantle Pricing
+
+OpenAI **GPT-5.5** and **GPT-5.4** are served through the AWS "mantle" inference engine and are priced on the **same AWS pricing page** as Bedrock models. Rather than a separate fetch pipeline, mantle pricing is an **incremental branch inside the existing AWS pricing scraper** — it does not touch the existing `data-pricing-markup` parsing path.
+
+Provider tag: `openai-mantle`. Source label: `scraper` (identical to the AWS Bedrock scrape, because the data comes from the same page).
+
+### Models and Pricing
+
+Prices are per 1M tokens (input / cached output / output):
+
+| Model | `model_id` | Input $/1M | Cached output $/1M | Output $/1M | Regions |
+|-------|-----------|-----------|--------------------|-------------|---------|
+| GPT-5.5 | `openai.gpt-5.5` | $5.50 | $0.55 | $33.00 | `us-east-2` only |
+| GPT-5.4 | `openai.gpt-5.4` | $2.75 | $0.275 | $16.50 | `us-east-2`, `us-west-2` |
+
+### Fetch Strategy
+
+- **Source:** the same `https://aws.amazon.com/bedrock/pricing/` HTML already fetched for the Bedrock scrape — no extra request.
+- **New branch:** `_scrape_openai_text_pricing(html)` in `backend/app/services/pricing_updater.py`. It is purely additive; the existing markup-based parsing path is unchanged.
+- **Locator:** a plain-text `<table>` containing the header `"Price per 1M input tokens"`. The table has 4 columns: `OpenAI models | input | cached output | output`, with values formatted like `$ 5.50`.
+- **Parsing:** each row is parsed and the model name is mapped to a `model_id` via the `MANTLE_PRICING_NAMES` mapping.
+
+### Storage
+
+- **One row per region the model is available in** — `gpt-5.4` is written for both `us-east-2` and `us-west-2`; `gpt-5.5` is written for `us-east-2` only. The region comes from the model's availability list, **not** from `settings.AWS_REGION`.
+- **Unit conversion:** unit price = `$ per 1M ÷ 1e6`.
+- **Cached output price** is written into the `cached_input_price_per_token` column (the same column Gemini reuses for caching price).
+- **Source label:** `scraper`.
+
+### Region Inference
+
+The region inference in `pricing.py` is **short-circuited for mantle models**: `resolve_mantle_region(model)` returns the local `AWS_REGION` if it is in the model's availability list, otherwise the preferred region. This is the same region used at write time, so `calculate_cost()` always finds a matching price row and never raises `ValueError`.
+
+### Safety / Non-interference
+
+- **`update_all_pricing` API-id filter** does not delete mantle rows: mantle models are not in the Price List API and have no geo prefix, so they fall outside the filter's delete set.
+- **`cleanup_stale_cross_region_entries`** only removes entries that carry a geo prefix; mantle rows have no prefix and are therefore untouched.
+
+### Typical Run Results
+
+```
+AWS pricing update completed: 77 models updated from api+aws-scraper, 0 failed
+OpenAI mantle pricing (scraper): 2 models → 3 region rows (gpt-5.5: us-east-2; gpt-5.4: us-east-2, us-west-2)
 ```
 
 ---
@@ -433,6 +482,7 @@ Initial pricing data loaded: 77 models from api+aws-scraper
 Pricing database already contains 218 records
 Starting AWS pricing update task...
 AWS pricing update completed: 77 models updated from api+aws-scraper, 0 failed
+OpenAI mantle pricing (scraper): 2 models → 3 region rows (gpt-5.5: us-east-2; gpt-5.4: us-east-2, us-west-2)
 ```
 
 **Gemini pricing:**
@@ -520,6 +570,8 @@ No extra configuration needed. Gemini pricing runs regardless of `GEMINI_API_KEY
 ### Dynamic Region Resolution for Pricing
 
 When calculating cost, the `ModelPricing.calculate_cost()` method determines the pricing region dynamically via `BedrockClient.resolve_model()`. This ensures that models routed to the fallback region (e.g. `zai.glm-5` → `us-west-2`) look up prices under the correct region in the database.
+
+For OpenAI mantle models (`openai.gpt-5.5`, `openai.gpt-5.4`) this region inference is **short-circuited** by `resolve_mantle_region(model)`, which returns the local `AWS_REGION` when it is in the model's availability list, otherwise the model's preferred region. Because this matches the region used when the price was written, the lookup always succeeds.
 
 ### Customize Scheduler Times
 

--- a/docs/pricing-system.zh.md
+++ b/docs/pricing-system.zh.md
@@ -5,7 +5,7 @@
 本系统从多个数据源动态获取模型价格，并自动更新到数据库。价格数据用于计算 API 调用成本。
 
 系统包含两个独立的定价子系统并行运行：
-- **AWS Bedrock 定价** — 覆盖所有通过 AWS Bedrock 调用的模型
+- **AWS Bedrock 定价** — 覆盖所有通过 AWS Bedrock 调用的模型。同时也覆盖经 AWS "mantle" 推理引擎提供的 OpenAI GPT-5.5/5.4，价格从同一个 AWS 定价页面抓取（详见下文 **OpenAI mantle 定价**）。
 - **Google Gemini 定价** — 覆盖通过 Gemini API 直接调用的模型（存储时 `region="global"`）
 
 ---
@@ -16,11 +16,11 @@
 
 | 字段 | 说明 |
 |------|------|
-| `model_id` | 模型标识符（如 `amazon.nova-lite-v1:0`、`gemini-2.5-pro`） |
-| `region` | AWS 区域、跨区域前缀（`us.`、`global.`），Gemini 模型为 `"global"` |
+| `model_id` | 模型标识符（如 `amazon.nova-lite-v1:0`、`gemini-2.5-pro`、`openai.gpt-5.5`） |
+| `region` | AWS 区域、跨区域前缀（`us.`、`global.`），Gemini 模型为 `"global"`。mantle 模型使用不带前缀的普通 AWS 区域（如 `us-east-2`、`us-west-2`） |
 | `input_price_per_token` | 输入 token 单价（USD） |
 | `output_price_per_token` | 输出 token 单价（USD） |
-| `cached_input_price_per_token` | 上下文缓存读取价格（USD），不支持则为 NULL |
+| `cached_input_price_per_token` | 上下文缓存读取价格（USD），不支持则为 NULL。Gemini 缓存价格与 mantle 的 cached output 价格复用此列 |
 | `currency` | 货币（USD） |
 | `source` | 数据来源，见下表 |
 | `last_updated` | 最后更新时间 |
@@ -32,6 +32,7 @@
 |----|------|
 | `api` | AWS Price List API |
 | `aws-scraper` | AWS Bedrock 定价页面爬虫 |
+| `scraper` | OpenAI mantle（GPT-5.5/5.4）从 AWS 定价页面抓取的条目 — 与 Bedrock 抓取同标签，因为来自同一页面 |
 | `gemini-scraper` | Gemini 三级策略（统一标签） |
 
 ---
@@ -79,7 +80,7 @@ API 数据始终优先，爬虫数据仅填补空缺。
 }
 ```
 
-### 支持的厂商（共 19 个）
+### 支持的厂商（共 20 个）
 
 | 厂商 | Price List API | 页面爬虫 | 备注 |
 |------|:-:|:-:|------|
@@ -96,6 +97,7 @@ API 数据始终优先，爬虫数据仅填补空缺。
 | Moonshot AI | 是 | — | Kimi K2 Thinking |
 | NVIDIA | 是 | — | Nemotron Nano 2、3 |
 | OpenAI | 是 | 是 | gpt-oss-20b、gpt-oss-120b |
+| OpenAI (mantle) | — | 是 | 经 AWS "mantle" 推理引擎提供的 GPT-5.5、GPT-5.4 — 详见下文 **OpenAI mantle 定价** |
 | Qwen | 是 | 是 | Qwen3、Qwen3 Coder、Qwen3 VL |
 | Stability AI | — | — | 图像生成（按图计价） |
 | TwelveLabs | — | — | 视频理解（按秒计价） |
@@ -151,6 +153,53 @@ Gemini pricing tier-1 (Google):           17 个模型
 Gemini pricing tier-2 (LiteLLM):          新增 17 个模型
 Gemini pricing tier-3 (static legacy):    新增 3 个模型
 Gemini pricing saved:                      共 37 个模型
+```
+
+---
+
+## OpenAI mantle 定价
+
+OpenAI **GPT-5.5** 和 **GPT-5.4** 经 AWS "mantle" 推理引擎提供，价格与 Bedrock 模型在**同一个 AWS 定价页面**上发布。因此它不是一条独立的获取管线，而是在**现有 AWS 定价爬虫内部新增的增量分支** —— 完全不改动现有的 `data-pricing-markup` 解析路径。
+
+厂商标记：`openai-mantle`。source 标签：`scraper`（与 AWS Bedrock 抓取完全相同，因为数据来自同一个页面）。
+
+### 模型与价格
+
+价格为每 1M tokens（input / cached output / output）：
+
+| 模型 | `model_id` | 输入 $/1M | cached output $/1M | 输出 $/1M | 区域 |
+|------|-----------|----------|--------------------|----------|------|
+| GPT-5.5 | `openai.gpt-5.5` | $5.50 | $0.55 | $33.00 | 仅 `us-east-2` |
+| GPT-5.4 | `openai.gpt-5.4` | $2.75 | $0.275 | $16.50 | `us-east-2`、`us-west-2` |
+
+### 获取策略
+
+- **数据源：** 复用 Bedrock 抓取已经获取的 `https://aws.amazon.com/bedrock/pricing/` HTML —— 不发起额外请求。
+- **新增分支：** `backend/app/services/pricing_updater.py` 中的 `_scrape_openai_text_pricing(html)`。纯增量实现，现有基于 markup 的解析路径保持不变。
+- **定位：** 含表头 `"Price per 1M input tokens"` 的纯文本 `<table>`。该表有 4 列：`OpenAI models | input | cached output | output`，值形如 `$ 5.50`。
+- **解析：** 逐行解析，模型名称经 `MANTLE_PRICING_NAMES` 映射表映射到 `model_id`。
+
+### 入库
+
+- **按模型所在区域各写一条** —— `gpt-5.4` 写入 `us-east-2` 和 `us-west-2` 两条；`gpt-5.5` 仅写入 `us-east-2`。区域取自模型的可用区域列表，**而非** `settings.AWS_REGION`。
+- **单位换算：** 单价 = `$/1M ÷ 1e6`。
+- **cached output 价格**写入 `cached_input_price_per_token` 列（与 Gemini 复用同一列）。
+- **source 标签：** `scraper`。
+
+### 区域推断
+
+`pricing.py` 中的区域推断对 mantle 模型**短路**：`resolve_mantle_region(model)` 在本地 `AWS_REGION` 处于模型可用区域列表时返回本地区域，否则返回首选区域。该区域与写入价格时使用的区域一致，因此 `calculate_cost()` 始终能查到匹配的价格行，不会抛出 `ValueError`。
+
+### 安全 / 互不干扰
+
+- **`update_all_pricing` 的 api_model_ids 过滤**不会误删 mantle 行：mantle 模型不在 Price List API 中、也没有 geo 前缀，因此落在该过滤器的删除集合之外。
+- **`cleanup_stale_cross_region_entries`** 只删除带 geo 前缀的条目；mantle 行无前缀，因此不受影响。
+
+### 典型运行结果
+
+```
+AWS pricing update completed: 77 models updated from api+aws-scraper, 0 failed
+OpenAI mantle pricing (scraper): 2 models → 3 region rows (gpt-5.5: us-east-2; gpt-5.4: us-east-2, us-west-2)
 ```
 
 ---
@@ -420,6 +469,7 @@ Pricing database is empty, fetching initial pricing data from AWS...
 Initial pricing data loaded: 77 models from api+aws-scraper
 Starting AWS pricing update task...
 AWS pricing update completed: 77 models updated from api+aws-scraper, 0 failed
+OpenAI mantle pricing (scraper): 2 models → 3 region rows (gpt-5.5: us-east-2; gpt-5.4: us-east-2, us-west-2)
 ```
 
 **Gemini 定价：**
@@ -504,6 +554,8 @@ Gemini 价格更新爬取公开的 Google 定价页面，无需 `GEMINI_API_KEY`
 ### 动态区域解析（定价）
 
 `ModelPricing.calculate_cost()` 通过 `BedrockClient.resolve_model()` 动态确定定价区域。这确保了路由到 fallback 区域的模型（如 `zai.glm-5` → `us-west-2`）使用数据库中正确区域的价格。
+
+对于 OpenAI mantle 模型（`openai.gpt-5.5`、`openai.gpt-5.4`），该区域推断被 `resolve_mantle_region(model)` **短路**：当本地 `AWS_REGION` 处于模型可用区域列表时返回本地区域，否则返回模型的首选区域。由于这与写入价格时使用的区域一致，查价始终成功。
 
 ### 自定义调度时间
 

--- a/docs/request-translation.md
+++ b/docs/request-translation.md
@@ -1,13 +1,16 @@
 # Request Translation Pipeline
 
-How Kolya BR Proxy translates requests into upstream LLM API calls, and converts responses back. The proxy supports two client-facing API formats:
+How Kolya BR Proxy translates requests into upstream LLM API calls, and converts responses back. The proxy supports three client-facing API formats:
 
-- **OpenAI-compatible** (`POST /v1/chat/completions`) -- routes to AWS Bedrock (non-Gemini) or Google Gemini (model starts with `gemini-`)
-- **Anthropic Messages API** (`POST /v1/messages`) -- near-passthrough to Bedrock InvokeModel
+- **OpenAI-compatible** (`POST /v1/chat/completions`) -- routes to AWS Bedrock (default), Google Gemini (model starts with `gemini-`), or AWS mantle / OpenAI Responses API (model is `openai.gpt-5.5` / `openai.gpt-5.4`)
+- **Anthropic Messages API** (`POST /v1/messages`) -- near-passthrough to Bedrock InvokeModel; mantle models (`openai.gpt-5.5` / `openai.gpt-5.4`) are routed to the Responses API instead
+- **OpenAI Responses API** (`POST /v1/responses`) -- native passthrough to AWS mantle for OpenAI GPT-5.5/5.4 only; zero protocol conversion
 
 For Bedrock: Anthropic models use the InvokeModel API (native Messages API format), while non-Anthropic models (Nova, DeepSeek, Mistral, Llama, etc.) use the Converse API.
 
 For Gemini: `GeminiClient` uses the native `generateContent` / `streamGenerateContent` API; OpenAI ↔ Gemini conversion happens entirely within the client layer.
+
+For mantle (OpenAI GPT-5.5/5.4): `MantleClient` talks to the OpenAI Responses API served by AWS's "mantle" inference engine. Activation is an exact model-id match via `is_openai_mantle_model(model)`. Like Gemini, all translation happens inside the client, so `chat.py` always sees an OpenAI-format dict; the native `/v1/responses` endpoint bypasses translation entirely.
 
 ---
 
@@ -25,6 +28,7 @@ For Gemini: `GeminiClient` uses the native `generateContent` / `streamGenerateCo
 10. [Automatic Fixes](#10-automatic-fixes)
 11. [Unsupported Parameters](#11-unsupported-parameters)
 12. [Google Gemini Native API Path](#12-google-gemini-native-api-path)
+13. [OpenAI mantle (Responses API) Path](#13-openai-mantle-responses-api-path)
 
 ---
 
@@ -743,16 +747,134 @@ The following Gemini-specific features are not currently mapped:
 
 ---
 
+## 13. OpenAI mantle (Responses API) Path
+
+**File**: `backend/app/services/mantle_client.py`
+
+OpenAI **GPT-5.5** (`openai.gpt-5.5`, us-east-2 only) and **GPT-5.4** (`openai.gpt-5.4`, us-east-2 + us-west-2) are served by AWS's "mantle" inference engine through the **OpenAI Responses API**, not the boto3 `converse` / `invoke_model` paths. Activated when `is_openai_mantle_model(model)` returns `True` — an exact model-id match (a prefix match on `openai.` would wrongly capture the open-weight `openai.gpt-oss-*` models, which use the standard Bedrock Converse path). The mantle region registry and routing live in `mantle_models.py`; auth is SigV4 over the existing AWS credential chain (reused from `BedrockClient`), so no new bearer token is introduced.
+
+Like Gemini, all translation happens inside `MantleClient`; `chat.py` always sees an OpenAI-format dict, exactly as it does for Bedrock responses.
+
+### 13.1 Data Flow
+
+```mermaid
+sequenceDiagram
+    participant Chat as chat.py
+    participant MC as MantleClient
+    participant Mantle as AWS mantle (Responses API)
+
+    Chat->>MC: invoke(payload) / invoke_stream(payload)
+    Note over MC: payload is the raw OpenAI dict<br/>(model, messages, max_tokens, tools, …)
+
+    MC->>MC: _openai_to_responses(payload)
+    Note over MC: messages → input (system/developer → role developer)<br/>max_tokens → max_output_tokens<br/>tools → flattened function spec<br/>response_format → text.format<br/>reasoning.effort ← bedrock_additional_model_request_fields
+
+    MC->>MC: SigV4 sign (shared AWS creds)
+
+    alt Non-streaming
+        MC->>Mantle: POST /openai/v1/responses
+        Mantle-->>MC: Responses response (JSON)
+        MC->>MC: _responses_to_openai()
+        MC-->>Chat: OpenAI ChatCompletionResponse dict
+    else Streaming
+        MC->>Mantle: POST /openai/v1/responses (stream:true)
+        loop per named SSE event
+            Mantle-->>MC: event: response.output_text.delta<br/>data: {…}
+            MC->>MC: translate to chat.completion.chunk
+            MC-->>Chat: "data: {chat.completion.chunk}\n\n"
+        end
+        MC-->>Chat: "data: [DONE]\n\n"
+    end
+```
+
+### 13.2 Request Conversion (`_openai_to_responses`)
+
+OpenAI ChatCompletions → OpenAI Responses request body.
+
+| OpenAI | Responses | Notes |
+|---|---|---|
+| `messages[role=system]` | `input[{role:"developer", content}]` | System / developer messages map to role `developer` |
+| `messages[role=user]` | `input[{role:"user", content}]` | Text parts → `input_text`; multimodal preserved |
+| `messages[role=assistant]` | `input[{role:"assistant", content}]` | Text parts → `output_text`; `tool_calls` → `function_call` items |
+| `messages[role=tool]` | `input[{type:"function_call_output", call_id, output}]` | Keyed by `tool_call_id` |
+| `content: [{type:"image_url", image_url:{url:"data:…"}}]` | `content[{type:"input_image", image_url}]` | Data URL (or plain URL) passed through on `input_image` |
+| `max_tokens` | `max_output_tokens` | |
+| `temperature` | `temperature` | |
+| `top_p` | `top_p` | |
+| `tools[].function` | `tools[{type:"function", name, description, parameters}]` | Function spec flattened to the tool top level |
+| `tool_choice: "none"/"auto"/"required"` | `tool_choice` | Passed through unchanged |
+| `tool_choice: {type:"function", function:{name}}` | `tool_choice: {type:"function", name}` | Flattened |
+| `response_format: {type:"text"\|"json_object"}` | `text.format: {type}` | Passed through |
+| `response_format: {type:"json_schema", json_schema:{name, schema, strict, description}}` | `text.format: {type:"json_schema", name, schema, strict, description}` | Flattened from nested `json_schema` to top level |
+| `bedrock_additional_model_request_fields.reasoning.effort` | `reasoning: {effort}` | Reuses the existing Bedrock passthrough channel (no new schema field). mantle supports `none`/`low`/`medium`/`high`/`xhigh`; `minimal` is **not** supported |
+| `frequency_penalty`, `presence_penalty`, `n`, `logprobs`, `user`, `bedrock_*` (other) | **Silently ignored** | Not passed to mantle; no filtering needed in caller |
+
+### 13.3 Response Conversion (`_responses_to_openai`)
+
+OpenAI Responses → OpenAI ChatCompletions.
+
+| Responses | OpenAI | Notes |
+|---|---|---|
+| `output[type=message].content[output_text]` | `choices[0].message.content` | Concatenated if multiple text parts |
+| `output[type=function_call]` | `choices[0].message.tool_calls[]` | `arguments` carried as-is; missing `call_id` synthesized |
+| `output[type=reasoning]` | **Skipped** | Internal reasoning items not forwarded |
+| `status: "incomplete"` | `finish_reason: length` | Otherwise `stop`; overridden to `tool_calls` when tool calls present |
+| `usage.input_tokens` | `usage.prompt_tokens` | |
+| `usage.output_tokens` | `usage.completion_tokens` | |
+| `usage.total_tokens` | `usage.total_tokens` | Falls back to prompt + completion |
+| `usage.input_tokens_details.cached_tokens` | `usage.prompt_tokens_details.cached_tokens` | Only when > 0 |
+
+### 13.4 Streaming Conversion (`invoke_stream`)
+
+Unlike Gemini's single-JSON-per-line stream, the Responses API emits **named SSE events** (`event: <name>` + `data: {…}`). `invoke_stream` parses them and translates into OpenAI `chat.completion.chunk` SSE lines:
+
+| Responses event | OpenAI chunk delta |
+|---|---|
+| `response.output_text.delta` | `{content: <delta>}` |
+| `response.output_item.added` (function_call) | `{tool_calls:[{index, id, type:"function", function:{name, arguments:""}}]}` — opens a tool call |
+| `response.function_call_arguments.delta` | `{tool_calls:[{index, function:{arguments:<delta>}}]}` |
+| `response.completed` / `response.incomplete` | Empty delta + `finish_reason` (`tool_calls` / `length` / `stop`) + `usage` for billing |
+| `response.failed` / `error` | Empty delta + `finish_reason: stop` (error logged) |
+
+The terminal chunk carries `"usage"` so `stream_mantle_completion` can extract billing (`extract_cached_tokens_from_chunk`). The stream ends with `data: [DONE]`.
+
+### 13.5 Cached Token Billing
+
+`chat.py` calls `extract_cached_tokens()` / `extract_cached_tokens_from_chunk()` (defined in `mantle_client.py`) on the OpenAI-format response/chunk. These read `usage.prompt_tokens_details.cached_tokens`, set by `_build_usage()` from the Responses `input_tokens_details.cached_tokens`. Cached tokens are deducted from prompt tokens so cached input is not charged at the full input rate.
+
+### 13.6 Three Access Paths
+
+mantle models can be reached through three endpoints, with decreasing translation loss:
+
+| Endpoint | Translation | Loss |
+|---|---|---|
+| `/v1/chat/completions` | OpenAI ChatCompletions ↔ Responses (`invoke` / `invoke_stream`) | Lossy — only the mapped fields above survive |
+| `/v1/messages` | Anthropic ↔ Responses | Lossy — Anthropic `system` + `messages` are first flattened to OpenAI-style messages (`_anthropic_to_openai_messages`), then routed through `MantleClient.invoke`; only text content and `temperature` / `max_tokens` are forwarded |
+| `/v1/responses` | **None** — native passthrough (`responses_passthrough` / `responses_passthrough_stream`) | Lossless — body forwarded verbatim, SSE returned unchanged; only `response.completed` / `response.incomplete` events are sniffed for usage billing |
+
+The `/v1/responses` path (`backend/app/api/v1/endpoints/responses.py`) is the only one that exposes mantle's full capability surface and will transparently gain new mantle features the moment AWS enables them — no code change required. The request body is accepted as an open JSON object so unknown/new Responses fields pass straight through. It rejects non-mantle models with HTTP 400.
+
+### 13.7 mantle Capability Boundary
+
+mantle supports: text + vision input, function calling, custom tools, tool_search, namespace, MCP, reasoning effort, and structured output. It does **not** support: `image_generation`, `web_search`, `code_interpreter`, `file_search`, `computer_use_preview`.
+
+Because the ChatCompletions (`/v1/chat/completions`) and Anthropic (`/v1/messages`) paths translate to/from a narrower protocol, any Responses-only feature not in the §13.2 mapping table (built-in tools, custom tools, MCP, multimodal output, etc.) is dropped on those paths. Use `/v1/responses` to access them.
+
+---
+
 ## File Reference
 
 | File | Role in Translation |
 |---|---|
-| `api/v1/endpoints/chat.py` | OpenAI entry point; routes to Bedrock or Gemini; orchestrates stream/non-stream flow |
-| `api/anthropic/endpoints/messages.py` | Anthropic entry point; `x-api-key` auth; Anthropic SSE streaming |
+| `api/v1/endpoints/chat.py` | OpenAI entry point; routes to Bedrock, Gemini, or mantle; orchestrates stream/non-stream flow |
+| `api/v1/endpoints/responses.py` | OpenAI Responses API entry point (`/v1/responses`); native mantle passthrough, usage-only billing sniff |
+| `api/anthropic/endpoints/messages.py` | Anthropic entry point; `x-api-key` auth; Anthropic SSE streaming; routes mantle models to the Responses API |
 | `services/translator.py` | `RequestTranslator`: OpenAI → BedrockRequest; `ResponseTranslator`: BedrockResponse → OpenAI |
 | `services/anthropic_translator.py` | `AnthropicRequestTranslator`: Anthropic → BedrockRequest; `AnthropicResponseTranslator`: BedrockResponse → Anthropic |
 | `services/bedrock.py` | `_build_anthropic_body()`: BedrockRequest → Anthropic JSON (Anthropic models); `_build_converse_params()`: BedrockRequest → Converse API params (non-Anthropic); `_anthropic_event_to_bedrock()` / `_converse_stream_event_to_bedrock()`: stream event mapping |
 | `services/gemini_client.py` | `GeminiClient`: `invoke()` / `invoke_stream()` with full OpenAI ↔ Gemini native conversion; `extract_cached_tokens()` helpers |
+| `services/mantle_client.py` | `MantleClient`: `invoke()` / `invoke_stream()` with OpenAI ↔ Responses conversion; `responses_passthrough()` / `responses_passthrough_stream()` for native passthrough; SigV4 signing; `extract_cached_tokens()` helpers |
+| `services/mantle_models.py` | mantle model registry: `is_openai_mantle_model()`, `resolve_mantle_region()`, region map, base URL |
 | `schemas/openai.py` | OpenAI request/response Pydantic models |
 | `schemas/anthropic.py` | Anthropic Messages API request/response/streaming Pydantic models |
 | `schemas/bedrock.py` | Internal Bedrock Pydantic models (BedrockRequest, BedrockResponse, BedrockStreamEvent) |

--- a/docs/request-translation.zh.md
+++ b/docs/request-translation.zh.md
@@ -1,13 +1,16 @@
 # 请求转换管线
 
-Kolya BR Proxy 如何将请求转换为上游 LLM API 调用，以及如何将响应转换回来。代理支持两种客户端 API 格式：
+Kolya BR Proxy 如何将请求转换为上游 LLM API 调用，以及如何将响应转换回来。代理支持三种客户端 API 格式：
 
-- **OpenAI 兼容**（`POST /v1/chat/completions`）-- 路由到 AWS Bedrock（非 Gemini）或 Google Gemini（模型以 `gemini-` 开头）
-- **Anthropic Messages API**（`POST /v1/messages`）-- 近乎直通 Bedrock InvokeModel
+- **OpenAI 兼容**（`POST /v1/chat/completions`）-- 路由到 AWS Bedrock（默认）、Google Gemini（模型以 `gemini-` 开头）或 AWS mantle / OpenAI Responses API（模型为 `openai.gpt-5.5` / `openai.gpt-5.4`）
+- **Anthropic Messages API**（`POST /v1/messages`）-- 近乎直通 Bedrock InvokeModel；mantle 模型（`openai.gpt-5.5` / `openai.gpt-5.4`）改为路由到 Responses API
+- **OpenAI Responses API**（`POST /v1/responses`）-- 仅服务 OpenAI GPT-5.5/5.4，原生直通 AWS mantle，零协议转换
 
 Bedrock 端：Anthropic 模型使用 InvokeModel API（原生 Messages API 格式），非 Anthropic 模型（Nova、DeepSeek、Mistral、Llama 等）使用 Converse API。
 
 Gemini 端：`GeminiClient` 使用原生 `generateContent` / `streamGenerateContent` API；OpenAI ↔ Gemini 的格式转换完全在 Client 层完成。
+
+mantle 端（OpenAI GPT-5.5/5.4）：`MantleClient` 对接由 AWS "mantle" 推理引擎服务的 OpenAI Responses API。通过 `is_openai_mantle_model(model)` 精确匹配模型 id 激活。与 Gemini 一样，所有转换都在 client 内完成，`chat.py` 始终看到 OpenAI 格式 dict；原生 `/v1/responses` 端点则完全绕过转换。
 
 ---
 
@@ -26,6 +29,7 @@ Gemini 端：`GeminiClient` 使用原生 `generateContent` / `streamGenerateCont
 11. [自动修正](#11-自动修正)
 12. [不支持的参数](#12-不支持的参数)
 13. [Google Gemini 原生 API 路径](#13-google-gemini-原生-api-路径)
+14. [OpenAI mantle（Responses API）路径](#14-openai-mantleresponses-api路径)
 
 ---
 
@@ -753,16 +757,134 @@ sequenceDiagram
 
 ---
 
+## 14. OpenAI mantle（Responses API）路径
+
+**文件**：`backend/app/services/mantle_client.py`
+
+OpenAI **GPT-5.5**（`openai.gpt-5.5`，仅 us-east-2）与 **GPT-5.4**（`openai.gpt-5.4`，us-east-2 + us-west-2）由 AWS "mantle" 推理引擎通过 **OpenAI Responses API** 服务，而非 boto3 `converse` / `invoke_model` 路径。当 `is_openai_mantle_model(model)` 返回 `True` 时激活——这是对模型 id 的精确匹配（若用 `openai.` 前缀匹配会错误地捕获走标准 Bedrock Converse 路径的开源权重 `openai.gpt-oss-*` 模型）。mantle 的区域注册表与路由逻辑位于 `mantle_models.py`；鉴权使用 SigV4，复用现有 AWS 凭证链（取自 `BedrockClient`），因此不引入新的 bearer token。
+
+与 Gemini 一样，所有格式转换均在 `MantleClient` 内部完成；`chat.py` 始终收到 OpenAI 格式的 dict，与处理 Bedrock 响应完全对称。
+
+### 14.1 数据流
+
+```mermaid
+sequenceDiagram
+    participant Chat as chat.py
+    participant MC as MantleClient
+    participant Mantle as AWS mantle (Responses API)
+
+    Chat->>MC: invoke(payload) / invoke_stream(payload)
+    Note over MC: payload 是原始 OpenAI dict<br/>（model, messages, max_tokens, tools…）
+
+    MC->>MC: _openai_to_responses(payload)
+    Note over MC: messages → input（system/developer → role developer）<br/>max_tokens → max_output_tokens<br/>tools → 扁平化的 function spec<br/>response_format → text.format<br/>reasoning.effort ← bedrock_additional_model_request_fields
+
+    MC->>MC: SigV4 签名（复用 AWS 凭证）
+
+    alt 非流式
+        MC->>Mantle: POST /openai/v1/responses
+        Mantle-->>MC: Responses 响应（JSON）
+        MC->>MC: _responses_to_openai()
+        MC-->>Chat: OpenAI ChatCompletionResponse dict
+    else 流式
+        MC->>Mantle: POST /openai/v1/responses（stream:true）
+        loop 每个具名 SSE 事件
+            Mantle-->>MC: event: response.output_text.delta<br/>data: {…}
+            MC->>MC: 转换为 chat.completion.chunk
+            MC-->>Chat: "data: {chat.completion.chunk}\n\n"
+        end
+        MC-->>Chat: "data: [DONE]\n\n"
+    end
+```
+
+### 14.2 请求转换（`_openai_to_responses`）
+
+OpenAI ChatCompletions → OpenAI Responses 请求体。
+
+| OpenAI 字段 | Responses 字段 | 说明 |
+|---|---|---|
+| `messages[role=system]` | `input[{role:"developer", content}]` | system / developer 消息映射为 role `developer` |
+| `messages[role=user]` | `input[{role:"user", content}]` | 文本 part → `input_text`；多模态保留 |
+| `messages[role=assistant]` | `input[{role:"assistant", content}]` | 文本 part → `output_text`；`tool_calls` → `function_call` item |
+| `messages[role=tool]` | `input[{type:"function_call_output", call_id, output}]` | 以 `tool_call_id` 关联 |
+| `content: [{type:"image_url", image_url:{url:"data:…"}}]` | `content[{type:"input_image", image_url}]` | data URL（或普通 URL）直接放在 `input_image` |
+| `max_tokens` | `max_output_tokens` | |
+| `temperature` | `temperature` | |
+| `top_p` | `top_p` | |
+| `tools[].function` | `tools[{type:"function", name, description, parameters}]` | function spec 扁平化到 tool 顶层 |
+| `tool_choice: "none"/"auto"/"required"` | `tool_choice` | 原样透传 |
+| `tool_choice: {type:"function", function:{name}}` | `tool_choice: {type:"function", name}` | 扁平化 |
+| `response_format: {type:"text"\|"json_object"}` | `text.format: {type}` | 透传 |
+| `response_format: {type:"json_schema", json_schema:{name, schema, strict, description}}` | `text.format: {type:"json_schema", name, schema, strict, description}` | 从嵌套的 `json_schema` 扁平化到顶层 |
+| `bedrock_additional_model_request_fields.reasoning.effort` | `reasoning: {effort}` | 复用现有 Bedrock 透传通道（无需新增 schema 字段）。mantle 支持 `none`/`low`/`medium`/`high`/`xhigh`；**不支持** `minimal` |
+| `frequency_penalty`、`presence_penalty`、`n`、`logprobs`、`user`、其他 `bedrock_*` | **静默忽略** | 不传给 mantle；无需在调用方过滤 |
+
+### 14.3 响应转换（`_responses_to_openai`）
+
+OpenAI Responses → OpenAI ChatCompletions。
+
+| Responses 字段 | OpenAI 字段 | 说明 |
+|---|---|---|
+| `output[type=message].content[output_text]` | `choices[0].message.content` | 多个 text part 拼接 |
+| `output[type=function_call]` | `choices[0].message.tool_calls[]` | `arguments` 原样携带；缺失 `call_id` 时合成 |
+| `output[type=reasoning]` | **跳过** | 内部推理 item 不转发 |
+| `status: "incomplete"` | `finish_reason: length` | 否则为 `stop`；有工具调用时覆盖为 `tool_calls` |
+| `usage.input_tokens` | `usage.prompt_tokens` | |
+| `usage.output_tokens` | `usage.completion_tokens` | |
+| `usage.total_tokens` | `usage.total_tokens` | 缺失时回退为 prompt + completion |
+| `usage.input_tokens_details.cached_tokens` | `usage.prompt_tokens_details.cached_tokens` | 仅 > 0 时设置 |
+
+### 14.4 流式转换（`invoke_stream`）
+
+与 Gemini 每行一段 JSON 的流不同，Responses API 发出**具名 SSE 事件**（`event: <name>` + `data: {…}`）。`invoke_stream` 解析这些事件并转换为 OpenAI `chat.completion.chunk` SSE 行：
+
+| Responses 事件 | OpenAI chunk delta |
+|---|---|
+| `response.output_text.delta` | `{content: <delta>}` |
+| `response.output_item.added`（function_call）| `{tool_calls:[{index, id, type:"function", function:{name, arguments:""}}]}`——开启一个工具调用 |
+| `response.function_call_arguments.delta` | `{tool_calls:[{index, function:{arguments:<delta>}}]}` |
+| `response.completed` / `response.incomplete` | 空 delta + `finish_reason`（`tool_calls` / `length` / `stop`）+ 用于计费的 `usage` |
+| `response.failed` / `error` | 空 delta + `finish_reason: stop`（记录错误日志）|
+
+终止 chunk 携带 `"usage"`，供 `stream_mantle_completion` 提取计费（`extract_cached_tokens_from_chunk`）。流以 `data: [DONE]` 结束。
+
+### 14.5 缓存 token 计费
+
+`chat.py` 在 OpenAI 格式的响应/chunk 上调用 `extract_cached_tokens()` / `extract_cached_tokens_from_chunk()`（定义于 `mantle_client.py`）。它们读取 `usage.prompt_tokens_details.cached_tokens`，该值由 `_build_usage()` 从 Responses 的 `input_tokens_details.cached_tokens` 设置。缓存 token 会从 prompt token 中扣除，避免缓存输入按完整输入价格计费。
+
+### 14.6 三条访问路径
+
+mantle 模型可通过三个端点访问，转换损耗依次递减：
+
+| 端点 | 转换 | 损耗 |
+|---|---|---|
+| `/v1/chat/completions` | OpenAI ChatCompletions ↔ Responses（`invoke` / `invoke_stream`）| 有损——仅上表映射的字段会保留 |
+| `/v1/messages` | Anthropic ↔ Responses | 有损——Anthropic `system` + `messages` 先扁平化为 OpenAI 风格 messages（`_anthropic_to_openai_messages`），再走 `MantleClient.invoke`；仅转发文本内容和 `temperature` / `max_tokens` |
+| `/v1/responses` | **无**——原生直通（`responses_passthrough` / `responses_passthrough_stream`）| 无损——body 原样转发、SSE 原样回传；只嗅探 `response.completed` / `response.incomplete` 事件中的 usage 计费 |
+
+`/v1/responses` 路径（`backend/app/api/v1/endpoints/responses.py`）是唯一能拿到 mantle 全量能力的路径，未来 AWS 一旦启用新功能即可透明可用——无需改代码。请求 body 以开放 JSON 对象接收，未知/新增的 Responses 字段直接透传。该端点对非 mantle 模型返回 HTTP 400。
+
+### 14.7 mantle 能力边界
+
+mantle 支持：文本 + vision 输入、function calling、custom tools、tool_search、namespace、MCP、reasoning effort、structured output。**不支持**：`image_generation`、`web_search`、`code_interpreter`、`file_search`、`computer_use_preview`。
+
+由于 ChatCompletions（`/v1/chat/completions`）和 Anthropic（`/v1/messages`）路径会转换到/自一个更窄的协议，任何不在 §14.2 映射表内的 Responses 专属功能（built-in tools、custom tools、MCP、多模态输出等）在这两条路径上都会被丢弃。需使用 `/v1/responses` 才能访问它们。
+
+---
+
 ## 文件参考
 
 | 文件 | 在转换中的角色 |
 |---|---|
-| `api/v1/endpoints/chat.py` | OpenAI 入口点；路由到 Bedrock 或 Gemini；编排流式/非流式流程 |
-| `api/anthropic/endpoints/messages.py` | Anthropic 入口点；`x-api-key` 认证；Anthropic SSE 流式输出 |
+| `api/v1/endpoints/chat.py` | OpenAI 入口点；路由到 Bedrock、Gemini 或 mantle；编排流式/非流式流程 |
+| `api/v1/endpoints/responses.py` | OpenAI Responses API 入口点（`/v1/responses`）；mantle 原生直通，仅嗅探 usage 计费 |
+| `api/anthropic/endpoints/messages.py` | Anthropic 入口点；`x-api-key` 认证；Anthropic SSE 流式输出；将 mantle 模型路由到 Responses API |
 | `services/translator.py` | `RequestTranslator`：OpenAI → BedrockRequest；`ResponseTranslator`：BedrockResponse → OpenAI |
 | `services/anthropic_translator.py` | `AnthropicRequestTranslator`：Anthropic → BedrockRequest；`AnthropicResponseTranslator`：BedrockResponse → Anthropic |
 | `services/bedrock.py` | `_build_anthropic_body()`：BedrockRequest → Anthropic JSON（Anthropic 模型）；`_build_converse_params()`：BedrockRequest → Converse API 参数（非 Anthropic）；`_anthropic_event_to_bedrock()` / `_converse_stream_event_to_bedrock()`：流式事件映射 |
 | `services/gemini_client.py` | `GeminiClient`：`invoke()` / `invoke_stream()` 含完整 OpenAI ↔ Gemini 原生格式转换；`extract_cached_tokens()` 计费辅助函数 |
+| `services/mantle_client.py` | `MantleClient`：`invoke()` / `invoke_stream()` 含 OpenAI ↔ Responses 转换；`responses_passthrough()` / `responses_passthrough_stream()` 原生直通；SigV4 签名；`extract_cached_tokens()` 辅助函数 |
+| `services/mantle_models.py` | mantle 模型注册表：`is_openai_mantle_model()`、`resolve_mantle_region()`、区域映射、base URL |
 | `schemas/openai.py` | OpenAI 请求/响应 Pydantic 模型 |
 | `schemas/anthropic.py` | Anthropic Messages API 请求/响应/流式 Pydantic 模型 |
 | `schemas/bedrock.py` | 内部 Bedrock Pydantic 模型（BedrockRequest、BedrockResponse、BedrockStreamEvent） |

--- a/frontend/src/pages/PlaygroundPage.vue
+++ b/frontend/src/pages/PlaygroundPage.vue
@@ -220,7 +220,7 @@ const modelsStore = useModelsStore();
 
 const selectedToken = ref<string | null>(null);
 const selectedModel = ref<string | null>(null);
-const selectedSdk = ref<'openai' | 'anthropic' | 'gemini'>('openai');
+const selectedSdk = ref<'openai' | 'anthropic' | 'gemini' | 'responses'>('openai');
 const temperature = ref(0.7);
 const maxTokens = ref(2048);
 const userMessage = ref('');
@@ -237,16 +237,32 @@ const uploadedImages = ref<Array<{ base64: string; mimeType: string; name: strin
 // SDK options based on selected model
 // ---------------------------------------------------------------------------
 
+/** OpenAI GPT-5.5/5.4 served by AWS mantle — native protocol is the Responses API. */
+function isMantleModel(modelId: string): boolean {
+  return modelId === 'openai.gpt-5.5' || modelId === 'openai.gpt-5.4';
+}
+
 const sdkOptions = computed(() => {
   const model = selectedModel.value || '';
   if (!model) return [];
-  // Gemini SDK protocol only works with Gemini models (direct Google API proxy).
-  // OpenAI & Anthropic protocols work with all models (routed via Bedrock/Gemini on the backend).
+  // OpenAI & Anthropic protocols work with every model the proxy serves —
+  // Bedrock (Claude/Nova), Gemini, and mantle (GPT-5.5/5.4) all expose both
+  // the /v1/chat/completions and /v1/messages endpoints on the backend.
+  // The Gemini SDK protocol is the native Google API path (Gemini only).
+  // The Responses API is mantle's native protocol (GPT-5.5/5.4 only) and is the
+  // only path that exposes Responses-only features without lossy conversion.
   if (model.includes('gemini')) {
     return [
       { label: 'OpenAI', value: 'openai' },
       { label: 'Anthropic', value: 'anthropic' },
       { label: 'Gemini SDK', value: 'gemini' },
+    ];
+  }
+  if (isMantleModel(model)) {
+    return [
+      { label: 'Responses', value: 'responses' },
+      { label: 'OpenAI', value: 'openai' },
+      { label: 'Anthropic', value: 'anthropic' },
     ];
   }
   return [
@@ -255,13 +271,16 @@ const sdkOptions = computed(() => {
   ];
 });
 
-// Auto-set default SDK when model changes
+// Auto-set default SDK to each model's native protocol when the model changes.
 watch(selectedModel, (newModel) => {
   if (!newModel) return;
   if (newModel.includes('gemini')) {
     selectedSdk.value = 'gemini';
   } else if (newModel.includes('anthropic')) {
     selectedSdk.value = 'anthropic';
+  } else if (isMantleModel(newModel)) {
+    // mantle's native protocol is the Responses API.
+    selectedSdk.value = 'responses';
   } else {
     selectedSdk.value = 'openai';
   }
@@ -688,6 +707,92 @@ async function sendViaGemini(plainToken: string, assistantMsgIndex: number) {
 }
 
 // ---------------------------------------------------------------------------
+// Send via Responses API (/v1/responses) — mantle native, no conversion
+// ---------------------------------------------------------------------------
+
+/** Build native Responses API `input` from the conversation. */
+function getResponsesInput(): Array<Record<string, unknown>> {
+  return messages.value
+    .slice(0, -1)
+    .filter(m => m.content?.trim() || m.imageUrls?.length)
+    .map(m => {
+      const isAssistant = m.role === 'assistant';
+      const textType = isAssistant ? 'output_text' : 'input_text';
+      const parts: Array<Record<string, unknown>> = [];
+      if (m.imageUrls?.length && !isAssistant) {
+        for (const url of m.imageUrls) {
+          parts.push({ type: 'input_image', image_url: url });
+        }
+      }
+      if (m.content?.trim()) {
+        parts.push({ type: textType, text: m.content });
+      }
+      return { role: m.role, content: parts };
+    });
+}
+
+async function sendViaResponses(plainToken: string, assistantMsgIndex: number) {
+  const apiBaseUrl = getApiBaseUrl();
+
+  const chatResponse = await fetch(`${apiBaseUrl}/v1/responses`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'Authorization': `Bearer ${plainToken}`,
+      'X-Requested-With': 'XMLHttpRequest',
+      'Cache-Control': 'no-cache',
+    },
+    body: JSON.stringify({
+      model: selectedModel.value,
+      input: getResponsesInput(),
+      stream: true,
+      ...(maxTokens.value !== null && { max_output_tokens: maxTokens.value }),
+      ...(supportsTemperature.value && temperature.value !== null && { temperature: temperature.value }),
+    }),
+  });
+
+  if (!chatResponse.ok) {
+    const error = await chatResponse.json().catch(() => ({}));
+    throw new Error((error as Record<string, string>).detail || chatResponse.statusText || `HTTP ${chatResponse.status}`);
+  }
+
+  const reader = chatResponse.body?.getReader();
+  if (!reader) throw new Error('Unable to read response stream');
+
+  loading.value = false;
+  const decoder = new TextDecoder();
+  let buffer = '';
+
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+
+    buffer += decoder.decode(value, { stream: true });
+    const lines = buffer.split('\n');
+    buffer = lines.pop() || '';
+
+    for (const line of lines) {
+      if (!line.startsWith('data: ')) continue;
+      const dataStr = line.slice(6).trim();
+      if (!dataStr || dataStr === '[DONE]') continue;
+      try {
+        const parsed = JSON.parse(dataStr) as Record<string, unknown>;
+        // Native Responses SSE: text deltas arrive as response.output_text.delta
+        if (parsed.type === 'response.output_text.delta') {
+          const delta = parsed.delta;
+          if (typeof delta === 'string' && delta) {
+            typewriterQueue.value += delta;
+            if (!isTyping.value) startTypewriter(assistantMsgIndex);
+          }
+        }
+        // Future: image_generation_call results would surface here once mantle
+        // enables them — handled the same way as the Gemini inlineData path.
+      } catch { /* ignore parse errors */ }
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
 // Main send function — dispatches to the correct SDK path
 // ---------------------------------------------------------------------------
 
@@ -733,6 +838,9 @@ async function sendMessage() {
         break;
       case 'gemini':
         await sendViaGemini(plainToken, assistantMsgIndex);
+        break;
+      case 'responses':
+        await sendViaResponses(plainToken, assistantMsgIndex);
         break;
       case 'openai':
       default:

--- a/iac/modules/eks-addons/main.tf
+++ b/iac/modules/eks-addons/main.tf
@@ -100,6 +100,17 @@ resource "aws_iam_policy" "backend_bedrock" {
         Resource = "*"
       },
       {
+        # OpenAI GPT-5.5/5.4 served by the AWS "mantle" inference engine use a
+        # distinct "bedrock-mantle" IAM service prefix that "bedrock:*" does not
+        # cover, so it must be granted explicitly.
+        Sid    = "MantleOpenAIModels"
+        Effect = "Allow"
+        Action = [
+          "bedrock-mantle:*"
+        ]
+        Resource = "*"
+      },
+      {
         Effect = "Allow"
         Action = [
           "cognito-idp:AdminCreateUser",


### PR DESCRIPTION
## 概述

接入 AWS **mantle** 推理引擎上的 OpenAI **GPT-5.5 / GPT-5.4**(走 OpenAI Responses API,非 boto3 converse/invoke_model)。照搬现有 Gemini 的"非 Bedrock 第三方 provider"模式:**提前路由 + 独立 client + pricing 短路**,在进入 `BedrockClient` 之前截走,因此**不影响现有 Claude / Nova / DeepSeek / Gemini 路径**。

| 模型 | model id | 可用 region | 价格 input/cached/output (/1M) |
|---|---|---|---|
| GPT-5.5 | `openai.gpt-5.5` | us-east-2 | $5.50 / $0.55 / $33.00 |
| GPT-5.4 | `openai.gpt-5.4` | us-east-2 + us-west-2 | $2.75 / $0.275 / $16.50 |

## 三条访问路径

- `POST /v1/chat/completions` — ChatCompletions ↔ Responses 转换(有损)
- `POST /v1/messages` — Anthropic ↔ Responses 转换(有损)
- `POST /v1/responses` — **原生 Responses 透传(零转换)**,mantle 新功能自动可用

## 改动

**新增**
- `services/mantle_models.py` — 模型→region 路由表、`is_openai_mantle_model()` 精确匹配、`resolve_mantle_region()`、`get_mantle_models()`(单一事实来源)
- `services/mantle_client.py` — `MantleClient`:SigV4 签名(复用 EKS Pod IRSA 凭证链);`_openai_to_responses`/`_responses_to_openai` 双向转换;`invoke`/`invoke_stream`;原生 `responses_passthrough`/`responses_passthrough_stream`;`response_format` → `text.format` 透传
- `api/v1/endpoints/responses.py` — `POST /v1/responses` 原生透传端点(开放 body、流式、计费对齐)

**改动**
- `chat.py` / `anthropic/endpoints/messages.py` — 在 Gemini 分支后并列加 mantle 提前路由
- `pricing.py` — region 推断对 mantle 短路
- `pricing_updater.py` — scraper 增量分支 `_scrape_openai_text_pricing`,按 region 各写一条
- `admin/endpoints/models.py` — 模型列表注入 GPT-5.5/5.4(`provider=openai-mantle`)
- `schemas/openai.py` — `ChatCompletionRequest` 加 `response_format`
- `PlaygroundPage.vue` — 新增 Responses 协议测试选项
- `iac/modules/eks-addons/main.tf` — backend-bedrock policy 补 `bedrock-mantle:*`(`MantleOpenAIModels`,与线上 policy v3 对齐,消除 drift)

**文档**(中英双语)
- README / architecture / request-translation / api-reference / pricing-system 均按 Gemini 既有写法并列补充 mantle

## 已验证

- mantle 能力边界经真实签名调用核验:支持 文本 / vision 输入 / function calling / custom tools / tool_search / namespace / MCP / reasoning effort / structured output;不支持 image_generation / web_search / code_interpreter / file_search / computer_use_preview
- 已部署到 EKS(namespace `kbp`),`/v1/responses` 路由线上注册,playground 三协议可测
- `pre-commit run --all-files` 全绿

## 约束符合

- 不引入新 secret(SigV4 复用现有 AWS 凭证链)
- 模型列表与价格表里的模型都查得到价(calculate_cost 不抛 ValueError)
- 现有四条路径行为不变
