### PR TITLE
fix: 升级 pyjwt 2.12.1 → 2.13.0 修复 4 个 CVE

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ dependencies = [
     "aioboto3>=13.0.0",
     "aiobotocore>=2.11.0",
     # Authentication and security
-    "PyJWT>=2.8.0",
+    "PyJWT>=2.13.0",  # 2.13.0 fixes PYSEC-2026-175/177/178/179
     "passlib[bcrypt]>=1.7.4",
     "bcrypt>=3.2.0,<4.0.0",
     "python-multipart>=0.0.27",

--- a/uv.lock
+++ b/uv.lock
@@ -1475,7 +1475,7 @@ requires-dist = [
     { name = "passlib", extras = ["bcrypt"], specifier = ">=1.7.4" },
     { name = "pydantic", specifier = ">=2.5.0" },
     { name = "pydantic-settings", specifier = ">=2.1.0" },
-    { name = "pyjwt", specifier = ">=2.8.0" },
+    { name = "pyjwt", specifier = ">=2.13.0" },
     { name = "python-dotenv", specifier = ">=1.2.2" },
     { name = "python-multipart", specifier = ">=0.0.27" },
     { name = "redis", extras = ["hiredis"], specifier = ">=5.0.0" },
@@ -2345,11 +2345,11 @@ wheels = [
 
 [[package]]
 name = "pyjwt"
-version = "2.12.1"
+version = "2.13.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c2/27/a3b6e5bf6ff856d2509292e95c8f57f0df7017cf5394921fc4e4ef40308a/pyjwt-2.12.1.tar.gz", hash = "sha256:c74a7a2adf861c04d002db713dd85f84beb242228e671280bf709d765b03672b", size = 102564, upload-time = "2026-03-13T19:27:37.25Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/3b/81/58d0ac84e1ef3a3843791d6954d94c0b33d526c75eeb1efbce9d0a4c4077/pyjwt-2.13.0.tar.gz", hash = "sha256:41571c89ca91598c79e8ef18a2d07367d4810fbbd6f637794879baf1b7703423", size = 107515, upload-time = "2026-05-21T19:54:36.618Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e5/7a/8dd906bd22e79e47397a61742927f6747fe93242ef86645ee9092e610244/pyjwt-2.12.1-py3-none-any.whl", hash = "sha256:28ca37c070cad8ba8cd9790cd940535d40274d22f80ab87f3ac6a713e6e8454c", size = 29726, upload-time = "2026-03-13T19:27:35.677Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/5e/ecf12fdb62546d64385c158514e9b2b671f7832108ef2ecd2020ce0af2d1/pyjwt-2.13.0-py3-none-any.whl", hash = "sha256:66adcc2aff09b3f1bbd95fc1e1577df8ac8723c978552fd43304c8a290ac5728", size = 31274, upload-time = "2026-05-21T19:54:35.362Z" },
 ]
 
 [package.optional-dependencies]


### PR DESCRIPTION
## 概述

CI 的 Python Dependency Audit(pip-audit)报告 `pyjwt 2.12.1` 存在 4 个漏洞:

| 包 | 版本 | 漏洞 | 修复版本 |
|---|---|---|---|
| pyjwt | 2.12.1 | PYSEC-2026-175 / 177 / 178 / 179 | 2.13.0 |

pyjwt 是 token 鉴权的关键依赖,予以升级。

## 改动
- `pyproject.toml`: `PyJWT>=2.8.0` → `>=2.13.0`
- `uv.lock`: pyjwt 2.12.1 → 2.13.0(仅此一包)

## 验证
- 本地 `pip-audit`(与 CI 同样的 ignore 列表):`No known vulnerabilities found`
- pre-commit 全绿