### PR TITLE
feat: trace viewer + model compatibility fixes

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -166,7 +166,7 @@
         "filename": "backend/app/core/config.py",
         "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
         "is_verified": false,
-        "line_number": 35
+        "line_number": 39
       }
     ],
     "backend/scripts/test_alembic.py": [
@@ -3881,5 +3881,5 @@
       }
     ]
   },
-  "generated_at": "2026-06-01T00:10:29Z"
+  "generated_at": "2026-06-08T03:04:49Z"
 }

--- a/backend/app/api/admin/endpoints/traces.py
+++ b/backend/app/api/admin/endpoints/traces.py
@@ -1,0 +1,45 @@
+"""Trace inspection endpoints."""
+
+from fastapi import APIRouter, Depends, HTTPException
+
+from app.api.deps import require_permission
+from app.models.user import User
+from app.services.trace_store import TraceStore
+
+router = APIRouter()
+
+
+@router.get("/")
+async def list_traces(
+    current_user: User = Depends(require_permission("view_usage")),
+):
+    """List recent traces (newest first)."""
+    store = TraceStore.get_instance()
+    return {
+        "enabled": TraceStore.is_enabled(),
+        "count": store.size,
+        "traces": store.list_all(),
+    }
+
+
+@router.get("/{request_id}")
+async def get_trace(
+    request_id: str,
+    current_user: User = Depends(require_permission("view_usage")),
+):
+    """Get a single trace by request_id."""
+    store = TraceStore.get_instance()
+    trace = store.get(request_id)
+    if not trace:
+        raise HTTPException(status_code=404, detail="Trace not found")
+    return trace
+
+
+@router.delete("/")
+async def clear_traces(
+    current_user: User = Depends(require_permission("view_usage")),
+):
+    """Clear all stored traces."""
+    store = TraceStore.get_instance()
+    store.clear()
+    return {"message": "Traces cleared"}

--- a/backend/app/api/admin/router.py
+++ b/backend/app/api/admin/router.py
@@ -14,6 +14,7 @@ from app.api.admin.endpoints import (
     models,
     teams,
     tokens,
+    traces,
     usage,
     users,
     pricing,
@@ -67,6 +68,9 @@ admin_router.include_router(
 admin_router.include_router(
     data_management.router, prefix="/data-management", tags=["admin-data-management"]
 )
+
+# Trace inspection (view_usage permission)
+admin_router.include_router(traces.router, prefix="/traces", tags=["admin-traces"])
 
 
 @admin_router.get("/")

--- a/backend/app/api/anthropic/endpoints/messages.py
+++ b/backend/app/api/anthropic/endpoints/messages.py
@@ -2,6 +2,7 @@
 Anthropic Messages API compatible endpoint.
 """
 
+import json
 import logging
 import time
 import uuid
@@ -29,10 +30,55 @@ from app.services.bedrock import BedrockClient, get_fallback_models
 from app.services.gemini_client import is_gemini_model as _is_gemini_model
 from app.services.mantle_models import is_openai_mantle_model as _is_mantle_model
 from app.services.pricing import ModelPricing
+from app.services.trace_store import TraceRecord, TraceStore
 
 router = APIRouter()
 logger = logging.getLogger(__name__)
 background_tasks = BackgroundTaskManager()
+
+
+def _build_trace_request(
+    request_data: AnthropicMessagesRequest, request_id: str, token: "APIToken"
+) -> TraceRecord:
+    """Build a TraceRecord from the incoming request (response fields filled later)."""
+
+    def _serialize_system(sys):
+        if sys is None:
+            return None
+        if isinstance(sys, str):
+            return sys
+        return [b.model_dump() if hasattr(b, "model_dump") else b for b in sys]
+
+    def _serialize_messages(msgs):
+        out = []
+        for m in msgs:
+            content = m.content
+            if isinstance(content, list):
+                content = [
+                    b.model_dump() if hasattr(b, "model_dump") else b for b in content
+                ]
+            out.append({"role": m.role, "content": content})
+        return out
+
+    def _serialize_tools(tools):
+        if not tools:
+            return []
+        return [t.model_dump() if hasattr(t, "model_dump") else t for t in tools]
+
+    return TraceRecord(
+        request_id=request_id,
+        timestamp=time.time(),
+        model=request_data.model,
+        token_id=str(token.id),
+        token_name=token.name or "",
+        system=_serialize_system(request_data.system),
+        messages=_serialize_messages(request_data.messages),
+        tools=_serialize_tools(request_data.tools),
+        thinking=request_data.thinking.model_dump() if request_data.thinking else None,
+        max_tokens=request_data.max_tokens,
+        temperature=request_data.temperature,
+        stream=request_data.stream or False,
+    )
 
 
 @router.post("/messages")
@@ -170,6 +216,7 @@ async def create_message(
                     http_request=http_request,
                     cache_ttl=cache_ttl or get_settings().PROMPT_CACHE_TTL,
                     allowed_model_names=allowed_model_names,
+                    request_data=request_data,
                 ),
                 media_type="text/event-stream",
                 headers={
@@ -235,6 +282,21 @@ async def create_message(
             cache_read_tokens=cache_read_tokens,
         )
 
+        # Record trace
+        if TraceStore.is_enabled():
+            trace_rec = _build_trace_request(request_data, request_id, token)
+            trace_rec.duration_s = round(duration, 3)
+            trace_rec.stop_reason = anthropic_response.stop_reason or ""
+            trace_rec.input_tokens = anthropic_response.usage.input_tokens
+            trace_rec.output_tokens = anthropic_response.usage.output_tokens
+            trace_rec.cache_creation_input_tokens = cache_creation_tokens
+            trace_rec.cache_read_input_tokens = cache_read_tokens
+            trace_rec.response_content = [
+                b.model_dump() if hasattr(b, "model_dump") else b
+                for b in (anthropic_response.content or [])
+            ]
+            TraceStore.get_instance().add(trace_rec)
+
         return anthropic_response
 
     except HTTPException:
@@ -294,6 +356,7 @@ async def stream_anthropic_messages(
     http_request: Request = None,
     cache_ttl: str = None,
     allowed_model_names: list[str] | None = None,
+    request_data: AnthropicMessagesRequest | None = None,
 ) -> AsyncGenerator[str, None]:
     """
     Stream Anthropic Messages API responses.
@@ -313,6 +376,11 @@ async def stream_anthropic_messages(
     }
     last_heartbeat = time.time()
     client_disconnected = False
+    # Accumulate response content blocks for trace
+    trace_content_blocks: list[dict] = []
+    trace_current_block: dict | None = None
+    trace_chunks: list[str] = []
+    trace_stop_reason = ""
 
     # Compute fallback models for stream failover
     fb_models = get_fallback_models(allowed_model_names or [], model)
@@ -348,6 +416,48 @@ async def stream_anthropic_messages(
             # Measure time to first content token
             if ttft is None and event.type == "content_block_delta":
                 ttft = time.time() - start_time
+
+            # Accumulate content for trace
+            if event.type == "content_block_start" and event.content_block:
+                cb = event.content_block
+                trace_current_block = {"type": cb.type}
+                trace_chunks = []
+                if cb.type == "tool_use":
+                    trace_current_block["id"] = cb.id or ""
+                    trace_current_block["name"] = cb.name or ""
+            elif (
+                event.type == "content_block_delta"
+                and event.delta
+                and trace_current_block
+            ):
+                delta = event.delta
+                chunk = (
+                    delta.get("text")
+                    or delta.get("thinking")
+                    or delta.get("partial_json")
+                    or delta.get("signature")
+                    or ""
+                )
+                if chunk:
+                    trace_chunks.append(chunk)
+            elif event.type == "content_block_stop" and trace_current_block:
+                joined = "".join(trace_chunks)
+                btype = trace_current_block["type"]
+                if btype == "text":
+                    trace_current_block["text"] = joined
+                elif btype == "thinking":
+                    trace_current_block["thinking"] = joined
+                elif btype == "tool_use":
+                    try:
+                        trace_current_block["input"] = json.loads(joined or "{}")
+                    except (ValueError, TypeError):
+                        trace_current_block["input"] = joined
+                elif btype == "signature":
+                    trace_current_block["signature"] = joined
+                trace_content_blocks.append(trace_current_block)
+                trace_current_block = None
+            elif event.type == "message_delta" and event.delta:
+                trace_stop_reason = event.delta.get("stop_reason", "")
 
             # Convert Bedrock event to Anthropic SSE events
             sse_events = AnthropicResponseTranslator.bedrock_stream_to_anthropic_events(
@@ -410,6 +520,18 @@ async def stream_anthropic_messages(
             cache_write_tokens=total_cache_creation,
             cache_read_tokens=total_cache_read,
         )
+
+        # Record trace
+        if TraceStore.is_enabled() and request_data:
+            trace_rec = _build_trace_request(request_data, request_id, token)
+            trace_rec.duration_s = round(duration, 3)
+            trace_rec.stop_reason = trace_stop_reason
+            trace_rec.input_tokens = total_input
+            trace_rec.output_tokens = total_output
+            trace_rec.cache_creation_input_tokens = total_cache_creation
+            trace_rec.cache_read_input_tokens = total_cache_read
+            trace_rec.response_content = trace_content_blocks
+            TraceStore.get_instance().add(trace_rec)
 
     except ClientError as e:
         error_code = e.response.get("Error", {}).get("Code", "Unknown")

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -23,6 +23,10 @@ class Settings(BaseSettings):
 
     # Application settings
     DEBUG: bool = Field(default=False, description="Enable debug mode")
+    TRACE_ENABLED: bool = Field(
+        default=True,
+        description="Enable request trace recording (in-memory ring buffer)",
+    )
     PORT: int = Field(default=8000, description="Application port")
     ALLOWED_ORIGINS: str = Field(
         default="http://localhost:3000,http://localhost:8000",

--- a/backend/app/services/bedrock.py
+++ b/backend/app/services/bedrock.py
@@ -528,17 +528,27 @@ class BedrockClient:
                 break
         return base.startswith(cls.ANTHROPIC_BASE_PREFIX)
 
-    _OPUS_SAMPLING_SUPPORTED = ("opus-4-5", "opus-4-6")
+    _SAMPLING_SUPPORTED_PATTERNS = (
+        "claude-3-",
+        "claude-3.",
+        "claude-v2",
+        "claude-instant",
+        "sonnet-4",
+        "haiku-4",
+        "opus-4-5",
+        "opus-4-6",
+    )
 
     @classmethod
     def _is_no_sampling_model(cls, model_id: str) -> bool:
         """Models that don't support temperature/top_p/top_k.
 
-        All Opus models except those in _OPUS_SAMPLING_SUPPORTED.
+        Whitelist approach: only models matching _SAMPLING_SUPPORTED_PATTERNS
+        support sampling. All newer models (post-4.6) do not.
         """
-        if "opus" not in model_id:
+        if not cls.is_anthropic_model(model_id):
             return False
-        return not any(pat in model_id for pat in cls._OPUS_SAMPLING_SUPPORTED)
+        return not any(pat in model_id for pat in cls._SAMPLING_SUPPORTED_PATTERNS)
 
     # Map AWS region prefix to geographic inference profile prefix
     REGION_TO_GEO_PREFIX = {

--- a/backend/app/services/mantle_client.py
+++ b/backend/app/services/mantle_client.py
@@ -241,6 +241,13 @@ def _openai_tool_choice_to_responses(tool_choice: Any) -> Optional[Any]:
     return None
 
 
+_REASONING_MODEL_PATTERNS = ("gpt-5.5", "o1", "o3", "o4")
+
+
+def _is_reasoning_model(model: str) -> bool:
+    return any(pat in model for pat in _REASONING_MODEL_PATTERNS)
+
+
 def _openai_to_responses(payload: Dict[str, Any]) -> Dict[str, Any]:
     """Convert a full OpenAI chat completion payload to a Responses request body.
 
@@ -266,9 +273,10 @@ def _openai_to_responses(payload: Dict[str, Any]) -> Dict[str, Any]:
 
     if payload.get("max_tokens") is not None:
         body["max_output_tokens"] = payload["max_tokens"]
-    if payload.get("temperature") is not None:
+    is_reasoning = _is_reasoning_model(body["model"])
+    if not is_reasoning and payload.get("temperature") is not None:
         body["temperature"] = payload["temperature"]
-    if payload.get("top_p") is not None:
+    if not is_reasoning and payload.get("top_p") is not None:
         body["top_p"] = payload["top_p"]
 
     tools = _openai_tools_to_responses(payload.get("tools"))
@@ -428,6 +436,20 @@ class MantleClient:
     # /v1/responses endpoint exposes mantle's full capability surface.
     # ------------------------------------------------------------------
 
+    @staticmethod
+    def _strip_unsupported_params(body: dict) -> dict:
+        """Remove parameters not supported by reasoning models."""
+        model = body.get("model", "")
+        if _is_reasoning_model(model):
+            for key in (
+                "temperature",
+                "top_p",
+                "frequency_penalty",
+                "presence_penalty",
+            ):
+                body.pop(key, None)
+        return body
+
     @classmethod
     async def responses_passthrough(cls, body: dict) -> dict:
         """Non-streaming native Responses request — body forwarded verbatim."""
@@ -435,6 +457,7 @@ class MantleClient:
         url, region = cls._endpoint(model)
         send_body = dict(body)
         send_body["stream"] = False
+        cls._strip_unsupported_params(send_body)
         body_bytes = json.dumps(send_body).encode("utf-8")
         headers = await _signed_headers("POST", url, body_bytes, region)
 
@@ -468,6 +491,7 @@ class MantleClient:
         url, region = cls._endpoint(model)
         send_body = dict(body)
         send_body["stream"] = True
+        cls._strip_unsupported_params(send_body)
         body_bytes = json.dumps(send_body).encode("utf-8")
         headers = await _signed_headers("POST", url, body_bytes, region)
         headers["Accept"] = "text/event-stream"

--- a/backend/app/services/trace_store.py
+++ b/backend/app/services/trace_store.py
@@ -1,0 +1,91 @@
+"""
+In-memory ring buffer trace store for request/response inspection.
+
+Stores the last N full API traces (request body, response, usage) for
+debugging and inspection via the /admin/traces endpoint.
+
+Controlled by TRACE_ENABLED env var (default: True).
+Production disables via KBR_TRACE_ENABLED=false in ConfigMap.
+"""
+
+from collections import deque
+from dataclasses import asdict, dataclass, field
+from typing import Any, Optional
+
+from app.core.config import get_settings
+
+
+@dataclass
+class TraceRecord:
+    """A single request/response trace."""
+
+    request_id: str
+    timestamp: float
+    model: str
+    token_id: str
+    token_name: str = ""
+
+    # Request
+    system: Any = None
+    messages: list = field(default_factory=list)
+    tools: list = field(default_factory=list)
+    thinking: Any = None
+    max_tokens: int = 0
+    temperature: Optional[float] = None
+    stream: bool = False
+
+    # Response
+    response_content: list = field(default_factory=list)
+    stop_reason: str = ""
+    duration_s: float = 0.0
+
+    # Usage
+    input_tokens: int = 0
+    output_tokens: int = 0
+    cache_creation_input_tokens: int = 0
+    cache_read_input_tokens: int = 0
+
+    # Error (if any)
+    error: Optional[str] = None
+
+    def to_dict(self) -> dict:
+        return asdict(self)
+
+
+class TraceStore:
+    """Thread-safe in-memory ring buffer for trace records."""
+
+    _instance: Optional["TraceStore"] = None
+
+    def __init__(self, max_size: int = 200):
+        self._buffer: deque[TraceRecord] = deque(maxlen=max_size)
+
+    @classmethod
+    def get_instance(cls) -> "TraceStore":
+        if cls._instance is None:
+            cls._instance = cls()
+        return cls._instance
+
+    @classmethod
+    def is_enabled(cls) -> bool:
+        settings = get_settings()
+        return settings.TRACE_ENABLED
+
+    def add(self, record: TraceRecord) -> None:
+        self._buffer.append(record)
+
+    def list_all(self) -> list[dict]:
+        return [r.to_dict() for r in reversed(self._buffer)]
+
+    def get(self, request_id: str) -> Optional[dict]:
+        for r in self._buffer:
+            if r.request_id == request_id:
+                return r.to_dict()
+        return None
+
+    def clear(self) -> None:
+        self._buffer.clear()
+
+    @property
+    def size(self) -> int:
+        return len(self._buffer)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -699,7 +699,7 @@ This section details the full lifecycle of gateway requests. The proxy supports 
 - **OpenAI path → Google Gemini** (`/v1/chat/completions`, `gemini-*` models): `GeminiClient` converts OpenAI ↔ Gemini native format; `chat.py` is format-agnostic
 - **OpenAI path → AWS mantle** (`/v1/chat/completions` and `/v1/messages`, `openai.gpt-5.5` / `openai.gpt-5.4`): `is_openai_mantle_model()` routes the request to `MantleClient`, which converts OpenAI ChatCompletions ↔ OpenAI Responses (lossy) and calls mantle's `POST /responses` over SigV4
 - **mantle native passthrough** (`/v1/responses`): zero-conversion OpenAI Responses API forwarded directly to mantle
-- **Anthropic path** (`/v1/messages`): Near-passthrough since Bedrock InvokeModel natively uses Anthropic Messages API format
+- **Anthropic path** (`/v1/messages`): Translated (not a true passthrough). The *format* is close — Bedrock InvokeModel natively uses Anthropic Messages API format — but the request is still mapped through `to_bedrock` → `BedrockRequest`, which has no `cache_control` field, so inline cache breakpoints are dropped (the proxy injects its own). `to_bedrock_with_passthrough` exists but is not currently wired in.
 
 OpenAI GPT-5.5/5.4 can therefore be reached via three access paths: `/v1/chat/completions` (lossy conversion), `/v1/messages` (lossy conversion), and `/v1/responses` (native, zero conversion).
 
@@ -899,7 +899,7 @@ sequenceDiagram
 
 ### 7.4 Anthropic Path Sequence Diagram
 
-The Anthropic path is a near-passthrough: since Bedrock's InvokeModel API natively accepts Anthropic Messages API format, minimal translation is needed. Key differences from the OpenAI path:
+The Anthropic path is close to the native format — Bedrock's InvokeModel API accepts Anthropic Messages API format — but it is still a **translation** (`to_bedrock` → `BedrockRequest`), not a byte passthrough: inline `cache_control` markers are dropped (see [Prompt Caching](prompt-caching.md)). Key differences from the OpenAI path:
 
 - Auth via `x-api-key` header instead of `Authorization: Bearer`
 - Thinking blocks are preserved in responses (OpenAI path skips them)
@@ -930,9 +930,9 @@ sequenceDiagram
 
     Msg->>Msg: Quota check + model access check<br/>(normalizes Anthropic short names to Bedrock IDs)
 
-    Msg->>Translator: to_bedrock_with_passthrough(request)
-    Note over Translator: Near 1:1 mapping,<br/>preserves cache_control
-    Translator-->>Msg: Raw dict for invoke_model
+    Msg->>Translator: to_bedrock(request)
+    Note over Translator: Maps to BedrockRequest;<br/>inline cache_control is DROPPED<br/>(schema has no such field)
+    Translator-->>Msg: BedrockRequest
 
     alt Streaming (stream=true)
         Msg->>Bedrock: invoke_stream(model, request)
@@ -965,7 +965,7 @@ sequenceDiagram
 | **OpenAI → Bedrock** | Three-phase (OpenAI → `BedrockRequest` → Bedrock API → `BedrockResponse` → OpenAI) | Full translation; tool calls, images, Bedrock extensions |
 | **OpenAI → Gemini** | `GeminiClient` internal conversion (OpenAI → Gemini GenerateContentRequest / back) | Native `generateContent` API; no OpenAI-compat layer |
 | **OpenAI → mantle** | `MantleClient` internal conversion (OpenAI ChatCompletions ↔ OpenAI Responses) | SigV4 to `POST /responses`; lossy. Native `/v1/responses` is zero-conversion passthrough |
-| **Anthropic → Bedrock** | Near-passthrough (`invoke_model`) | Minimal translation; preserves `cache_control`, thinking blocks |
+| **Anthropic → Bedrock** | Translated via `to_bedrock` → `BedrockRequest` (`invoke_model`) | Format is close to native, but it is a translation, not a passthrough: thinking blocks are preserved; inline `cache_control` markers are **dropped** (`BedrockRequest` has no such field). The proxy injects its own breakpoints. `to_bedrock_with_passthrough` exists but is **not wired in**. |
 
 For non-Anthropic Bedrock models (Nova, DeepSeek, Mistral, Llama, etc.), the Bedrock path uses the Converse API via `converse`/`converse_stream`.
 

--- a/docs/architecture.zh.md
+++ b/docs/architecture.zh.md
@@ -689,7 +689,7 @@ sequenceDiagram
 - **OpenAI 路径 → Google Gemini**（`/v1/chat/completions`，`gemini-*` 模型）：`GeminiClient` 在内部完成 OpenAI ↔ Gemini 原生格式转换；`chat.py` 格式无感知
 - **OpenAI 路径 → AWS mantle**（`/v1/chat/completions` 和 `/v1/messages`，`openai.gpt-5.5` / `openai.gpt-5.4`）：`is_openai_mantle_model()` 将请求路由到 `MantleClient`，由其完成 OpenAI ChatCompletions ↔ OpenAI Responses 转换（有损），并通过 SigV4 调用 mantle 的 `POST /responses`
 - **mantle 原生透传**（`/v1/responses`）：零转换的 OpenAI Responses API，直接转发给 mantle
-- **Anthropic 路径**（`/v1/messages`）：近乎直通，因为 Bedrock InvokeModel 原生使用 Anthropic Messages API 格式
+- **Anthropic 路径**（`/v1/messages`）：属翻译而非真正直通。**格式**接近——Bedrock InvokeModel 原生使用 Anthropic Messages API 格式——但请求仍经 `to_bedrock` → `BedrockRequest` 映射，而该模型无 `cache_control` 字段，故 inline 缓存断点被丢弃（改由代理自行注入）。`to_bedrock_with_passthrough` 存在但当前未接入。
 
 因此 OpenAI GPT-5.5/5.4 有三条访问路径：`/v1/chat/completions`（有损转换）、`/v1/messages`（有损转换）、`/v1/responses`（原生，零转换）。
 
@@ -859,7 +859,7 @@ sequenceDiagram
 
 ### 7.4 Anthropic 路径时序图
 
-Anthropic 路径是近乎直通的：由于 Bedrock 的 InvokeModel API 原生接受 Anthropic Messages API 格式，只需极少转换。与 OpenAI 路径的关键区别：
+Anthropic 路径**格式**接近原生：Bedrock 的 InvokeModel API 原生接受 Anthropic Messages API 格式，只需极少转换。但它仍是一次**翻译**（`to_bedrock` → `BedrockRequest`），并非字节级直通：内部模型不携带的字段——尤其是消息/system/tools 块里 inline 的 `cache_control` 标记——会被丢弃（详见 [Prompt Caching](prompt-caching.md)）。与 OpenAI 路径的关键区别：
 
 - 通过 `x-api-key` 头认证，而非 `Authorization: Bearer`
 - 响应中保留 thinking blocks（OpenAI 路径会跳过它们）
@@ -890,9 +890,9 @@ sequenceDiagram
 
     Msg->>Msg: 配额检查 + 模型访问检查<br/>（支持 Anthropic 短格式名称自动映射到 Bedrock ID）
 
-    Msg->>Translator: to_bedrock_with_passthrough(request)
-    Note over Translator: 近 1:1 映射，<br/>保留 cache_control
-    Translator-->>Msg: invoke_model 原始字典
+    Msg->>Translator: to_bedrock(request)
+    Note over Translator: 映射为 BedrockRequest；<br/>inline cache_control 被丢弃<br/>（schema 无此字段）
+    Translator-->>Msg: BedrockRequest
 
     alt Streaming (stream=true)
         Msg->>Bedrock: invoke_stream(model, request)
@@ -925,12 +925,12 @@ sequenceDiagram
 | **OpenAI → Bedrock** | 三阶段（OpenAI → `BedrockRequest` → Bedrock API → `BedrockResponse` → OpenAI）| 完整转换；支持工具调用、图片、Bedrock 扩展字段 |
 | **OpenAI → Gemini** | `GeminiClient` 内部转换（OpenAI → Gemini GenerateContentRequest / 反向）| 原生 `generateContent` API；不经过 OpenAI 兼容层 |
 | **OpenAI → mantle** | `MantleClient` 内部转换（OpenAI ChatCompletions ↔ OpenAI Responses）| SigV4 调用 `POST /responses`；有损。原生 `/v1/responses` 为零转换透传 |
-| **Anthropic → Bedrock** | 近乎直通（`invoke_model`）| 最小转换；保留 `cache_control`、thinking blocks |
+| **Anthropic → Bedrock** | 经 `to_bedrock` → `BedrockRequest` 翻译（`invoke_model`）| 格式接近原生，但属翻译而非直通：thinking blocks 保留；inline `cache_control` 标记被**丢弃**（`BedrockRequest` 无此字段），改由代理自行注入断点。`to_bedrock_with_passthrough` 存在但**未接入**。 |
 
 代理在客户端 API 格式和 Bedrock 之间执行转换：
 
 - **OpenAI 路径**：三阶段转换（OpenAI → `BedrockRequest` → Bedrock API → `BedrockResponse` → OpenAI）。包括消息转换、工具调用映射、参数翻译和自动修正。
-- **Anthropic 路径**：近乎直通（Anthropic → 原始字典 → `invoke_model`）。由于 Bedrock 原生使用 Anthropic Messages API 格式处理 Claude 模型，只需极少转换。保留 `cache_control` 标记和 thinking blocks。
+- **Anthropic 路径**：经 `to_bedrock` → `BedrockRequest` 翻译（`invoke_model`）。由于 Bedrock 原生使用 Anthropic Messages API 格式处理 Claude 模型，**格式**接近原生、转换极少；thinking blocks 保留,但 inline `cache_control` 标记被**丢弃**（`BedrockRequest` 无此字段），改由代理自行注入断点。这是翻译而非字节级直通。
 
 对于非 Anthropic 模型（Nova、DeepSeek、Mistral、Llama 等），两条路径都通过 `converse`/`converse_stream` 使用 Converse API。
 

--- a/docs/prompt-caching.md
+++ b/docs/prompt-caching.md
@@ -225,16 +225,24 @@ assistant.content: [
 
 The proxy searches backward from the end of content for the first non-thinking block and places `cache_control` on it. Although the breakpoint is on the text block, both thinking blocks are still cached as part of the prefix.
 
-### Pre-existing Breakpoints & Budget
+### Inline `cache_control` Markers Are Not Preserved
 
-If the request already contains `cache_control` markers (e.g., set by the client), those count against the budget of 4. Pre-existing markers also have their TTL upgraded to match the server configuration.
+> **Important**: `cache_control` markers placed **inline** by the client — i.e. inside individual `messages`/`system`/`tools` content blocks (the way Claude Code and the Anthropic SDK set breakpoints) — are **dropped during request translation** and do **not** reach Bedrock.
+>
+> Both request paths translate the incoming body into the internal `BedrockRequest` model, whose `BedrockContentPart`, `BedrockTool`, and `system` (a plain string) carry **no** `cache_control` field. The proxy then injects its own breakpoints (see strategy above). The net effect: **the gateway, not the client, controls where breakpoints go** for Anthropic models.
 
-**Example**: Client pre-set 2 breakpoints, server TTL configured as `1h`:
+This means the client's own breakpoint placement (e.g. Claude Code's strategy) has no effect end-to-end. If auto-injection is enabled, the proxy's `tools[-1] → system[-1] → last-assistant` strategy is what actually runs; if disabled, no caching happens at all. To control caching, use the configuration options below — not inline markers.
+
+### Pre-existing Breakpoints & Budget (`bedrock_prompt_caching` only)
+
+There is exactly one way to pass caching configuration through to Bedrock untouched: the dedicated **`bedrock_prompt_caching`** body field (OpenAI path). Its value is merged into the outgoing body verbatim (`body.update(prompt_caching)`), so any `cache_control` it contains survives. **Only** breakpoints supplied this way are detected by `_body_has_cache_control` — inline markers (above) are already gone by this point and are never detected.
+
+When `bedrock_prompt_caching` supplies breakpoints, they count against the budget of 4, have their TTL upgraded to the server configuration, and suppress auto-injection up to the remaining budget:
 
 ```
-On arrival:
-  tools[-1]:  {"cache_control": {"type": "ephemeral"}}          ← client pre-set (5m)
-  system[-1]: {"cache_control": {"type": "ephemeral"}}          ← client pre-set (5m)
+On arrival (via bedrock_prompt_caching):
+  tools[-1]:  {"cache_control": {"type": "ephemeral"}}          ← supplied (5m)
+  system[-1]: {"cache_control": {"type": "ephemeral"}}          ← supplied (5m)
 
 After proxy processing:
   tools[-1]:  {"cache_control": {"type": "ephemeral", "ttl": "1h"}}  ← TTL upgraded
@@ -554,7 +562,7 @@ INFO  Streaming chat completion successful: request_id=chatcmpl-xxx, duration=5.
 | `Prompt cache:` appears but `cache_write=0` | Content below Bedrock's **token** minimum (1024 for Sonnet) | Make the system prompt longer (8000+ chars to safely exceed 1024 tokens) |
 | `cache_write` on first request but no `cache_read` on second | Cache TTL expired or content changed between requests | Send second request within TTL window; ensure content is identical. Consider `KBR_PROMPT_CACHE_TTL=1h` for longer sessions |
 | `cache_write` appears but `cache_read` never does | Model may not support caching, or region limitation | Verify model and region support prompt caching in AWS docs |
-| Neither `cache_write` nor `cache_read` in log | Injection skipped because client sent manual `cache_control` | Check if `bedrock_prompt_caching` is set in request body |
+| Neither `cache_write` nor `cache_read` in log | Auto-injection disabled, or `bedrock_prompt_caching` supplied breakpoints that all missed (inline `cache_control` markers do **not** suppress injection — they are dropped in translation) | Verify `should_inject` in the debug log; if `bedrock_prompt_caching` is set, check its breakpoint positions |
 
 ### Debug Logging
 
@@ -570,7 +578,9 @@ This shows the exact decision chain: per-request override → server default →
 
 ### Interaction with Manual Prompt Caching
 
-If the client already sets `cache_control` markers via `bedrock_prompt_caching` (pass-through), the auto-injection is skipped entirely. This avoids conflicts — the client is assumed to manage caching itself.
+If breakpoints are supplied via the **`bedrock_prompt_caching`** body field (the only pass-through channel — see [Pre-existing Breakpoints & Budget](#pre-existing-breakpoints--budget-bedrock_prompt_caching-only)), auto-injection is suppressed up to the remaining budget, on the assumption that the client is managing caching itself.
+
+Note this does **not** apply to inline `cache_control` markers inside message/system/tool blocks (e.g. those set by Claude Code or the Anthropic SDK): those are stripped during translation, never detected, and therefore never suppress auto-injection.
 
 ### Scope
 

--- a/docs/prompt-caching.zh.md
+++ b/docs/prompt-caching.zh.md
@@ -225,16 +225,24 @@ assistant.content: [
 
 代理从 content 末尾往回找第一个非 thinking block，在其上放置 `cache_control`。虽然断点在 text block 上，但两个 thinking block 作为前缀的一部分仍会被缓存。
 
-### 预存断点与预算
+### inline `cache_control` 标记不会被保留
 
-如果请求中已包含 `cache_control` 标记（如客户端自行设置），这些标记计入 4 个断点预算。已有标记的 TTL 会被升级到服务端配置的值。
+> **重要**：客户端打在 **inline** 位置的 `cache_control` 标记——即放在单个 `messages`/`system`/`tools` 内容块里的断点（Claude Code 和 Anthropic SDK 就是这么打断点的）——会在**请求翻译阶段被丢弃**,**不会**到达 Bedrock。
+>
+> 两条请求路径都会把入站 body 翻译成内部的 `BedrockRequest` 模型,而它的 `BedrockContentPart`、`BedrockTool` 以及 `system`（纯字符串）都**没有** `cache_control` 字段。随后代理注入自己的断点（见上文策略）。净效果:对 Anthropic 模型而言,**断点位置由网关决定,而非客户端**。
 
-**示例**：客户端预设了 2 个断点，服务端 TTL 配置为 `1h`：
+也就是说,客户端自己的断点布局（如 Claude Code 的策略）端到端不起作用。若自动注入开启,真正生效的是代理的 `tools[-1] → system[-1] → 末条 assistant` 策略;若关闭,则完全不缓存。要控制缓存,请用下面的配置项,而非 inline 标记。
+
+### 预存断点与预算（仅 `bedrock_prompt_caching`）
+
+只有一种方式能让缓存配置原样透传给 Bedrock:专用的 **`bedrock_prompt_caching`** body 字段（OpenAI 路径）。它的值会被原样合并进出站 body（`body.update(prompt_caching)`）,所以其中的 `cache_control` 得以保留。**只有**这种方式提供的断点才会被 `_body_has_cache_control` 检测到——inline 标记（见上）此时早已被剥离,永远检测不到。
+
+当 `bedrock_prompt_caching` 提供断点时,它们计入 4 个断点预算、TTL 会被升级到服务端配置值,并在剩余预算内抑制自动注入:
 
 ```
-请求到达时:
-  tools[-1]:  {"cache_control": {"type": "ephemeral"}}          ← 客户端预设 (5m)
-  system[-1]: {"cache_control": {"type": "ephemeral"}}          ← 客户端预设 (5m)
+请求到达时（经 bedrock_prompt_caching）:
+  tools[-1]:  {"cache_control": {"type": "ephemeral"}}          ← 提供 (5m)
+  system[-1]: {"cache_control": {"type": "ephemeral"}}          ← 提供 (5m)
 
 代理处理后:
   tools[-1]:  {"cache_control": {"type": "ephemeral", "ttl": "1h"}}  ← TTL 升级
@@ -554,7 +562,7 @@ INFO  Streaming chat completion successful: request_id=chatcmpl-xxx, duration=5.
 | 出现 `Prompt cache:` 但 `cache_write=0` | 内容低于 Bedrock 的 **token** 最低要求（Sonnet 需 1024） | 加长 system prompt（8000+ 字符以确保超过 1024 tokens） |
 | 首次 `cache_write` 正常但第二次无 `cache_read` | 缓存 TTL 过期或两次请求内容不一致 | 在 TTL 时间内发送第二次请求；确保内容完全相同。可设置 `KBR_PROMPT_CACHE_TTL=1h` 延长缓存 |
 | 有 `cache_write` 但始终无 `cache_read` | 模型或区域可能不支持缓存 | 查阅 AWS 文档确认模型和区域支持 prompt caching |
-| 日志中既无 `cache_write` 也无 `cache_read` | 客户端已手动设置 `cache_control`，自动注入被跳过 | 检查请求体中是否设置了 `bedrock_prompt_caching` |
+| 日志中既无 `cache_write` 也无 `cache_read` | 自动注入被关闭,或 `bedrock_prompt_caching` 提供的断点全部未命中（inline `cache_control` 标记**不会**抑制注入——它们在翻译阶段已被丢弃）| 查看 debug 日志中的 `should_inject`;若设置了 `bedrock_prompt_caching`,检查其断点位置 |
 
 ### Debug 日志
 
@@ -570,7 +578,9 @@ DEBUG  Prompt cache check: auto_cache=None, server_default=True, should_inject=T
 
 ### 与手动缓存配置的交互
 
-如果客户端已通过 `bedrock_prompt_caching`（透传）设置了 `cache_control` 标记，自动注入会被完全跳过，避免冲突 — 此时由客户端自行管理缓存。
+如果断点是通过 **`bedrock_prompt_caching`** body 字段（唯一的透传通道——见[预存断点与预算](#预存断点与预算仅-bedrock_prompt_caching)）提供的,自动注入会在剩余预算内被抑制,假定由客户端自行管理缓存。
+
+注意这**不**适用于消息/system/tools 块里 inline 的 `cache_control` 标记（如 Claude Code 或 Anthropic SDK 设置的那些）:它们在翻译阶段被剥离、从不被检测到,因此永远不会抑制自动注入。
 
 ### 适用范围
 

--- a/docs/request-translation.md
+++ b/docs/request-translation.md
@@ -416,7 +416,7 @@ message_delta  ──▶  output_tokens  (captured near stream end)
 
 **Files**: `backend/app/api/anthropic/endpoints/messages.py`, `backend/app/services/anthropic_translator.py`
 
-When clients use the Anthropic Messages API (`POST /v1/messages` with `x-api-key` header), the translation is minimal because Bedrock's InvokeModel API for Anthropic models natively uses the Messages API format.
+When clients use the Anthropic Messages API (`POST /v1/messages` with `x-api-key` header), the translation is minimal because Bedrock's InvokeModel API for Anthropic models natively uses the Messages API format. Note "near-passthrough" refers to the **format similarity**, not a byte passthrough: the request is still mapped through `to_bedrock` → `BedrockRequest`, so fields the internal model doesn't carry — notably inline `cache_control` markers — are dropped. A `to_bedrock_with_passthrough` helper exists for true passthrough but is **not currently wired into the endpoint**.
 
 ### 7.1 Data Flow
 
@@ -453,7 +453,7 @@ sequenceDiagram
 | `stop_reason` | Mapped to `finish_reason` (`end_turn` → `stop`) | Passed through as-is |
 | Streaming format | `data: {json}\n\n` + `data: [DONE]\n\n` | `event: type\ndata: {json}\n\n` |
 | Error format | `{"error": {"message": "...", "type": "..."}}` | `{"type": "error", "error": {"type": "...", "message": "..."}}` |
-| `cache_control` | Via `bedrock_auto_cache` or `X-Bedrock-Auto-Cache` | Native support (passed through directly) |
+| `cache_control` | Via `bedrock_auto_cache` / `X-Bedrock-Auto-Cache`; inline markers dropped in translation | Same: inline `cache_control` markers are **dropped** by `to_bedrock` (`BedrockRequest` has no such field). The proxy injects its own breakpoints when auto-cache is on. See [Prompt Caching](prompt-caching.md). |
 
 ### 7.3 Thinking Block Pass-through
 

--- a/docs/request-translation.zh.md
+++ b/docs/request-translation.zh.md
@@ -441,7 +441,7 @@ message_delta  ──▶  output_tokens  （在流接近结束时捕获）
 
 **文件**：`backend/app/api/anthropic/endpoints/messages.py`、`backend/app/services/anthropic_translator.py`
 
-当客户端使用 Anthropic Messages API（`POST /v1/messages`，通过 `x-api-key` 请求头认证）时，转换非常少，因为 Bedrock 的 InvokeModel API 对 Anthropic 模型原生使用 Messages API 格式。
+当客户端使用 Anthropic Messages API（`POST /v1/messages`，通过 `x-api-key` 请求头认证）时，转换非常少，因为 Bedrock 的 InvokeModel API 对 Anthropic 模型原生使用 Messages API 格式。注意"近乎直通"指的是**格式相似**,并非字节级直通:请求仍经 `to_bedrock` → `BedrockRequest` 映射,内部模型不携带的字段——尤其是 inline 的 `cache_control` 标记——会被丢弃。另有 `to_bedrock_with_passthrough` 辅助函数可做真正透传,但**当前未接入该端点**。
 
 ### 8.1 数据流
 
@@ -478,7 +478,7 @@ sequenceDiagram
 | `stop_reason` | 映射为 `finish_reason`（`end_turn` → `stop`） | 原样传递 |
 | 流式格式 | `data: {json}\n\n` + `data: [DONE]\n\n` | `event: type\ndata: {json}\n\n` |
 | 错误格式 | `{"error": {"message": "...", "type": "..."}}` | `{"type": "error", "error": {"type": "...", "message": "..."}}` |
-| `cache_control` | 通过 `bedrock_auto_cache` 或 `X-Bedrock-Auto-Cache` | 原生支持（直接传递） |
+| `cache_control` | 通过 `bedrock_auto_cache` / `X-Bedrock-Auto-Cache`；inline 标记在翻译中被丢弃 | 同样:inline `cache_control` 标记会被 `to_bedrock` **丢弃**（`BedrockRequest` 无此字段）。自动注入开启时由代理注入自己的断点。详见 [Prompt Caching](prompt-caching.md)。 |
 
 ### 8.3 Thinking 块透传
 

--- a/frontend/src/layouts/MainLayout.vue
+++ b/frontend/src/layouts/MainLayout.vue
@@ -204,6 +204,13 @@ const allMenuLinks = [
     to: '/activity',
   },
   {
+    title: 'Traces',
+    caption: 'Inspect request/response traces',
+    icon: 'travel_explore',
+    to: '/traces',
+    permission: 'view_usage',
+  },
+  {
     title: 'Admin Users',
     caption: 'Manage admin accounts',
     icon: 'admin_panel_settings',

--- a/frontend/src/pages/TracesPage.vue
+++ b/frontend/src/pages/TracesPage.vue
@@ -1,0 +1,618 @@
+<template>
+  <q-page class="q-pa-md">
+    <!-- Header row -->
+    <div class="row items-center q-mb-md">
+      <div class="text-h4">Traces</div>
+      <q-badge
+        :color="enabled ? 'green-7' : 'red-7'"
+        :label="enabled ? 'Recording ON' : 'Recording OFF'"
+        class="q-ml-md"
+      />
+      <q-space />
+      <q-btn
+        flat
+        dense
+        icon="refresh"
+        label="Refresh"
+        :loading="loading"
+        @click="fetchTraces"
+      />
+      <q-btn
+        flat
+        dense
+        :icon="autoOn ? 'pause' : 'play_arrow'"
+        :label="autoOn ? 'Auto: On' : 'Auto: Off'"
+        :color="autoOn ? 'primary' : undefined"
+        class="q-ml-sm"
+        @click="toggleAuto"
+      />
+      <q-btn
+        flat
+        dense
+        icon="delete_outline"
+        label="Clear"
+        color="negative"
+        class="q-ml-sm"
+        @click="clearTraces"
+      />
+    </div>
+
+    <!-- Filters -->
+    <q-card class="q-mb-md">
+      <q-card-section class="row items-center q-gutter-md">
+        <q-select
+          v-model="filterModel"
+          :options="modelOptions"
+          label="Model"
+          outlined
+          dense
+          dark
+          emit-value
+          map-options
+          style="min-width: 200px"
+        />
+        <q-select
+          v-model="filterToken"
+          :options="tokenOptions"
+          label="API Key"
+          outlined
+          dense
+          dark
+          emit-value
+          map-options
+          style="min-width: 200px"
+        />
+        <q-input
+          v-model="search"
+          label="Search content"
+          outlined
+          dense
+          dark
+          clearable
+          debounce="300"
+          style="min-width: 220px"
+        >
+          <template v-slot:prepend>
+            <q-icon name="search" />
+          </template>
+        </q-input>
+        <q-space />
+        <div class="text-grey-5">{{ filtered.length }} / {{ allTraces.length }} traces</div>
+      </q-card-section>
+    </q-card>
+
+
+    <!-- Error banner -->
+    <q-banner v-if="error" class="bg-red-9 text-white q-mb-md" rounded dense>
+      {{ error }}
+    </q-banner>
+
+    <!-- Timeline -->
+    <div v-if="!filtered.length" class="text-center text-grey-6 q-pa-xl">
+      No traces yet. Waiting for requests...
+    </div>
+
+    <q-list v-else bordered separator class="trace-list">
+      <q-expansion-item
+        v-for="t in filtered"
+        :key="t.request_id"
+        group="traces"
+        dense
+      >
+        <!-- Trace header -->
+        <template v-slot:header>
+          <q-item-section avatar class="trace-avatar">
+            <q-badge color="blue-9" :label="t.model" class="model-badge" />
+          </q-item-section>
+          <q-item-section>
+            <div class="row items-center q-gutter-xs">
+              <q-badge v-if="t.stream" color="orange-9" label="stream" />
+              <q-badge :color="stopColor(t.stop_reason)" :label="t.stop_reason || '?'" />
+              <span class="text-caption text-grey-5">{{ t.token_name }}</span>
+              <span class="text-caption text-grey-7">{{ fmtTime(t.timestamp) }}</span>
+              <span class="text-caption text-grey-6">{{ t.duration_s }}s</span>
+            </div>
+          </q-item-section>
+          <q-item-section side>
+            <div class="row items-center q-gutter-sm token-stats">
+              <span class="text-grey-5">in:{{ fmt(t.input_tokens) }}</span>
+              <span class="text-grey-5">out:{{ fmt(t.output_tokens) }}</span>
+              <span v-if="t.cache_read_input_tokens" class="text-green-5"
+                >⚡{{ fmt(t.cache_read_input_tokens) }}</span
+              >
+              <span v-if="t.cache_creation_input_tokens" class="text-orange-5"
+                >✎{{ fmt(t.cache_creation_input_tokens) }}</span
+              >
+            </div>
+          </q-item-section>
+        </template>
+
+        <!-- Trace body -->
+        <q-card>
+          <q-card-section style="max-height: 80vh; overflow-y: auto">
+            <!-- Usage grid -->
+            <div class="usage-grid q-mb-md">
+              <div class="usage-item">
+                <span class="k">Input</span><span class="v">{{ fmt(t.input_tokens) }}</span>
+              </div>
+              <div class="usage-item">
+                <span class="k">Output</span><span class="v">{{ fmt(t.output_tokens) }}</span>
+              </div>
+              <div class="usage-item">
+                <span class="k">Cache Read</span
+                ><span class="v text-green-5">{{ fmt(t.cache_read_input_tokens) }}</span>
+              </div>
+              <div class="usage-item">
+                <span class="k">Cache Write</span
+                ><span class="v text-orange-5">{{ fmt(t.cache_creation_input_tokens) }}</span>
+              </div>
+              <div class="usage-item">
+                <span class="k">Duration</span><span class="v">{{ t.duration_s }}s</span>
+              </div>
+              <div class="usage-item">
+                <span class="k">Request ID</span><span class="v mono">{{ t.request_id }}</span>
+              </div>
+            </div>
+
+            <!-- System prompt -->
+            <q-expansion-item
+              v-if="systemText(t)"
+              label="System Prompt"
+              header-class="section-header"
+              dense
+            >
+              <div class="block-text system-block">{{ systemText(t) }}</div>
+            </q-expansion-item>
+
+            <!-- Tools -->
+            <q-expansion-item
+              v-if="t.tools && t.tools.length"
+              :label="`Tools (${t.tools.length})`"
+              header-class="section-header"
+              dense
+            >
+              <div class="tools-scroll">
+                <div v-for="(tool, i) in t.tools" :key="i" class="tool-def">
+                  <div class="tool-name">{{ tool.name }}</div>
+                  <div v-if="tool.description" class="tool-desc">
+                    {{ String(tool.description).slice(0, 200) }}
+                  </div>
+                  <pre class="tool-schema">{{ schemaPreview(tool.input_schema) }}</pre>
+                </div>
+              </div>
+            </q-expansion-item>
+
+            <!-- Messages -->
+            <q-expansion-item
+              v-if="t.messages && t.messages.length"
+              :label="`Messages (${t.messages.length})`"
+              header-class="section-header"
+              default-opened
+              dense
+            >
+              <div class="section-scroll">
+                <div v-for="(m, i) in t.messages" :key="i" class="msg" :class="m.role">
+                  <div class="role-tag" :class="m.role">{{ m.role }}</div>
+                  <template v-if="typeof m.content === 'string'">
+                    <div class="block-text">{{ m.content }}</div>
+                  </template>
+                  <template v-else>
+                    <div
+                      v-for="(b, j) in m.content"
+                      :key="j"
+                      v-html="renderBlock(b)"
+                      class="block-wrap"
+                    ></div>
+                  </template>
+                </div>
+              </div>
+            </q-expansion-item>
+
+            <!-- Response -->
+            <q-expansion-item
+              v-if="t.response_content && t.response_content.length"
+              label="Response"
+              header-class="section-header"
+              default-opened
+              dense
+            >
+              <div class="section-scroll">
+                <div
+                  v-for="(b, i) in t.response_content"
+                  :key="i"
+                  v-html="renderBlock(b)"
+                  class="block-wrap"
+                ></div>
+              </div>
+            </q-expansion-item>
+
+            <!-- Error -->
+            <div v-if="t.error" class="block-text error-block q-mt-sm">{{ t.error }}</div>
+          </q-card-section>
+        </q-card>
+      </q-expansion-item>
+    </q-list>
+  </q-page>
+</template>
+
+<script setup lang="ts">
+import { ref, computed, onMounted, onUnmounted } from 'vue';
+import { api } from 'src/boot/axios';
+import { Dialog, Notify } from 'quasar';
+
+interface ContentBlock {
+  type?: string;
+  text?: string;
+  thinking?: string;
+  name?: string;
+  id?: string;
+  input?: unknown;
+  content?: unknown;
+  is_error?: boolean;
+  source?: { media_type?: string };
+}
+
+interface Trace {
+  request_id: string;
+  timestamp: number;
+  model: string;
+  token_id: string;
+  token_name: string;
+  system?: string | { text?: string }[] | null;
+  messages?: { role: string; content: string | ContentBlock[] }[];
+  tools?: { name?: string; description?: string; input_schema?: unknown }[];
+  response_content?: ContentBlock[];
+  stream?: boolean;
+  stop_reason?: string;
+  duration_s?: number;
+  input_tokens?: number;
+  output_tokens?: number;
+  cache_read_input_tokens?: number;
+  cache_creation_input_tokens?: number;
+  error?: string | null;
+}
+
+const allTraces = ref<Trace[]>([]);
+const enabled = ref(false);
+const loading = ref(false);
+const error = ref('');
+
+const filterModel = ref('all');
+const filterToken = ref('all');
+const search = ref('');
+
+let autoInterval: ReturnType<typeof setInterval> | null = null;
+const autoOn = ref(false);
+
+const modelOptions = computed(() => {
+  const set = new Set(allTraces.value.map((t) => t.model));
+  return [{ label: 'All', value: 'all' }, ...[...set].map((m) => ({ label: m, value: m }))];
+});
+
+const tokenOptions = computed(() => {
+  const map = new Map<string, string>();
+  allTraces.value.forEach((t) => {
+    if (t.token_name) map.set(t.token_id, t.token_name);
+  });
+  return [
+    { label: 'All', value: 'all' },
+    ...[...map].map(([id, name]) => ({ label: name, value: id })),
+  ];
+});
+
+const filtered = computed(() => {
+  let list = allTraces.value;
+  if (filterModel.value !== 'all') list = list.filter((t) => t.model === filterModel.value);
+  if (filterToken.value !== 'all') list = list.filter((t) => t.token_id === filterToken.value);
+  if (search.value) {
+    const q = search.value.toLowerCase();
+    list = list.filter((t) => JSON.stringify(t).toLowerCase().includes(q));
+  }
+  return list;
+});
+
+
+async function fetchTraces() {
+  loading.value = true;
+  try {
+    const { data } = await api.get('/admin/traces/');
+    enabled.value = data.enabled;
+    allTraces.value = data.traces || [];
+    error.value = '';
+  } catch (e) {
+    error.value = e instanceof Error ? e.message : 'Failed to load traces';
+  } finally {
+    loading.value = false;
+  }
+}
+
+function clearTraces() {
+  Dialog.create({
+    title: 'Clear Traces',
+    message: 'Clear all stored traces? This cannot be undone.',
+    cancel: true,
+    dark: true,
+  }).onOk(() => {
+    void (async () => {
+      try {
+        await api.delete('/admin/traces/');
+        await fetchTraces();
+        Notify.create({ type: 'positive', message: 'Traces cleared', position: 'top' });
+      } catch (e) {
+        Notify.create({
+          type: 'negative',
+          message: e instanceof Error ? e.message : 'Failed to clear',
+          position: 'top',
+        });
+      }
+    })();
+  });
+}
+
+function toggleAuto() {
+  autoOn.value = !autoOn.value;
+  if (autoOn.value) {
+    autoInterval = setInterval(() => void fetchTraces(), 3000);
+  } else if (autoInterval) {
+    clearInterval(autoInterval);
+    autoInterval = null;
+  }
+}
+
+// --- formatting helpers ---
+function fmt(n?: number): string {
+  const v = n || 0;
+  if (v >= 1_000_000) return `${(v / 1_000_000).toFixed(1)}M`;
+  if (v >= 1000) return `${(v / 1000).toFixed(1)}k`;
+  return String(v);
+}
+
+function fmtTime(ts: number): string {
+  return new Date(ts * 1000).toLocaleTimeString('en-US', {
+    hour12: false,
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit',
+  });
+}
+
+function stopColor(reason?: string): string {
+  if (reason === 'end_turn') return 'green-8';
+  if (reason === 'tool_use') return 'orange-9';
+  if (reason === 'max_tokens') return 'red-8';
+  return 'grey-8';
+}
+
+function systemText(t: Trace): string {
+  if (!t.system) return '';
+  if (typeof t.system === 'string') return t.system;
+  return t.system.map((b) => b.text || '').join('\n');
+}
+
+function schemaPreview(schema: unknown): string {
+  return JSON.stringify(schema, null, 2).slice(0, 500);
+}
+
+function esc(s: string | number | null | undefined): string {
+  return String(s ?? '')
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;');
+}
+
+function renderBlock(b: ContentBlock): string {
+  if (!b) return '';
+  const type = b.type || 'text';
+  if (type === 'text') return `<div class="block-text">${esc(b.text)}</div>`;
+  if (type === 'thinking') return `<div class="block-text thinking-block">${esc(b.thinking)}</div>`;
+  if (type === 'tool_use') {
+    const inputStr =
+      typeof b.input === 'string' ? b.input : JSON.stringify(b.input || {}, null, 2);
+    return `<div class="block-text tool-use-block"><span class="tool-name">${esc(
+      b.name,
+    )}</span> <span class="tool-id">${esc(b.id)}</span><div class="tool-input">${esc(
+      inputStr,
+    )}</div></div>`;
+  }
+  if (type === 'tool_result') {
+    const content =
+      typeof b.content === 'string' ? b.content : JSON.stringify(b.content || '', null, 2);
+    return `<div class="block-text tool-result-block${
+      b.is_error ? ' error-block' : ''
+    }">${esc(content)}</div>`;
+  }
+  if (type === 'image') return `<div class="block-text">[image: ${esc(b.source?.media_type)}]</div>`;
+  if (type === 'redacted_thinking')
+    return `<div class="block-text thinking-block">[redacted thinking]</div>`;
+  return `<div class="block-text">${esc(JSON.stringify(b))}</div>`;
+}
+
+onMounted(() => {
+  void fetchTraces();
+});
+
+onUnmounted(() => {
+  if (autoInterval) clearInterval(autoInterval);
+});
+</script>
+
+<style scoped lang="scss">
+.trace-list {
+  border-radius: 12px;
+  overflow: hidden;
+}
+
+.trace-avatar {
+  min-width: auto;
+  padding-right: 12px;
+}
+
+.model-badge {
+  font-family: 'SF Mono', Menlo, monospace;
+}
+
+.token-stats {
+  font-size: 12px;
+  font-family: 'SF Mono', Menlo, monospace;
+}
+
+.usage-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 8px;
+}
+
+.usage-item {
+  display: flex;
+  justify-content: space-between;
+  background: rgba(255, 255, 255, 0.04);
+  padding: 6px 10px;
+  border-radius: 6px;
+  font-size: 12px;
+
+  .k {
+    color: #9aa0a6;
+  }
+  .v {
+    color: #e8eaed;
+    font-weight: 500;
+  }
+  .v.mono {
+    font-family: 'SF Mono', Menlo, monospace;
+    font-size: 11px;
+  }
+}
+
+.msg {
+  margin: 6px 0;
+  padding: 8px 10px;
+  border-radius: 6px;
+
+  &.system {
+    border-left: 3px solid #7c3aed;
+  }
+  &.user {
+    border-left: 3px solid #58a6ff;
+  }
+  &.assistant {
+    border-left: 3px solid #d2a8ff;
+  }
+}
+
+.role-tag {
+  font-size: 10px;
+  font-weight: 600;
+  text-transform: uppercase;
+  margin-bottom: 4px;
+
+  &.system {
+    color: #a78bfa;
+  }
+  &.user {
+    color: #79c0ff;
+  }
+  &.assistant {
+    color: #d2a8ff;
+  }
+}
+
+:deep(.block-text),
+.block-text {
+  white-space: pre-wrap;
+  word-break: break-word;
+  font-family: 'SF Mono', Menlo, monospace;
+  font-size: 12px;
+  padding: 6px 8px;
+  border-radius: 4px;
+  margin: 4px 0;
+  color: #c9d1d9;
+  background: rgba(0, 0, 0, 0.25);
+}
+
+:deep(.thinking-block) {
+  color: #a78bfa;
+  max-height: 220px;
+  overflow-y: auto;
+}
+
+:deep(.tool-use-block) {
+  border-left: 2px solid #d29922;
+}
+
+:deep(.tool-result-block) {
+  border-left: 2px solid #3fb950;
+  max-height: 220px;
+  overflow-y: auto;
+}
+
+:deep(.error-block),
+.error-block {
+  border-left: 2px solid #f85149;
+  color: #ff7b72;
+}
+
+:deep(.tool-name) {
+  color: #d29922;
+  font-weight: 600;
+}
+
+:deep(.tool-id) {
+  color: #6e7681;
+  font-size: 10px;
+}
+
+:deep(.tool-input) {
+  margin-top: 4px;
+}
+
+.system-block {
+  max-height: 300px;
+  overflow-y: auto;
+}
+
+.tools-scroll {
+  max-height: 400px;
+  overflow-y: auto;
+}
+
+.section-scroll {
+  max-height: 600px;
+  overflow-y: auto;
+}
+
+.tool-def {
+  background: rgba(255, 255, 255, 0.04);
+  border-radius: 6px;
+  padding: 8px 10px;
+  margin: 6px 0;
+
+  .tool-name {
+    color: #58a6ff;
+    font-weight: 600;
+    font-size: 13px;
+  }
+  .tool-desc {
+    color: #9aa0a6;
+    font-size: 12px;
+    margin: 4px 0;
+  }
+  .tool-schema {
+    font-family: 'SF Mono', Menlo, monospace;
+    font-size: 11px;
+    color: #8b949e;
+    white-space: pre-wrap;
+    word-break: break-word;
+    margin: 0;
+    max-height: 300px;
+    overflow-y: auto;
+  }
+}
+
+:deep(.section-header) {
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  color: #9aa0a6;
+  letter-spacing: 0.5px;
+}
+</style>

--- a/frontend/src/router/routes.ts
+++ b/frontend/src/router/routes.ts
@@ -60,6 +60,11 @@ const routes: RouteRecordRaw[] = [
         component: () => import('pages/ActivityPage.vue'),
       },
       {
+        path: 'traces',
+        name: 'traces',
+        component: () => import('pages/TracesPage.vue'),
+      },
+      {
         path: 'admin-users',
         name: 'admin-users',
         component: () => import('pages/AdminUsersPage.vue'),


### PR DESCRIPTION
## Summary
- 新增 Trace Viewer：内存环形缓冲区存储最近 200 条请求/响应，管理后台可查看完整 trace（system prompt、messages、tools、response）
- 修复 Fable 5/Mythos 5 调用报错：白名单方式管理支持 sampling 的模型，4.6 之后的新模型自动剥离 temperature/top_p/top_k
- 修复 GPT-5.5 temperature not supported 报错：提取 `_is_reasoning_model` 谓词，统一处理推理模型不支持的参数
- 修复 `@classmethod` + `@staticmethod` 堆叠 bug
- 优化流式 trace 累积：使用 chunk list + join 替代 O(n²) 字符串拼接

## Test plan
- [ ] 验证 Fable 5 调用正常（data retention 已设置为 provider_data_share）
- [ ] 验证 GPT-5.5 调用不再报 temperature 错误
- [ ] 验证 Claude 4.6 及更早模型 temperature 正常传递
- [ ] 验证 /admin/traces 页面可查看、搜索、清除 trace
- [ ] 验证流式响应 trace 内容完整（thinking、tool_use、text）