### PR TITLE
fix: support standard reasoning_effort field on /v1/chat/completions

### DIFF
--- a/backend/app/services/mantle_client.py
+++ b/backend/app/services/mantle_client.py
@@ -291,12 +291,15 @@ def _openai_to_responses(payload: Dict[str, Any]) -> Dict[str, Any]:
     if text_format is not None:
         body["text"] = {"format": text_format}
 
-    # reasoning.effort rides the existing bedrock_additional_model_request_fields
-    # passthrough channel so no new request schema field is needed.
-    extra = payload.get("bedrock_additional_model_request_fields") or {}
-    reasoning = extra.get("reasoning")
-    if isinstance(reasoning, dict) and reasoning.get("effort"):
-        body["reasoning"] = {"effort": reasoning["effort"]}
+    # reasoning_effort: standard OpenAI field, or via bedrock_additional_model_request_fields
+    effort = payload.get("reasoning_effort")
+    if not effort:
+        extra = payload.get("bedrock_additional_model_request_fields") or {}
+        reasoning = extra.get("reasoning")
+        if isinstance(reasoning, dict):
+            effort = reasoning.get("effort")
+    if effort:
+        body["reasoning"] = {"effort": effort}
 
     return body
 


### PR DESCRIPTION
## Summary
- `/v1/chat/completions` 现在支持 OpenAI 标准的 `reasoning_effort` 顶层字段（`low`/`medium`/`high`）
- 兼容原有的 `bedrock_additional_model_request_fields.reasoning.effort` 写法，标准字段优先
- OpenAI SDK 客户端无需使用 KBP 私有字段即可控制 GPT-5.5 推理深度

## Test plan
- [x] `reasoning_effort: "high"` 正常返回
- [x] `reasoning_effort: "low"` 正常返回，token 消耗有差异
- [x] 带 `temperature` 的请求不再 400（`_is_reasoning_model` 自动剥离）
- [x] 旧写法 `bedrock_additional_model_request_fields.reasoning.effort` 仍有效