### PR TITLE
fix: Sonnet 5 pricing missing + usage_records performance indexes

### DIFF
--- a/backend/alembic/versions/w4x5y6z7a8b9_add_usage_records_perf_indexes.py
+++ b/backend/alembic/versions/w4x5y6z7a8b9_add_usage_records_perf_indexes.py
@@ -1,0 +1,41 @@
+"""add performance indexes for usage_records
+
+Revision ID: w4x5y6z7a8b9
+Revises: v3w4x5y6z7a8
+Create Date: 2026-07-04
+
+"""
+
+from alembic import op
+
+revision = "w4x5y6z7a8b9"
+down_revision = "v3w4x5y6z7a8"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # Use CONCURRENTLY to avoid locking the table during index creation.
+    # Requires autocommit — disable the migration transaction wrapper.
+    op.execute("COMMIT")
+    op.execute(
+        "CREATE INDEX CONCURRENTLY IF NOT EXISTS "
+        "ix_usage_records_record_type_created_at "
+        "ON usage_records (record_type, created_at)"
+    )
+    op.execute(
+        "CREATE INDEX CONCURRENTLY IF NOT EXISTS "
+        "ix_usage_records_model_created_at "
+        "ON usage_records (model, created_at)"
+    )
+    op.execute(
+        "CREATE INDEX CONCURRENTLY IF NOT EXISTS "
+        "ix_usage_records_token_model_created_at "
+        "ON usage_records (token_id, model, created_at)"
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_usage_records_token_model_created_at", "usage_records")
+    op.drop_index("ix_usage_records_model_created_at", "usage_records")
+    op.drop_index("ix_usage_records_record_type_created_at", "usage_records")

--- a/backend/app/models/usage.py
+++ b/backend/app/models/usage.py
@@ -27,6 +27,11 @@ class UsageRecord(Base):
     __table_args__ = (
         Index("ix_usage_records_user_id_created_at", "user_id", "created_at"),
         Index("ix_usage_records_token_id_created_at", "token_id", "created_at"),
+        Index("ix_usage_records_record_type_created_at", "record_type", "created_at"),
+        Index("ix_usage_records_model_created_at", "model", "created_at"),
+        Index(
+            "ix_usage_records_token_model_created_at", "token_id", "model", "created_at"
+        ),
     )
 
     id = Column(PostgresUUID(as_uuid=True), primary_key=True, default=uuid4)

--- a/backend/app/services/pricing_updater.py
+++ b/backend/app/services/pricing_updater.py
@@ -715,7 +715,7 @@ class PricingUpdater:
                 prefix = ""
 
             for match in row_pattern.finditer(markup):
-                model_name = match.group(1).strip()
+                model_name = match.group(1).strip().rstrip("*").strip()
                 input_ref = match.group(2)
                 output_ref = match.group(3)
 
@@ -1032,7 +1032,13 @@ class PricingUpdater:
         #    "Claude 3 Haiku (200K)"), or for cross-region prefix variants.
         model_mapping = {
             # ── Anthropic Claude ──────────────────────────────────
+            # Claude 5.x
+            "Claude Sonnet 5": "anthropic.claude-sonnet-5-v1",
+            "Claude Fable 5": "anthropic.claude-fable-5-v1",
+            "Claude Mythos 5": "anthropic.claude-mythos-5-v1",
             # Claude 4.x
+            "Claude Opus 4.8": "anthropic.claude-opus-4-8-v1",
+            "Claude Opus 4.7": "anthropic.claude-opus-4-7-v1",
             "Claude Opus 4.6": "anthropic.claude-opus-4-6-v1",
             "Claude Sonnet 4.6": "anthropic.claude-sonnet-4-6",
             "Claude Haiku 4.5": "anthropic.claude-haiku-4-5-20251001-v1:0",


### PR DESCRIPTION
## Summary
- AWS pricing page上新模型名字带尾部星号（如 `Claude Sonnet 5*`），导致 scraper 无法匹配映射表，价格不入库
- monitor 页面加载慢，usage_records 表缺少针对常用查询模式的复合索引

## Changes
- Scraper 解析时 strip 尾部 `*`，确保新模型名字能正确匹配
- 静态映射表补充 Sonnet 5、Fable 5、Mythos 5、Opus 4.7、Opus 4.8
- 新增 3 个复合索引（CONCURRENTLY 不锁表）：
  - `(record_type, created_at)` — 覆盖所有查询的基础过滤
  - `(model, created_at)` — by-model 聚合
  - `(token_id, model, created_at)` — breakdown 查询

## Test plan
- [ ] 部署后触发 pricing refresh，确认 Sonnet 5 价格出现
- [ ] 运行 `alembic upgrade head`，确认索引创建成功
- [ ] Monitor 页面加载速度改善