### PR TITLE
fix: enable 1h prompt cache TTL for active Claude models + correct billing

### DIFF
--- a/backend/app/services/bedrock.py
+++ b/backend/app/services/bedrock.py
@@ -828,30 +828,42 @@ class BedrockClient:
 
     # ------------------------------------------------------------------
 
-    # Models that support the extended 1-hour cache TTL.
-    # Only Claude 4.5 family models support ``ttl`` in ``cache_control``;
-    # older/newer families (Claude 4, etc.) reject it with
+    # Legacy Claude families that do NOT support the extended 1-hour cache TTL
+    # (the ``ttl`` field in ``cache_control``) and reject it with
     # ``Extra inputs are not permitted``.
-    _EXTENDED_TTL_MODEL_PATTERNS = (
-        "claude-opus-4-5",
-        "claude-sonnet-4-5",
-        "claude-haiku-4-5",
+    #
+    # Per Anthropic's prompt caching docs, the 1h cache duration is available on
+    # Amazon Bedrock for all *active* Claude models (Opus 4.5/4.6/4.7/4.8,
+    # Sonnet 4.5/4.6/5, Haiku 4.5, Fable 5, Mythos 5, ...). We therefore default
+    # to *supported* and only exclude the pre-extended-TTL legacy families
+    # below. This denylist replaces a former allowlist that went stale and
+    # silently down-graded newer models (e.g. Opus 4.8) to a 5m cache.
+    # https://platform.claude.com/docs/en/docs/build-with-claude/prompt-caching
+    _NO_EXTENDED_TTL_PATTERNS = (
+        "claude-3",  # Claude 3 / 3.5 / 3.7
+        "claude-v2",
+        "claude-instant",
     )
 
     @classmethod
     def _model_supports_cache_ttl(cls, model_id: str | None) -> bool:
-        """Check if a model supports the extended ``ttl`` field in cache_control."""
-        if not model_id:
+        """Check if a model supports the extended ``ttl`` field in cache_control.
+
+        Returns True for all active Anthropic models and False for non-Anthropic
+        models and the legacy Claude families that predate extended TTL.
+        """
+        if not model_id or not cls.is_anthropic_model(model_id):
             return False
-        return any(pat in model_id for pat in cls._EXTENDED_TTL_MODEL_PATTERNS)
+        return not any(pat in model_id for pat in cls._NO_EXTENDED_TTL_PATTERNS)
 
     @staticmethod
     def _new_cache_marker(ttl: str | None = None, model_id: str | None = None) -> dict:
         """Create a cache_control marker with configured TTL.
 
-        The ``ttl`` field is only supported by Claude 4.5 family models.
-        For unsupported models the field must be omitted, otherwise Bedrock
-        returns ``Extra inputs are not permitted``.
+        The ``ttl`` field is supported by all active Claude models (see
+        ``_model_supports_cache_ttl``). For legacy/non-Claude models the field
+        must be omitted, otherwise Bedrock returns
+        ``Extra inputs are not permitted``.
         """
         cache_ttl = ttl or get_settings().PROMPT_CACHE_TTL
         marker: dict = {"type": "ephemeral"}

--- a/backend/app/services/pricing.py
+++ b/backend/app/services/pricing.py
@@ -91,9 +91,25 @@ class ModelPricing:
                 # the model runs — matches the routing in bedrock.py.
                 _, region = BedrockClient.get_instance().resolve_model(model)
 
-        # Determine cache write multiplier (Bedrock only)
+        # Determine cache write multiplier (Bedrock only).
+        #
+        # The extended 1h TTL (2.0x write price) is only actually applied at
+        # Bedrock for models that support the ``ttl`` field in cache_control.
+        # For legacy/unsupported models the proxy strips the ttl and Bedrock
+        # writes a 5m cache billed at 1.25x — see
+        # ``BedrockClient._model_supports_cache_ttl`` /
+        # ``_inject_cache_control``. Gate the billing multiplier on the SAME
+        # predicate so the cost we record always matches what AWS charges;
+        # otherwise a 1h cache_ttl on an unsupported model over-bills the 0.75x
+        # difference on every cache-write token.
+        effective_write_ttl = cache_ttl or "5m"
+        if effective_write_ttl != "5m":
+            from app.services.bedrock import BedrockClient
+
+            if not BedrockClient._model_supports_cache_ttl(model):
+                effective_write_ttl = "5m"
         write_multiplier = self.CACHE_WRITE_MULTIPLIER.get(
-            cache_ttl or "5m", Decimal("1.25")
+            effective_write_ttl, self.CACHE_WRITE_MULTIPLIER["5m"]
         )
 
         # Try to get pricing from database

--- a/backend/tests/test_pricing.py
+++ b/backend/tests/test_pricing.py
@@ -686,3 +686,75 @@ class TestPricingIntegration:
         )
         # Expected: (1000 * 0.000003) + (500 * 0.000015) = 0.003 + 0.0075 = 0.0105
         assert cost == Decimal("0.0105")
+
+
+class TestCacheWriteMultiplier:
+    """Cache-write multiplier must match the TTL actually applied at Bedrock.
+
+    Per Anthropic's docs the extended 1h TTL (2.0x write) is supported by all
+    active Claude models on Bedrock, so a 1h cache_ttl bills 2.0x for them.
+    Legacy Claude families (Claude 3.x and older) do not support the ``ttl``
+    field: the proxy strips it and Bedrock writes a 5m cache billed at 1.25x,
+    so billing must fall back to 1.25x for them. Billing is gated on the same
+    predicate the request pipeline uses (``_model_supports_cache_ttl``),
+    otherwise a 1h cache_ttl on an unsupported model over-bills the 0.75x
+    difference on every cache-write token (see the hotspot over-billing
+    incident that stemmed from a stale model allowlist).
+    """
+
+    INPUT_PRICE = Decimal("0.000005")
+
+    async def _seed(self, db_session, model_id):
+        updater = PricingUpdater(db_session)
+        await updater._save_pricing_data(
+            [
+                {
+                    "model_id": model_id,
+                    "region": "us-west-2",
+                    "input_price_per_token": self.INPUT_PRICE,
+                    "output_price_per_token": Decimal("0.000025"),
+                }
+            ],
+            "api",
+        )
+
+    async def _write_multiplier(self, db_session, model_id, cache_ttl):
+        """Return the effective cache-write multiplier calculate_cost applied."""
+        cw = 100_000
+        cost = await PricingService(db_session).calculate_cost(
+            model=model_id,
+            prompt_tokens=0,
+            completion_tokens=0,
+            cache_creation_input_tokens=cw,
+            cache_read_input_tokens=0,
+            cache_ttl=cache_ttl,
+            region="us-west-2",
+        )
+        return cost / (Decimal(cw) * self.INPUT_PRICE)
+
+    @pytest.mark.asyncio
+    async def test_legacy_model_1h_billed_as_5m(self, db_session):
+        # Claude 3.x does NOT support the 1h ttl field -> must bill 1.25x
+        model = "anthropic.claude-3-5-sonnet-20241022-v2:0"
+        await self._seed(db_session, model)
+        for ttl in ("1h", "5m", None):
+            mult = await self._write_multiplier(db_session, model, ttl)
+            assert mult == Decimal("1.25"), f"ttl={ttl} should bill 1.25x, got {mult}"
+
+    @pytest.mark.asyncio
+    async def test_active_models_honor_1h_ttl(self, db_session):
+        # All active Claude models (incl. Opus 4.8) support 1h -> 1h bills 2.0x,
+        # 5m bills 1.25x. Opus 4.8 is the model behind the hotspot incident.
+        for model in (
+            "global.anthropic.claude-opus-4-8",
+            "global.anthropic.claude-opus-4-5-20251101-v1:0",
+            "global.anthropic.claude-sonnet-4-6",
+            "global.anthropic.claude-fable-5",
+        ):
+            await self._seed(db_session, model)
+            assert await self._write_multiplier(db_session, model, "1h") == Decimal(
+                "2.0"
+            ), f"{model} 1h should bill 2.0x"
+            assert await self._write_multiplier(db_session, model, "5m") == Decimal(
+                "1.25"
+            ), f"{model} 5m should bill 1.25x"

--- a/backend/tests/test_prompt_cache_injection.py
+++ b/backend/tests/test_prompt_cache_injection.py
@@ -22,7 +22,9 @@ MARKER_TTL = {"type": "ephemeral", "ttl": "1h"}
 MARKER = {"type": "ephemeral"}
 
 TTL_MODEL = "us.anthropic.claude-sonnet-4-5-20250929-v1:0"  # Claude 4.5 supports ttl
-NO_TTL_MODEL = "us.anthropic.claude-sonnet-4-20250514-v1:0"  # Claude 4 does not
+# Legacy Claude 3.x predates the extended 1h TTL — see the denylist in
+# BedrockClient._model_supports_cache_ttl. (Claude 4 / 4.x DO support it.)
+NO_TTL_MODEL = "us.anthropic.claude-3-5-sonnet-20241022-v2:0"
 
 LONG_TEXT = "x" * 5000
 
@@ -214,7 +216,7 @@ def test_ttl_1h_has_ttl_field_supported_model():
 
 
 def test_ttl_1h_no_ttl_field_unsupported_model():
-    """With TTL=1h on Claude 4 model, marker should NOT include ttl field."""
+    """With TTL=1h on legacy Claude 3.x model, marker should NOT include ttl field."""
     body = {"system": "prompt", "messages": []}
     _inject(body, ttl="1h", model_id=NO_TTL_MODEL)
     assert "ttl" not in body["system"][0]["cache_control"]


### PR DESCRIPTION
## 背景

排查一个 API key(hotspot)的计费异常时发现:同一个 token 明明设了 5 分钟 prompt cache,却有大量 cache-write 按 **1 小时费率(2.0x)** 计费。

## 根因

`bedrock.py` 里用一份 **过时的 allowlist**(`_EXTENDED_TTL_MODEL_PATTERNS`,只匹配 Claude 4.5 家族)判断模型是否支持扩展 1h TTL。较新的模型(Opus 4.8/4.7/4.6、Sonnet 4.6、Fable 5…)全部落在名单外,导致:

1. **功能**:请求里的 `ttl:"1h"` 被 strip 掉,静默降级为 5m 缓存 —— 用户设的 1h 从没生效。
2. **计费**:计费侧仍按 1h 的 2.0x 写入倍率记账,而 AWS 实收 1.25x → 每个 cache-write token 多记 0.75x。

## 影响量化(线上 usage_records)

按当前定价重算,受影响记录 **10721 条,累计多记账约 \$486.80**,全部来自这一 bug(方向为多记,非少记)。

## 修复

依据 [Anthropic prompt caching 文档](https://platform.claude.com/docs/en/docs/build-with-claude/prompt-caching)——1h TTL 在 Bedrock 上对**所有在售 Claude 模型**可用——把 allowlist 改为 **denylist**(仅排除 legacy 家族 Claude 3.x / v2 / instant):

- **`bedrock.py`**:`_model_supports_cache_ttl` 改为基于共享的 `is_anthropic_model` 判断,默认支持,只排除 legacy。denylist 可防止将来新模型再次因名单过时被漏掉。
- **`pricing.py`**:`calculate_cost` 对不支持 ttl 字段的模型将写入倍率回退到 5m(1.25x),复用同一个 `_model_supports_cache_ttl` 谓词,使记账口径与实际发送给 Bedrock 的口径一致。
- **`test_pricing.py`**:新增 `TestCacheWriteMultiplier`,锁定在售模型(含 Opus 4.8)1h→2.0x、legacy 1h→回退 1.25x。

## 修复后行为(opus-4.8)

| 前端设置 | Bedrock 实际 | AWS 收费 | proxy 计费 |
|---|---|---|---|
| 1h | 真 1 小时缓存 ✅ | 2.0x | 2.0x ✅ |
| 5m | 5 分钟缓存 | 1.25x | 1.25x ✅ |

## 测试

- `pre-commit run --all-files` 全部通过。
- `TestCacheWriteMultiplier` + 定价集成测试通过;谓词对 11 个模型 ID(含 geo 前缀、legacy、非 Anthropic)判断全部正确。
- 既有失败的 4 个 pricing 测试为 pre-existing(AWS 实时定价抓取类),与本改动无关。

## 遗留待办(不在本 PR)

- **历史数据回溯**:约 \$486.80 多记账 + 相关配额修正,需单独评估。
- **Altitude 改进**:effective TTL 目前在请求路径与计费路径分别用 `_model_supports_cache_ttl` 各判一次(且作用在不同的 model 字符串上),建议后续把生效 TTL 计算一次并透传,避免潜在分歧。