### PR TITLE
fix: 流式用量在异常/断连时仍记账,价格缺失时降级记录而非丢弃

### DIFF
--- a/backend/app/api/anthropic/endpoints/messages.py
+++ b/backend/app/api/anthropic/endpoints/messages.py
@@ -6,6 +6,7 @@ import json
 import logging
 import time
 import uuid
+from decimal import Decimal
 from typing import AsyncGenerator
 
 from botocore.exceptions import ClientError
@@ -376,6 +377,43 @@ async def stream_anthropic_messages(
     }
     last_heartbeat = time.time()
     client_disconnected = False
+    usage_recorded = False
+
+    def _record_stream_usage():
+        """Record usage once, from the tokens accumulated so far.
+
+        Runs from ``finally`` so tokens are still accounted when the stream
+        aborts mid-way (client disconnect or an exception after Bedrock has
+        already produced — and been charged for — tokens). Idempotent via the
+        ``usage_recorded`` guard so the normal and error paths don't double
+        count.
+        """
+        nonlocal usage_recorded
+        if usage_recorded:
+            return
+        total_input = accumulated_usage.get("input_tokens", 0)
+        total_output = accumulated_usage.get("output_tokens", 0)
+        total_cache_creation = accumulated_usage.get("cache_creation_input_tokens", 0)
+        total_cache_read = accumulated_usage.get("cache_read_input_tokens", 0)
+        if not (total_input or total_output):
+            # Nothing consumed (e.g. failure before message_start) → skip.
+            return
+        usage_recorded = True
+        background_tasks.create_task(
+            record_usage(
+                token_id=token.id,
+                user_id=token.user_id,
+                model=model,
+                request_id=request_id,
+                prompt_tokens=total_input,
+                completion_tokens=total_output,
+                cache_creation_input_tokens=total_cache_creation,
+                cache_read_input_tokens=total_cache_read,
+                cache_ttl=cache_ttl if total_cache_creation else None,
+            ),
+            task_name=f"record_usage_{request_id}",
+        )
+
     # Accumulate response content blocks for trace
     trace_content_blocks: list[dict] = []
     trace_current_block: dict | None = None
@@ -471,26 +509,13 @@ async def stream_anthropic_messages(
                 yield sse_event
                 last_heartbeat = current_time
 
-        # Record usage
+        # Usage is recorded in the finally block (idempotent) so mid-stream
+        # aborts still account already-consumed tokens. These totals are read
+        # here for logging / metrics / trace.
         total_input = accumulated_usage.get("input_tokens", 0)
         total_output = accumulated_usage.get("output_tokens", 0)
         total_cache_creation = accumulated_usage.get("cache_creation_input_tokens", 0)
         total_cache_read = accumulated_usage.get("cache_read_input_tokens", 0)
-
-        background_tasks.create_task(
-            record_usage(
-                token_id=token.id,
-                user_id=token.user_id,
-                model=model,
-                request_id=request_id,
-                prompt_tokens=total_input,
-                completion_tokens=total_output,
-                cache_creation_input_tokens=total_cache_creation,
-                cache_read_input_tokens=total_cache_read,
-                cache_ttl=cache_ttl if total_cache_creation else None,
-            ),
-            task_name=f"record_usage_{request_id}",
-        )
 
         duration = time.time() - start_time
         cache_info = ""
@@ -577,6 +602,11 @@ async def stream_anthropic_messages(
             "error": {"type": "server_error", "message": "Internal server error"},
         }
         yield f"event: error\ndata: {_json.dumps(error_data)}\n\n"
+    finally:
+        # Record usage for tokens already consumed on every exit path —
+        # normal completion, client disconnect, or a mid-stream error after
+        # Bedrock produced tokens. Idempotent, so the success path records once.
+        _record_stream_usage()
 
 
 async def record_usage(
@@ -595,15 +625,28 @@ async def record_usage(
 
     async for db in get_db():
         try:
+            # If pricing is missing (e.g. a new model without a price row), do
+            # NOT drop the usage — record the token counts with cost_usd=0 and a
+            # note so the tokens stay auditable and the cost can be back-filled.
+            note = None
             pricing_service = ModelPricing(db=db)
-            cost_usd = await pricing_service.calculate_cost(
-                model=model,
-                prompt_tokens=prompt_tokens,
-                completion_tokens=completion_tokens,
-                cache_creation_input_tokens=cache_creation_input_tokens,
-                cache_read_input_tokens=cache_read_input_tokens,
-                cache_ttl=cache_ttl,
-            )
+            try:
+                cost_usd = await pricing_service.calculate_cost(
+                    model=model,
+                    prompt_tokens=prompt_tokens,
+                    completion_tokens=completion_tokens,
+                    cache_creation_input_tokens=cache_creation_input_tokens,
+                    cache_read_input_tokens=cache_read_input_tokens,
+                    cache_ttl=cache_ttl,
+                )
+            except ValueError as e:
+                cost_usd = Decimal("0.0000")
+                note = "pricing_missing"
+                logger.error(
+                    f"Pricing not available for model {model}, "
+                    f"recording usage with cost_usd=0: {e}",
+                    extra={"request_id": request_id, "model": model},
+                )
 
             usage_record = UsageRecord(
                 user_id=user_id,
@@ -619,6 +662,7 @@ async def record_usage(
                 cache_read_input_tokens=cache_read_input_tokens,
                 cost_usd=cost_usd,
                 request_id=request_id,
+                note=note,
             )
 
             db.add(usage_record)
@@ -639,12 +683,6 @@ async def record_usage(
                     "cost_usd": round(cost_usd, 6),
                 },
             )
-        except ValueError as e:
-            logger.error(
-                f"Pricing not available for model {model}: {e}",
-                extra={"request_id": request_id, "model": model},
-            )
-            await db.rollback()
         except Exception as e:
             logger.error(f"Failed to record usage: {e}", exc_info=True)
             await db.rollback()

--- a/backend/app/api/gemini/endpoints/generate.py
+++ b/backend/app/api/gemini/endpoints/generate.py
@@ -10,6 +10,7 @@ import json
 import logging
 import time
 import uuid
+from decimal import Decimal
 from typing import AsyncGenerator, Dict
 
 import httpx
@@ -108,13 +109,24 @@ async def _record_usage(
 
     async for db in _get_db():
         try:
+            # Missing pricing → record tokens with cost_usd=0 + note instead of
+            # dropping the usage, so it stays auditable and back-fillable.
+            note = None
             pricing_service = ModelPricing(db=db)
-            cost_usd = await pricing_service.calculate_cost(
-                model=model,
-                prompt_tokens=non_cached_prompt,
-                completion_tokens=completion_tokens,
-                cache_read_input_tokens=cached_tokens,
-            )
+            try:
+                cost_usd = await pricing_service.calculate_cost(
+                    model=model,
+                    prompt_tokens=non_cached_prompt,
+                    completion_tokens=completion_tokens,
+                    cache_read_input_tokens=cached_tokens,
+                )
+            except ValueError as e:
+                cost_usd = Decimal("0.0000")
+                note = "pricing_missing"
+                logger.error(
+                    f"Pricing not available for model {model}, "
+                    f"recording usage with cost_usd=0: {e}"
+                )
 
             usage_record = UsageRecord(
                 user_id=token.user_id,
@@ -126,6 +138,7 @@ async def _record_usage(
                 cache_read_input_tokens=cached_tokens,
                 cost_usd=cost_usd,
                 request_id=request_id,
+                note=note,
             )
             db.add(usage_record)
             await db.commit()
@@ -143,9 +156,6 @@ async def _record_usage(
                 "Gemini usage recorded",
                 extra={"request_id": request_id, "cost_usd": round(cost_usd, 6)},
             )
-        except ValueError as e:
-            logger.error(f"Pricing not available for model {model}: {e}")
-            await db.rollback()
         except Exception as e:
             logger.error(f"Failed to record Gemini usage: {e}", exc_info=True)
             await db.rollback()
@@ -318,6 +328,25 @@ async def _stream_proxy(
     prompt_tokens = 0
     completion_tokens = 0
     cached_tokens = 0
+    usage_recorded = False
+
+    def _record():
+        """Record usage once, on any exit path (incl. client disconnect)."""
+        nonlocal usage_recorded
+        if usage_recorded or not (prompt_tokens or completion_tokens):
+            return
+        usage_recorded = True
+        background_tasks.create_task(
+            _record_usage(
+                token=token,
+                model=model_name,
+                request_id=request_id,
+                prompt_tokens=prompt_tokens,
+                completion_tokens=completion_tokens,
+                cached_tokens=cached_tokens,
+            ),
+            task_name=f"gemini_usage_{request_id}",
+        )
 
     try:
         async with httpx.AsyncClient(timeout=3600) as client:
@@ -366,19 +395,10 @@ async def _stream_proxy(
             exc_info=True,
         )
         yield 'data: {"error": {"message": "Internal server error"}}\n\n'
-
-    # Record usage
-    background_tasks.create_task(
-        _record_usage(
-            token=token,
-            model=model_name,
-            request_id=request_id,
-            prompt_tokens=prompt_tokens,
-            completion_tokens=completion_tokens,
-            cached_tokens=cached_tokens,
-        ),
-        task_name=f"gemini_usage_{request_id}",
-    )
+    finally:
+        # Record usage on every exit path — normal completion, client
+        # disconnect, or a mid-stream error after Google produced tokens.
+        _record()
 
     duration = time.time() - start_time
     cache_info = f", cached={cached_tokens}" if cached_tokens else ""

--- a/backend/app/api/v1/endpoints/chat.py
+++ b/backend/app/api/v1/endpoints/chat.py
@@ -5,6 +5,7 @@ OpenAI-compatible chat completions endpoint.
 import logging
 import time
 import uuid
+from decimal import Decimal
 from typing import AsyncGenerator
 
 from botocore.exceptions import ClientError
@@ -769,6 +770,38 @@ async def stream_chat_completion(
     total_cache_read_tokens = 0
     last_heartbeat = time.time()
     client_disconnected = False
+    usage_recorded = False
+
+    def _record_stream_usage():
+        """Record usage once, from the tokens seen so far.
+
+        Runs from ``finally`` so tokens are still accounted when the stream
+        aborts mid-way (client disconnect or an exception after Bedrock has
+        already produced — and been charged for — tokens). Idempotent via the
+        ``usage_recorded`` guard so the normal and error paths don't double
+        count.
+        """
+        nonlocal usage_recorded
+        if usage_recorded:
+            return
+        if not (total_input_tokens or total_output_tokens):
+            # Nothing consumed (e.g. failure before message_start) → skip.
+            return
+        usage_recorded = True
+        background_tasks.create_task(
+            record_usage(
+                token_id=token.id,
+                user_id=token.user_id,
+                model=model,
+                request_id=request_id,
+                prompt_tokens=total_input_tokens,
+                completion_tokens=total_output_tokens,
+                cache_creation_input_tokens=total_cache_creation_tokens,
+                cache_read_input_tokens=total_cache_read_tokens,
+                cache_ttl=cache_ttl if total_cache_creation_tokens else None,
+            ),
+            task_name=f"record_usage_{request_id}",
+        )
 
     # Track tool use state for streaming
     tool_use_blocks = {}  # {index: {"id": ..., "name": ..., "input": ""}}
@@ -931,22 +964,6 @@ async def stream_chat_completion(
             # Send done marker
             yield ResponseTranslator.create_stream_done()
 
-        # Record usage for tokens already consumed (even if client disconnected)
-        background_tasks.create_task(
-            record_usage(
-                token_id=token.id,
-                user_id=token.user_id,
-                model=model,
-                request_id=request_id,
-                prompt_tokens=total_input_tokens,
-                completion_tokens=total_output_tokens,
-                cache_creation_input_tokens=total_cache_creation_tokens,
-                cache_read_input_tokens=total_cache_read_tokens,
-                cache_ttl=cache_ttl if total_cache_creation_tokens else None,
-            ),
-            task_name=f"record_usage_{request_id}",
-        )
-
         duration = time.time() - start_time
         cache_info = ""
         if total_cache_creation_tokens:
@@ -1012,6 +1029,12 @@ async def stream_chat_completion(
             )
         )
         yield f"data: {error_response.model_dump_json()}\n\n"
+    finally:
+        # Record usage for tokens already consumed on every exit path —
+        # normal completion, client disconnect, or a mid-stream error after
+        # Bedrock produced tokens. Idempotent, so the success path (which also
+        # reaches here) records exactly once.
+        _record_stream_usage()
 
 
 async def record_usage(
@@ -1042,16 +1065,29 @@ async def record_usage(
     # Create new db session for background task
     async for db in get_db():
         try:
-            # Calculate cost using actual model pricing from database
+            # Calculate cost using actual model pricing from the database.
+            # If pricing is missing (e.g. a new model without a price row), do
+            # NOT drop the usage — record the token counts with cost_usd=0 and a
+            # note so the tokens stay auditable and the cost can be back-filled.
+            note = None
             pricing_service = ModelPricing(db=db)
-            cost_usd = await pricing_service.calculate_cost(
-                model=model,
-                prompt_tokens=prompt_tokens,
-                completion_tokens=completion_tokens,
-                cache_creation_input_tokens=cache_creation_input_tokens,
-                cache_read_input_tokens=cache_read_input_tokens,
-                cache_ttl=cache_ttl,
-            )
+            try:
+                cost_usd = await pricing_service.calculate_cost(
+                    model=model,
+                    prompt_tokens=prompt_tokens,
+                    completion_tokens=completion_tokens,
+                    cache_creation_input_tokens=cache_creation_input_tokens,
+                    cache_read_input_tokens=cache_read_input_tokens,
+                    cache_ttl=cache_ttl,
+                )
+            except ValueError as e:
+                cost_usd = Decimal("0.0000")
+                note = "pricing_missing"
+                logger.error(
+                    f"Pricing not available for model {model}, "
+                    f"recording usage with cost_usd=0: {e}",
+                    extra={"request_id": request_id, "model": model},
+                )
 
             # Create usage record
             usage_record = UsageRecord(
@@ -1068,6 +1104,7 @@ async def record_usage(
                 cache_read_input_tokens=cache_read_input_tokens,
                 cost_usd=cost_usd,
                 request_id=request_id,
+                note=note,
             )
 
             db.add(usage_record)
@@ -1088,13 +1125,6 @@ async def record_usage(
                     "cost_usd": round(cost_usd, 6),
                 },
             )
-        except ValueError as e:
-            # If pricing not found, log error
-            logger.error(
-                f"Pricing not available for model {model}: {e}",
-                extra={"request_id": request_id, "model": model},
-            )
-            await db.rollback()
         except Exception as e:
             logger.error(f"Failed to record usage: {e}", exc_info=True)
             await db.rollback()

--- a/backend/app/api/v1/endpoints/responses.py
+++ b/backend/app/api/v1/endpoints/responses.py
@@ -193,6 +193,26 @@ async def _stream_responses(
     usage = {"non_cached_prompt": 0, "completion": 0, "cached": 0}
     buffer = ""
     last_heartbeat = time.time()
+    usage_recorded = False
+
+    def _record():
+        """Record usage once, on any exit path (incl. client disconnect)."""
+        nonlocal usage_recorded
+        if usage_recorded or not (usage["non_cached_prompt"] or usage["completion"]):
+            return
+        usage_recorded = True
+        background_tasks.create_task(
+            record_usage(
+                token_id=token.id,
+                user_id=token.user_id,
+                model=model,
+                request_id=request_id,
+                prompt_tokens=usage["non_cached_prompt"],
+                completion_tokens=usage["completion"],
+                cache_read_input_tokens=usage["cached"],
+            ),
+            task_name=f"record_usage_{request_id}",
+        )
 
     try:
         async for raw in MantleClient.responses_passthrough_stream(body):
@@ -255,20 +275,10 @@ async def _stream_responses(
         }
         yield f"event: error\ndata: {json.dumps(err)}\n\n".encode("utf-8")
         return
-
-    # Record usage after the stream completes
-    background_tasks.create_task(
-        record_usage(
-            token_id=token.id,
-            user_id=token.user_id,
-            model=model,
-            request_id=request_id,
-            prompt_tokens=usage["non_cached_prompt"],
-            completion_tokens=usage["completion"],
-            cache_read_input_tokens=usage["cached"],
-        ),
-        task_name=f"record_usage_{request_id}",
-    )
+    finally:
+        # Record usage on every exit path — normal completion, client
+        # disconnect, or a mid-stream error after tokens were produced.
+        _record()
 
     duration = time.time() - start_time
     cache_info = f", cached={usage['cached']}" if usage["cached"] else ""

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,0 +1,23 @@
+"""Shared pytest configuration.
+
+Several application modules call ``get_settings()`` at *import* time (e.g.
+``app.core.security`` builds a module-level ``settings`` object). ``Settings``
+is a pydantic ``BaseSettings`` whose ``DATABASE_URL`` / ``JWT_SECRET_KEY`` are
+required. Locally a ``.env`` satisfies them, but CI provides neither, so the
+first test that imports such a module fails during import — before any fixture
+can run.
+
+Set dummy-but-valid values here, at conftest import time, which pytest loads
+before collecting any test module. ``setdefault`` never overrides values a real
+environment (or ``.env`` via pydantic) already provides, so this is a no-op
+locally and in deployed environments.
+"""
+
+import os
+
+# Valid Postgres URL + a 32+ char secret so the Settings field validators pass.
+os.environ.setdefault(
+    "DATABASE_URL",
+    "postgresql+asyncpg://user:pass@localhost:5432/test",  # pragma: allowlist secret
+)
+os.environ.setdefault("JWT_SECRET_KEY", "x" * 32)  # pragma: allowlist secret

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -3,21 +3,23 @@
 Several application modules call ``get_settings()`` at *import* time (e.g.
 ``app.core.security`` builds a module-level ``settings`` object). ``Settings``
 is a pydantic ``BaseSettings`` whose ``DATABASE_URL`` / ``JWT_SECRET_KEY`` are
-required. Locally a ``.env`` satisfies them, but CI provides neither, so the
-first test that imports such a module fails during import — before any fixture
-can run.
+required. Locally a ``.env`` / ``.env.local`` satisfies them, but CI ships
+neither (``.env.local`` is git-ignored), so the first test that imports such a
+module fails during import — before any fixture can run.
 
 Set dummy-but-valid values here, at conftest import time, which pytest loads
-before collecting any test module. ``setdefault`` never overrides values a real
-environment (or ``.env`` via pydantic) already provides, so this is a no-op
-locally and in deployed environments.
+before collecting any test module. NOTE: Settings uses ``env_prefix = "KBR_"``,
+so the variables must be named ``KBR_DATABASE_URL`` / ``KBR_JWT_SECRET_KEY``.
+``setdefault`` never overrides values a real environment already provides, so
+this is a no-op locally and in deployed environments.
 """
 
 import os
 
-# Valid Postgres URL + a 32+ char secret so the Settings field validators pass.
+# Settings reads env vars with the KBR_ prefix. Valid Postgres URL + a 32+ char
+# secret so the field validators pass.
 os.environ.setdefault(
-    "DATABASE_URL",
+    "KBR_DATABASE_URL",
     "postgresql+asyncpg://user:pass@localhost:5432/test",  # pragma: allowlist secret
 )
-os.environ.setdefault("JWT_SECRET_KEY", "x" * 32)  # pragma: allowlist secret
+os.environ.setdefault("KBR_JWT_SECRET_KEY", "x" * 32)  # pragma: allowlist secret

--- a/backend/tests/test_usage_recording.py
+++ b/backend/tests/test_usage_recording.py
@@ -24,26 +24,6 @@ import pytest
 from app.schemas.bedrock import BedrockStreamEvent, BedrockUsage
 
 
-@pytest.fixture(autouse=True)
-def _settings_env(monkeypatch):
-    """Provide the required settings env vars so get_settings() works in CI.
-
-    Settings is a pydantic BaseSettings with DATABASE_URL / JWT_SECRET_KEY as
-    required fields; locally a .env satisfies them, but CI has neither. The
-    streaming handlers and record_usage call get_settings() (lru_cached), so
-    set dummy-but-valid values and clear the cache around each test.
-    """
-    from app.core.config import get_settings
-
-    monkeypatch.setenv(
-        "DATABASE_URL", "postgresql+asyncpg://user:pass@localhost:5432/test"
-    )
-    monkeypatch.setenv("JWT_SECRET_KEY", "x" * 32)  # pragma: allowlist secret
-    get_settings.cache_clear()
-    yield
-    get_settings.cache_clear()
-
-
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_usage_recording.py
+++ b/backend/tests/test_usage_recording.py
@@ -24,6 +24,26 @@ import pytest
 from app.schemas.bedrock import BedrockStreamEvent, BedrockUsage
 
 
+@pytest.fixture(autouse=True)
+def _settings_env(monkeypatch):
+    """Provide the required settings env vars so get_settings() works in CI.
+
+    Settings is a pydantic BaseSettings with DATABASE_URL / JWT_SECRET_KEY as
+    required fields; locally a .env satisfies them, but CI has neither. The
+    streaming handlers and record_usage call get_settings() (lru_cached), so
+    set dummy-but-valid values and clear the cache around each test.
+    """
+    from app.core.config import get_settings
+
+    monkeypatch.setenv(
+        "DATABASE_URL", "postgresql+asyncpg://user:pass@localhost:5432/test"
+    )
+    monkeypatch.setenv("JWT_SECRET_KEY", "x" * 32)  # pragma: allowlist secret
+    get_settings.cache_clear()
+    yield
+    get_settings.cache_clear()
+
+
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_usage_recording.py
+++ b/backend/tests/test_usage_recording.py
@@ -1,0 +1,325 @@
+"""
+Tests for usage-recording robustness.
+
+Covers two guarantees that keep recorded usage from silently diverging from
+what the upstream provider actually charged:
+
+A. Streaming records usage on *every* exit path — normal completion, client
+   disconnect, or a mid-stream error after the provider already produced (and
+   billed) tokens — and does so exactly once (idempotent).
+
+B. When pricing is missing for a model, usage is still recorded with
+   ``cost_usd=0`` and ``note="pricing_missing"`` instead of being dropped, so
+   the tokens stay auditable and the cost can be back-filled later.
+
+All provider/DB access is mocked — no real AWS or database calls.
+"""
+
+import uuid
+from decimal import Decimal
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.schemas.bedrock import BedrockStreamEvent, BedrockUsage
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _message_start(input_tokens=100, cache_read=0, cache_write=0):
+    return BedrockStreamEvent(
+        type="message_start",
+        usage=BedrockUsage(
+            input_tokens=input_tokens,
+            cache_read_input_tokens=cache_read,
+            cache_creation_input_tokens=cache_write,
+        ),
+    )
+
+
+def _content_delta(text="hi"):
+    return BedrockStreamEvent(type="content_block_delta", index=0, delta={"text": text})
+
+
+def _make_token():
+    token = MagicMock()
+    token.id = uuid.uuid4()
+    token.user_id = uuid.uuid4()
+    return token
+
+
+class _CaptureTasks:
+    """Stand-in for BackgroundTaskManager that captures scheduled coroutines."""
+
+    def __init__(self):
+        self.calls = []
+
+    def create_task(self, coro, task_name="background_task"):
+        self.calls.append((task_name, coro))
+        # Close the coroutine so pytest doesn't warn about it never being awaited.
+        coro.close()
+
+
+# ---------------------------------------------------------------------------
+# A — streaming records usage on abnormal exit paths, exactly once
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_openai_stream_records_usage_on_midstream_error():
+    """If Bedrock produces tokens then the stream raises, usage is still recorded."""
+    from app.api.v1.endpoints import chat
+
+    async def broken_stream(*args, **kwargs):
+        yield _message_start(input_tokens=123)
+        yield _content_delta("partial")
+        raise RuntimeError("connection dropped mid-stream")
+
+    bedrock_client = MagicMock()
+    bedrock_client.invoke_stream = broken_stream
+
+    capture = _CaptureTasks()
+    with (
+        patch.object(chat, "background_tasks", capture),
+        patch.object(chat, "get_fallback_models", return_value=[]),
+    ):
+        gen = chat.stream_chat_completion(
+            request_id="req-err",
+            model="global.anthropic.claude-opus-4-8",
+            bedrock_request={},
+            bedrock_client=bedrock_client,
+            token=_make_token(),
+            db=MagicMock(),
+            start_time=0.0,
+        )
+        # Drain the generator; the mid-stream error is caught and turned into an
+        # SSE error frame, not re-raised.
+        async for _ in gen:
+            pass
+
+    record_calls = [c for c in capture.calls if c[0] == "record_usage_req-err"]
+    assert len(record_calls) == 1, "usage must be recorded exactly once on error path"
+
+
+@pytest.mark.asyncio
+async def test_openai_stream_records_usage_once_on_success():
+    """Normal completion records usage exactly once (finally is idempotent)."""
+    from app.api.v1.endpoints import chat
+
+    async def good_stream(*args, **kwargs):
+        yield _message_start(input_tokens=50)
+        yield _content_delta("hello")
+        yield BedrockStreamEvent(
+            type="message_delta",
+            delta={"stop_reason": "end_turn"},
+            usage=BedrockUsage(output_tokens=7),
+        )
+        yield BedrockStreamEvent(type="message_stop")
+
+    bedrock_client = MagicMock()
+    bedrock_client.invoke_stream = good_stream
+
+    capture = _CaptureTasks()
+    with (
+        patch.object(chat, "background_tasks", capture),
+        patch.object(chat, "get_fallback_models", return_value=[]),
+    ):
+        gen = chat.stream_chat_completion(
+            request_id="req-ok",
+            model="global.anthropic.claude-opus-4-8",
+            bedrock_request={},
+            bedrock_client=bedrock_client,
+            token=_make_token(),
+            db=MagicMock(),
+            start_time=0.0,
+        )
+        async for _ in gen:
+            pass
+
+    record_calls = [c for c in capture.calls if c[0] == "record_usage_req-ok"]
+    assert len(record_calls) == 1, "success path must record exactly once"
+
+
+@pytest.mark.asyncio
+async def test_openai_stream_no_usage_when_nothing_consumed():
+    """A failure before any tokens arrive records nothing (matches AWS: no charge)."""
+    from app.api.v1.endpoints import chat
+
+    async def empty_then_error(*args, **kwargs):
+        raise RuntimeError("failed before message_start")
+        yield  # pragma: no cover - makes this an async generator
+
+    bedrock_client = MagicMock()
+    bedrock_client.invoke_stream = empty_then_error
+
+    capture = _CaptureTasks()
+    with (
+        patch.object(chat, "background_tasks", capture),
+        patch.object(chat, "get_fallback_models", return_value=[]),
+    ):
+        gen = chat.stream_chat_completion(
+            request_id="req-none",
+            model="global.anthropic.claude-opus-4-8",
+            bedrock_request={},
+            bedrock_client=bedrock_client,
+            token=_make_token(),
+            db=MagicMock(),
+            start_time=0.0,
+        )
+        async for _ in gen:
+            pass
+
+    record_calls = [c for c in capture.calls if c[0] == "record_usage_req-none"]
+    assert len(record_calls) == 0, "no tokens consumed → no usage record"
+
+
+@pytest.mark.asyncio
+async def test_anthropic_stream_records_usage_on_midstream_error():
+    """Anthropic native path also records usage when the stream aborts mid-way."""
+    from app.api.anthropic.endpoints import messages
+
+    async def broken_stream(*args, **kwargs):
+        yield _message_start(input_tokens=200)
+        raise RuntimeError("boom")
+
+    # The Anthropic path accumulates usage via the translator; make it populate
+    # input_tokens from the message_start event like the real translator does.
+    def fake_translate(event, model, request_id, accumulated_usage):
+        if event.type == "message_start" and event.usage:
+            accumulated_usage["input_tokens"] = event.usage.input_tokens or 0
+        return []
+
+    bedrock_client = MagicMock()
+    bedrock_client.invoke_stream = broken_stream
+
+    capture = _CaptureTasks()
+    with (
+        patch.object(messages, "background_tasks", capture),
+        patch.object(messages, "get_fallback_models", return_value=[]),
+        patch.object(
+            messages.AnthropicResponseTranslator,
+            "bedrock_stream_to_anthropic_events",
+            side_effect=fake_translate,
+        ),
+    ):
+        gen = messages.stream_anthropic_messages(
+            request_id="req-anthropic",
+            model="global.anthropic.claude-opus-4-8",
+            bedrock_request={},
+            bedrock_client=bedrock_client,
+            token=_make_token(),
+            db=MagicMock(),
+            start_time=0.0,
+        )
+        async for _ in gen:
+            pass
+
+    record_calls = [c for c in capture.calls if c[0] == "record_usage_req-anthropic"]
+    assert len(record_calls) == 1, "anthropic path must record once on error"
+
+
+# ---------------------------------------------------------------------------
+# B — missing pricing degrades to cost=0 + note instead of dropping usage
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_record_usage_pricing_missing_records_zero_cost():
+    """When calculate_cost raises ValueError, a record is still written."""
+    from app.api.v1.endpoints import chat
+
+    added = []
+
+    class FakeSession:
+        def add(self, obj):
+            added.append(obj)
+
+        async def commit(self):
+            pass
+
+        async def rollback(self):
+            pass
+
+        async def close(self):
+            pass
+
+    async def fake_get_db():
+        yield FakeSession()
+
+    pricing_instance = MagicMock()
+    pricing_instance.calculate_cost = AsyncMock(
+        side_effect=ValueError("no pricing row for model")
+    )
+
+    with (
+        patch.object(chat, "get_db", fake_get_db),
+        patch.object(chat, "ModelPricing", return_value=pricing_instance),
+        patch("app.services.alert.check_alerts_for_usage", new=AsyncMock()),
+    ):
+        await chat.record_usage(
+            token_id=uuid.uuid4(),
+            user_id=uuid.uuid4(),
+            model="global.anthropic.some-brand-new-model",
+            request_id="req-nopricing",
+            prompt_tokens=100,
+            completion_tokens=20,
+            cache_creation_input_tokens=0,
+            cache_read_input_tokens=0,
+        )
+
+    assert len(added) == 1, "usage must be recorded even without pricing"
+    rec = added[0]
+    assert rec.cost_usd == Decimal("0.0000")
+    assert rec.note == "pricing_missing"
+    assert rec.prompt_tokens == 100
+    assert rec.completion_tokens == 20
+    assert rec.total_tokens == 120
+
+
+@pytest.mark.asyncio
+async def test_record_usage_normal_pricing_has_no_note():
+    """Happy path records the computed cost and leaves note unset."""
+    from app.api.v1.endpoints import chat
+
+    added = []
+
+    class FakeSession:
+        def add(self, obj):
+            added.append(obj)
+
+        async def commit(self):
+            pass
+
+        async def rollback(self):
+            pass
+
+        async def close(self):
+            pass
+
+    async def fake_get_db():
+        yield FakeSession()
+
+    pricing_instance = MagicMock()
+    pricing_instance.calculate_cost = AsyncMock(return_value=Decimal("0.1234"))
+
+    with (
+        patch.object(chat, "get_db", fake_get_db),
+        patch.object(chat, "ModelPricing", return_value=pricing_instance),
+        patch("app.services.alert.check_alerts_for_usage", new=AsyncMock()),
+    ):
+        await chat.record_usage(
+            token_id=uuid.uuid4(),
+            user_id=uuid.uuid4(),
+            model="global.anthropic.claude-opus-4-8",
+            request_id="req-ok",
+            prompt_tokens=100,
+            completion_tokens=20,
+        )
+
+    assert len(added) == 1
+    rec = added[0]
+    assert rec.cost_usd == Decimal("0.1234")
+    assert rec.note is None


### PR DESCRIPTION
## 背景

排查计费一致性时发现:成功且完整走完的流式请求用量能对上,但**边界场景会漏记**,导致 `usage_records` 与上游(Bedrock/Google/Mantle)实际扣费不一致。方向上是漏记(对客户偏保守),但对账时会出现"上游账单 > 系统记录"。

## 修复

### A. 流式中途异常 / 客户端断连 → 用量丢失

原实现把 `record_usage` 放在 `try` 块**末尾**。一旦流在产出 token 后抛异常(网络抖动、Bedrock 中途断流、翻译异常),控制流跳到 `except` 只发一个 SSE error 帧,`record_usage` **永不执行** —— input + 已产出的 output token 全部不记账,而上游已扣费。

改为在 `finally` 中调用一个**幂等**的记录闭包(`usage_recorded` 守卫),保证三条路径都恰好记一次:正常完成 / 客户端断连 / 中途报错。`message_start` 之前就失败(无 token 消耗)则不记,与"上游不扣费"一致。

覆盖全部 4 条流式路径:
- `chat.py` — OpenAI `/v1/chat`
- `messages.py` — Anthropic 原生 `/messages`
- `generate.py` — Gemini passthrough
- `responses.py` — Responses / Mantle(原来两个 `except` 里直接 `return`,漏得最明显)

### B. 价格缺失 → 整条用量静默丢弃

`record_usage` 在 `calculate_cost` 抛 `ValueError`(模型无价格行,如新模型上线未同步价格表)时,原来只 `log + rollback`,token 计数彻底丢失。

改为降级记录 `cost_usd=0` + `note="pricing_missing"`,保住 token 计数与对账线索,成本可后续回填。三处 `record_usage`(chat / messages / gemini)一致处理。

## 测试

新增 `tests/test_usage_recording.py`(6 例,全部 mock,无真实 AWS/DB):
- 流式中途报错仍记一次(OpenAI + Anthropic)
- 成功路径只记一次(幂等)
- 无 token 消耗不记
- 价格缺失降级为 `cost=0` + `note`
- 正常路径 `note` 为空

全量:`91 passed`(+6);剩余 4 个失败为既有的 AWS pricing scraper 网络测试,与本改动无关。

## 说明

- 本 PR 不依赖 #77(定价修复),可独立合并。
- 不含历史数据回溯(按此前决定)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
