### PR TITLE
feat: 支持 OpenAI GPT-5.6 (Sol/Terra/Luna) + mantle 模型自动发现

### DIFF
--- a/backend/app/api/admin/endpoints/pricing.py
+++ b/backend/app/api/admin/endpoints/pricing.py
@@ -31,6 +31,15 @@ async def update_pricing(
         Update statistics
     """
     try:
+        # Refresh the mantle (OpenAI) model registry first so pricing rows for
+        # newly launched models can be matched in this same update.
+        from app.services.mantle_models import refresh_mantle_registry
+
+        try:
+            await refresh_mantle_registry()
+        except Exception as e:
+            logger.warning(f"Mantle model discovery failed (non-fatal): {e}")
+
         updater = PricingUpdater(db)
         stats = await updater.update_all_pricing()
 

--- a/backend/app/api/v1/endpoints/responses.py
+++ b/backend/app/api/v1/endpoints/responses.py
@@ -102,7 +102,7 @@ async def create_response(
             status_code=400,
             detail=(
                 f"Model '{model}' is not available on the Responses API. "
-                "This endpoint serves OpenAI GPT-5.5/5.4 (mantle) only; "
+                "This endpoint serves OpenAI GPT-5.6/5.5/5.4 (mantle) only; "
                 "use /v1/chat/completions for other models."
             ),
         )

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -74,11 +74,18 @@ class Settings(BaseSettings):
         description="Google Cloud region for Vertex AI",
     )
 
-    # OpenAI-on-Bedrock (mantle) settings — GPT-5.5 / GPT-5.4 via Responses API
+    # OpenAI-on-Bedrock (mantle) settings — GPT-5.6/5.5/5.4 via Responses API
     MANTLE_SIGV4_SERVICE: str = Field(
         default="bedrock",
         description="SigV4 service name used to sign mantle (OpenAI Responses API) requests. "
         "Override to 'bedrock-runtime' / 'bedrock-mantle' if signing is rejected.",
+    )
+    MANTLE_DISCOVERY_REGIONS: str = Field(
+        default="us-east-1,us-east-2,us-west-2",
+        description="Comma-separated regions probed by mantle model discovery "
+        "(bedrock-mantle:ListModels). Order matters: the first region a model "
+        "is found in becomes its preferred routing region. Empty disables "
+        "discovery (static registry only).",
     )
 
     # AWS Bedrock settings
@@ -237,6 +244,11 @@ class Settings(BaseSettings):
         "Example: 'anthropic.claude-opus-4-0-20250514-v1:0,anthropic.claude-sonnet-4-20250514-v1:0'. "
         "Empty string disables model degradation.",
     )
+
+    def get_mantle_discovery_regions(self) -> List[str]:
+        """Get mantle ListModels probe regions as a list."""
+        regions = (self.MANTLE_DISCOVERY_REGIONS or "").strip('"').strip("'")
+        return [r.strip() for r in regions.split(",") if r.strip()]
 
     def get_allowed_origins(self) -> List[str]:
         """Get CORS allowed origins as a list."""

--- a/backend/app/services/mantle_client.py
+++ b/backend/app/services/mantle_client.py
@@ -241,7 +241,7 @@ def _openai_tool_choice_to_responses(tool_choice: Any) -> Optional[Any]:
     return None
 
 
-_REASONING_MODEL_PATTERNS = ("gpt-5.5", "o1", "o3", "o4")
+_REASONING_MODEL_PATTERNS = ("gpt-5.6", "gpt-5.5", "o1", "o3", "o4")
 
 
 def _is_reasoning_model(model: str) -> bool:

--- a/backend/app/services/mantle_models.py
+++ b/backend/app/services/mantle_models.py
@@ -1,7 +1,8 @@
 """
 OpenAI-on-Bedrock (mantle) model registry.
 
-GPT-5.5 / GPT-5.4 are served by AWS's "mantle" inference engine through the
+GPT-5.6 (Sol/Terra/Luna) and GPT-5.5 / GPT-5.4 are served by AWS's "mantle"
+inference engine through the
 OpenAI Responses API (``https://bedrock-mantle.{region}.api.aws/openai/v1``),
 **not** through the standard boto3 ``converse`` / ``invoke_model`` paths.  They
 do not appear in ``list-foundation-models`` / ``list-inference-profiles`` or the
@@ -16,27 +17,189 @@ Price List API, so they need their own static registry:
 
 This module is the single source of truth shared by chat routing, pricing, and
 the admin model list.
+
+The registry has two layers:
+
+  * a static seed table (below) — always available, hand-maintained as a
+    fallback;
+  * a discovered layer populated by ``refresh_mantle_registry()``, which calls
+    the mantle ``ListModels`` API (``GET /v1/models``, IAM action
+    ``bedrock-mantle:ListModels``) per candidate region at startup and on a
+    daily schedule.  Discovered entries override the static seed per model;
+    static models never disappear, so a failed discovery can only miss NEW
+    models, never break existing routing.
 """
 
-from typing import Dict, List
+import logging
+import re
+from typing import Dict, List, Optional
 
 from app.core.config import get_settings
 
-# Model ID → regions where it can be invoked (first entry is the preferred one).
-# Source: AWS "Get started with OpenAI GPT-5.5 / GPT-5.4 on Amazon Bedrock".
+logger = logging.getLogger(__name__)
+
+# Static seed: model ID → regions where it can be invoked (first entry is the
+# preferred one).  Source: AWS Bedrock model cards ("Models at a glance" →
+# OpenAI).  Kept as a fallback for when ListModels discovery is disabled or
+# fails — discovered data (see refresh_mantle_registry) takes precedence.
 MANTLE_MODEL_REGIONS: Dict[str, List[str]] = {
+    "openai.gpt-5.6-sol": ["us-east-1", "us-east-2"],
+    "openai.gpt-5.6-terra": ["us-east-1", "us-east-2", "us-west-2"],
+    "openai.gpt-5.6-luna": ["us-east-1", "us-east-2", "us-west-2"],
     "openai.gpt-5.5": ["us-east-2"],
     "openai.gpt-5.4": ["us-east-2", "us-west-2"],
 }
 
+# Discovered layer — set by refresh_mantle_registry(), None until first run.
+_discovered_model_regions: Optional[Dict[str, List[str]]] = None
+
 # mantle OpenAI-compatible endpoint base URL (per region).
 MANTLE_BASE_URL = "https://bedrock-mantle.{region}.api.aws/openai/v1"
 
-# Display name on the AWS Bedrock pricing page → model ID (for the scraper).
-MANTLE_PRICING_NAMES: Dict[str, str] = {
-    "GPT-5.5": "openai.gpt-5.5",
-    "GPT-5.4": "openai.gpt-5.4",
-}
+# mantle ListModels endpoint (per region).  NOTE: lives at /v1/models on the
+# mantle host, NOT under the /openai/v1 prefix used for inference.
+MANTLE_LIST_MODELS_URL = "https://bedrock-mantle.{region}.api.aws/v1/models"
+
+
+def get_mantle_model_regions() -> Dict[str, List[str]]:
+    """Effective registry: discovered entries override the static seed.
+
+    Static models missing from the discovered layer are preserved so a partial
+    discovery (e.g. one region probe failing) never removes known models.
+    """
+    if _discovered_model_regions:
+        merged = dict(MANTLE_MODEL_REGIONS)
+        merged.update(_discovered_model_regions)
+        return merged
+    return MANTLE_MODEL_REGIONS
+
+
+def set_discovered_mantle_models(regions: Optional[Dict[str, List[str]]]) -> None:
+    """Replace the discovered layer (called by refresh_mantle_registry)."""
+    global _discovered_model_regions
+    _discovered_model_regions = regions
+
+
+def mantle_display_name(model_id: str) -> str:
+    """Derive the human/pricing-page display name from a mantle model ID.
+
+    "openai.gpt-5.6-sol" → "GPT-5.6 Sol";  "openai.gpt-5.5" → "GPT-5.5".
+    Digit-led tokens attach to the previous token with a hyphen; the rest are
+    capitalized words.  This is the inverse of the normalization used by
+    mantle_pricing_name_to_id, so the two stay consistent for new models.
+    """
+    tokens = model_id.split(".", 1)[-1].split("-")
+    parts: List[str] = []
+    for token in tokens:
+        if parts and token[:1].isdigit():
+            parts[-1] += f"-{token}"
+        elif token.lower().startswith("gpt"):
+            parts.append(token.upper())
+        else:
+            parts.append(token.capitalize())
+    return " ".join(parts)
+
+
+async def discover_mantle_models() -> Dict[str, List[str]]:
+    """Discover mantle-served models via the ListModels API.
+
+    Probes ``GET /v1/models`` (IAM action ``bedrock-mantle:ListModels``) in
+    every candidate region from ``MANTLE_DISCOVERY_REGIONS`` and aggregates a
+    model → available-regions map.  Region order follows the configured
+    candidate order, so the first entry is a stable preferred region.
+
+    Only ``openai.*`` model IDs are kept, and ``openai.gpt-oss-*`` is excluded
+    — the open-weight models run through the standard Bedrock converse path,
+    not the mantle Responses API (see is_openai_mantle_model).
+
+    A region probe failing (permission, throttle, endpoint missing) skips that
+    region with a warning; an empty overall result means callers should keep
+    the previous registry.
+    """
+    import httpx
+
+    # Lazy import: mantle_client imports from this module at module level.
+    from app.services.mantle_client import _signed_headers
+
+    model_regions: Dict[str, List[str]] = {}
+    for region in get_settings().get_mantle_discovery_regions():
+        url = MANTLE_LIST_MODELS_URL.format(region=region)
+        try:
+            headers = await _signed_headers("GET", url, b"", region)
+            async with httpx.AsyncClient(timeout=30.0) as client:
+                resp = await client.get(url, headers=headers)
+            if resp.status_code != 200:
+                logger.warning(
+                    f"mantle ListModels failed in {region}: "
+                    f"status={resp.status_code}, body={resp.text[:200]}"
+                )
+                continue
+            entries = (resp.json() or {}).get("data") or []
+        except Exception as e:
+            logger.warning(f"mantle ListModels probe failed in {region}: {e}")
+            continue
+
+        for entry in entries:
+            model_id = entry.get("id") if isinstance(entry, dict) else None
+            if not model_id or not model_id.startswith("openai."):
+                continue
+            if "gpt-oss" in model_id:
+                continue
+            model_regions.setdefault(model_id, []).append(region)
+
+    if model_regions:
+        logger.info(
+            f"mantle ListModels discovered {len(model_regions)} models: "
+            f"{sorted(model_regions)}"
+        )
+    return model_regions
+
+
+async def refresh_mantle_registry() -> Dict[str, List[str]]:
+    """Refresh the discovered layer from ListModels; returns the new mapping.
+
+    New models (absent from both the static seed and the previous discovered
+    layer) are logged prominently so operators notice launches — but note the
+    model is NOT usable for billing until the pricing update task also finds
+    its price row (calculate_cost raises for unpriced models, and the pricing
+    task runs right after this in the scheduler).
+
+    On empty discovery (all probes failed / no permission) the previous
+    registry is kept untouched.
+    """
+    previous = set(get_mantle_model_regions())
+    discovered = await discover_mantle_models()
+    if not discovered:
+        logger.warning(
+            "mantle model discovery returned nothing "
+            "(missing bedrock-mantle:ListModels permission?); "
+            "keeping existing registry"
+        )
+        return get_mantle_model_regions()
+
+    new_models = set(discovered) - previous
+    if new_models:
+        logger.warning(
+            f"mantle discovery found NEW models not in the static registry: "
+            f"{sorted(new_models)} — they will be routed automatically; "
+            f"verify pricing rows exist after the next pricing update"
+        )
+    set_discovered_mantle_models(discovered)
+    return get_mantle_model_regions()
+
+
+def mantle_pricing_name_to_id(display_name: str) -> Optional[str]:
+    """Map an AWS pricing-page display name to a registry model ID.
+
+    Normalizes "GPT-5.6 Sol" → "gpt-5.6-sol" and matches it against the
+    ``openai.``-suffix of every registry entry, so newly discovered models
+    match their pricing rows without a hand-maintained name table.
+    """
+    normalized = re.sub(r"[\s\-]+", "-", display_name.strip().lower())
+    for model_id in get_mantle_model_regions():
+        if model_id.split(".", 1)[-1] == normalized:
+            return model_id
+    return None
 
 
 def is_openai_mantle_model(model_id: str) -> bool:
@@ -46,7 +209,7 @@ def is_openai_mantle_model(model_id: str) -> bool:
     would wrongly capture the open-weight ``openai.gpt-oss-*`` models, which run
     through the standard Bedrock converse path.
     """
-    return model_id in MANTLE_MODEL_REGIONS
+    return model_id in get_mantle_model_regions()
 
 
 def resolve_mantle_region(model_id: str) -> str:
@@ -56,7 +219,7 @@ def resolve_mantle_region(model_id: str) -> str:
     cross-region latency); otherwise use the model's preferred region.  Raises
     KeyError for non-mantle models — callers guard with is_openai_mantle_model.
     """
-    regions = MANTLE_MODEL_REGIONS[model_id]
+    regions = get_mantle_model_regions()[model_id]
     local = get_settings().AWS_REGION
     return local if local in regions else regions[0]
 
@@ -68,9 +231,9 @@ def get_mantle_models() -> List[Dict]:
     ``list_aws_available_models`` so the frontend renders them uniformly.
     """
     models: List[Dict] = []
-    for model_id in MANTLE_MODEL_REGIONS:
-        # "openai.gpt-5.5" → "GPT-5.5"
-        friendly_name = model_id.split(".", 1)[-1].upper()
+    for model_id in get_mantle_model_regions():
+        # "openai.gpt-5.6-sol" → "GPT-5.6 Sol"
+        friendly_name = mantle_display_name(model_id)
         models.append(
             {
                 "model_id": model_id,

--- a/backend/app/services/pricing_updater.py
+++ b/backend/app/services/pricing_updater.py
@@ -26,7 +26,10 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy import select
 from app.core.config import get_settings
 from app.models.model_pricing import ModelPricing
-from app.services.mantle_models import MANTLE_MODEL_REGIONS, MANTLE_PRICING_NAMES
+from app.services.mantle_models import (
+    get_mantle_model_regions,
+    mantle_pricing_name_to_id,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -820,56 +823,79 @@ class PricingUpdater:
         return pricing_data
 
     def _scrape_openai_text_pricing(self, html: str) -> List[Dict]:
-        """Parse the OpenAI (GPT-5.5/5.4) plain-text pricing table.
+        """Parse the OpenAI (GPT-5.6/5.5/5.4) plain-text pricing table.
 
         These models are served by AWS mantle and do not appear in the
         ``data-pricing-markup`` sections or the Price List API.  On the pricing
-        page they sit in an ordinary ``<table>`` with four columns::
+        page they sit in an ordinary ``<table>``; since the GPT-5.6 launch the
+        table has five columns::
 
-            OpenAI models | Price per 1M input tokens
-                          | Price per 1M cached output tokens
-                          | Price per 1M output tokens
+            OpenAI models | input | cache write | cache read | output   (per 1M)
+
+        where "cache write" is "-" for models without an explicit write price
+        (GPT-5.5/5.4).  Older 4-column rows (no cache-write column) still appear
+        further down the page and are parsed for backward compatibility.
 
         Prices are identical across the model's regions, so rather than parse the
         per-region table headers we map each display name via
-        ``MANTLE_PRICING_NAMES`` and write one row per region from
-        ``MANTLE_MODEL_REGIONS`` — keeping the pricing region keys exactly aligned
-        with ``resolve_mantle_region`` (used by calculate_cost) so every model in
-        the list can always look up a price.
+        ``mantle_pricing_name_to_id`` (normalized against the live registry, so
+        discovered models match without a hand-maintained name table) and write
+        one row per region from the registry — keeping the pricing region keys
+        exactly aligned with ``resolve_mantle_region`` (used by calculate_cost)
+        so every model in the list can always look up a price.
 
-        The "cached output" price is stored in ``cached_input_price_per_token``
-        (the same column Gemini's implicit cache uses), so calculate_cost reads it
-        back uniformly.
+        The cache-read price is stored in ``cached_input_price_per_token`` (the
+        same column Gemini's implicit cache uses).  The cache-write price has no
+        DB column; calculate_cost bills writes at input × 1.25, which matches the
+        published mantle write prices exactly (e.g. GPT-5.6 Sol: 5.00 × 1.25 =
+        6.25).
         """
-        # Locate every <tr> whose first cell is one of the known OpenAI names.
-        # The table uses plain text and "$ 5.50"-style values (space after $).
-        row_re = re.compile(
-            r"<tr>\s*<td>\s*([A-Za-z0-9.\- ]+?)\s*</td>"
-            r"\s*<td>\s*\$\s*([\d.]+)\s*</td>"  # input / 1M
-            r"\s*<td>\s*\$\s*([\d.]+)\s*</td>"  # cached output / 1M
-            r"\s*<td>\s*\$\s*([\d.]+)\s*</td>",  # output / 1M
-            re.IGNORECASE,
-        )
+        row_re = re.compile(r"<tr>\s*(.*?)\s*</tr>", re.IGNORECASE | re.DOTALL)
+        cell_re = re.compile(r"<td>\s*(.*?)\s*</td>", re.IGNORECASE | re.DOTALL)
+        # "$ 5.50" / "$5.00" / "$3.125&nbsp;" — space and trailing entities vary.
+        money_re = re.compile(r"\$\s*([\d.]+)")
 
         # Dedup: display names repeat across the per-region tables, but the prices
         # are identical, so the first occurrence per model is authoritative.
         seen_names: Set[str] = set()
         pricing_data: List[Dict] = []
 
-        for match in row_re.finditer(html):
-            display_name = match.group(1).strip()
-            model_id = MANTLE_PRICING_NAMES.get(display_name)
-            if not model_id or display_name in seen_names:
+        for row_match in row_re.finditer(html):
+            cells = [c.strip() for c in cell_re.findall(row_match.group(1))]
+            if len(cells) not in (4, 5):
+                continue
+            display_name = cells[0]
+            if not display_name.startswith("GPT-") or display_name in seen_names:
+                continue
+            model_id = mantle_pricing_name_to_id(display_name)
+            if not model_id:
+                # Row for a model the registry doesn't know — likely a brand-new
+                # launch discovery hasn't picked up yet.  Loud so operators see it.
+                logger.warning(
+                    f"OpenAI pricing row '{display_name}' has no matching mantle "
+                    f"registry entry; skipping (model not yet discovered?)"
+                )
+                seen_names.add(display_name)
+                continue
+
+            prices = [money_re.search(c) for c in cells[1:]]
+            if len(cells) == 5:
+                # input | cache write (may be "-") | cache read | output
+                input_m, _write_m, cached_m, output_m = prices
+            else:
+                # legacy: input | cache read | output
+                input_m, cached_m, output_m = prices
+            if not (input_m and cached_m and output_m):
                 continue
             seen_names.add(display_name)
 
-            input_per_1m = Decimal(match.group(2))
-            cached_per_1m = Decimal(match.group(3))
-            output_per_1m = Decimal(match.group(4))
+            input_per_1m = Decimal(input_m.group(1))
+            cached_per_1m = Decimal(cached_m.group(1))
+            output_per_1m = Decimal(output_m.group(1))
 
             # Write one row per region the model can be invoked in, keyed by the
             # same region resolve_mantle_region() will produce at billing time.
-            for region in MANTLE_MODEL_REGIONS.get(model_id, []):
+            for region in get_mantle_model_regions().get(model_id, []):
                 pricing_data.append(
                     {
                         "model_id": model_id,

--- a/backend/app/tasks/pricing_tasks.py
+++ b/backend/app/tasks/pricing_tasks.py
@@ -45,6 +45,19 @@ async def refresh_profile_cache_task():
         logger.error(f"Profile cache refresh task failed: {e}", exc_info=True)
 
 
+async def refresh_mantle_registry_task():
+    """Background task to discover mantle (OpenAI) models via ListModels."""
+    logger.info("Starting mantle model discovery task...")
+
+    try:
+        from app.services.mantle_models import refresh_mantle_registry
+
+        registry = await refresh_mantle_registry()
+        logger.info(f"Mantle model discovery completed: {len(registry)} models")
+    except Exception as e:
+        logger.error(f"Mantle model discovery task failed: {e}", exc_info=True)
+
+
 async def update_gemini_pricing_task():
     """Background task to update Google Gemini model pricing."""
     logger.info("Starting Gemini pricing update task...")
@@ -81,6 +94,16 @@ def start_scheduler():
         replace_existing=True,
     )
 
+    # Mantle model discovery MUST run BEFORE the AWS pricing update so newly
+    # discovered models get their pricing-page rows matched in the same cycle.
+    scheduler.add_job(
+        refresh_mantle_registry_task,
+        trigger=CronTrigger(hour=1, minute=55),
+        id="refresh_mantle_registry",
+        name="Discover mantle (OpenAI) models via ListModels",
+        replace_existing=True,
+    )
+
     # Schedule AWS pricing update daily at 2:00 AM UTC
     scheduler.add_job(
         update_pricing_task,
@@ -101,7 +124,8 @@ def start_scheduler():
 
     scheduler.start()
     logger.info(
-        "Scheduler started (profile cache: 1:50, AWS pricing: 2:00, Gemini: 2:30 UTC)"
+        "Scheduler started (profile cache: 1:50, mantle discovery: 1:55, "
+        "AWS pricing: 2:00, Gemini: 2:30 UTC)"
     )
 
 

--- a/backend/main.py
+++ b/backend/main.py
@@ -55,6 +55,17 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
     await bedrock.refresh_profile_cache()
     logger.info("Inference profile cache populated")
 
+    # Discover mantle (OpenAI GPT-5.x) models BEFORE pricing init so the first
+    # pricing run matches rows for newly launched models. Non-fatal: falls back
+    # to the static registry in mantle_models.py.
+    from app.services.mantle_models import refresh_mantle_registry
+
+    try:
+        mantle_registry = await refresh_mantle_registry()
+        logger.info(f"Mantle model registry ready: {len(mantle_registry)} models")
+    except Exception as e:
+        logger.warning(f"Mantle model discovery failed (using static registry): {e}")
+
     # Initialize pricing data if database is empty
     from app.core.database import async_session_maker
     from app.services.pricing_updater import PricingUpdater

--- a/backend/tests/test_mantle_registry.py
+++ b/backend/tests/test_mantle_registry.py
@@ -1,0 +1,87 @@
+"""Tests for the mantle (OpenAI-on-Bedrock) model registry and discovery."""
+
+import pytest
+
+from app.services import mantle_models as mm
+
+
+@pytest.fixture(autouse=True)
+def _reset_discovered_layer():
+    """Each test starts from the static seed only."""
+    mm.set_discovered_mantle_models(None)
+    yield
+    mm.set_discovered_mantle_models(None)
+
+
+class TestRegistryMerge:
+    def test_static_seed_without_discovery(self):
+        regions = mm.get_mantle_model_regions()
+        assert regions == mm.MANTLE_MODEL_REGIONS
+
+    def test_discovered_overrides_static_per_model(self):
+        mm.set_discovered_mantle_models({"openai.gpt-5.6-sol": ["us-west-2"]})
+        regions = mm.get_mantle_model_regions()
+        assert regions["openai.gpt-5.6-sol"] == ["us-west-2"]
+        # Static models absent from discovery are preserved
+        assert regions["openai.gpt-5.5"] == mm.MANTLE_MODEL_REGIONS["openai.gpt-5.5"]
+
+    def test_discovered_new_model_is_routable(self):
+        mm.set_discovered_mantle_models({"openai.gpt-5.7": ["us-east-2"]})
+        assert mm.is_openai_mantle_model("openai.gpt-5.7")
+        assert mm.resolve_mantle_region("openai.gpt-5.7") == "us-east-2"
+
+    def test_gpt_oss_never_matches(self):
+        assert not mm.is_openai_mantle_model("openai.gpt-oss-120b")
+
+
+class TestDisplayNames:
+    @pytest.mark.parametrize(
+        "model_id,expected",
+        [
+            ("openai.gpt-5.6-sol", "GPT-5.6 Sol"),
+            ("openai.gpt-5.6-terra", "GPT-5.6 Terra"),
+            ("openai.gpt-5.5", "GPT-5.5"),
+            ("openai.gpt-5.4", "GPT-5.4"),
+        ],
+    )
+    def test_display_name(self, model_id, expected):
+        assert mm.mantle_display_name(model_id) == expected
+
+    @pytest.mark.parametrize(
+        "display_name,expected",
+        [
+            ("GPT-5.6 Sol", "openai.gpt-5.6-sol"),
+            ("GPT-5.6 Luna", "openai.gpt-5.6-luna"),
+            ("GPT-5.5", "openai.gpt-5.5"),
+            ("GPT-9 Unknown", None),
+        ],
+    )
+    def test_pricing_name_to_id(self, display_name, expected):
+        assert mm.mantle_pricing_name_to_id(display_name) == expected
+
+    def test_round_trip_for_all_registry_models(self):
+        for model_id in mm.get_mantle_model_regions():
+            name = mm.mantle_display_name(model_id)
+            assert mm.mantle_pricing_name_to_id(name) == model_id
+
+
+class TestRefreshRegistry:
+    @pytest.mark.asyncio
+    async def test_empty_discovery_keeps_previous_registry(self, monkeypatch):
+        async def _no_models():
+            return {}
+
+        monkeypatch.setattr(mm, "discover_mantle_models", _no_models)
+        registry = await mm.refresh_mantle_registry()
+        assert registry == mm.MANTLE_MODEL_REGIONS
+
+    @pytest.mark.asyncio
+    async def test_discovery_result_is_applied(self, monkeypatch):
+        async def _models():
+            return {"openai.gpt-5.7": ["us-east-1", "us-east-2"]}
+
+        monkeypatch.setattr(mm, "discover_mantle_models", _models)
+        registry = await mm.refresh_mantle_registry()
+        assert registry["openai.gpt-5.7"] == ["us-east-1", "us-east-2"]
+        # Static seed still present
+        assert "openai.gpt-5.5" in registry

--- a/iac/modules/eks-addons/main.tf
+++ b/iac/modules/eks-addons/main.tf
@@ -100,9 +100,11 @@ resource "aws_iam_policy" "backend_bedrock" {
         Resource = "*"
       },
       {
-        # OpenAI GPT-5.5/5.4 served by the AWS "mantle" inference engine use a
-        # distinct "bedrock-mantle" IAM service prefix that "bedrock:*" does not
-        # cover, so it must be granted explicitly.
+        # OpenAI GPT-5.x models served by the AWS "mantle" inference engine use
+        # a distinct "bedrock-mantle" IAM service prefix that "bedrock:*" does
+        # not cover, so it must be granted explicitly. Covers both inference
+        # (InvokeModel) and model discovery (ListModels, used by the backend's
+        # mantle registry refresh task).
         Sid    = "MantleOpenAIModels"
         Effect = "Allow"
         Action = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,12 @@ dependencies = [
     "opentelemetry-sdk-extension-aws>=2.0.0",
 ]
 
+[tool.uv]
+# semgrep (dev-only) pins click~=8.1.8, which drags the whole lockfile onto a
+# version with PYSEC-2026-2132 (fixed in 8.3.3) and fails pip-audit. Override
+# within the same major version; semgrep's CLI works fine on click 8.3.
+override-dependencies = ["click>=8.3.3,<9"]
+
 [dependency-groups]
 dev = [
     "pre-commit>=4.3.0",

--- a/uv.lock
+++ b/uv.lock
@@ -2,6 +2,9 @@ version = 1
 revision = 3
 requires-python = ">=3.12"
 
+[manifest]
+overrides = [{ name = "click", specifier = ">=8.3.3,<9" }]
+
 [[package]]
 name = "aioboto3"
 version = "15.5.0"
@@ -581,14 +584,14 @@ wheels = [
 
 [[package]]
 name = "click"
-version = "8.1.8"
+version = "8.4.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b9/2e/0090cbf739cee7d23781ad4b89a9894a41538e4fcf4c31dcdd705b78eb8b/click-8.1.8.tar.gz", hash = "sha256:ed53c9d8990d83c2a27deae68e4ee337473f6330c040a31d4225c9574d16096a", size = 226593, upload-time = "2024-12-21T18:38:44.339Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/76/d4/81420972a676e8ffea40450d8c8c92943e7218a78fe9b64359836cc9876b/click-8.4.2.tar.gz", hash = "sha256:9a6cea6e60b17ebe0a44c5cc636d94f09bd66142c1cd7d8b4cd731c4917a15f6", size = 338000, upload-time = "2026-06-24T17:45:15.148Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7e/d4/7ebdbd03970677812aac39c869717059dbb71a4cfc033ca6e5221787892c/click-8.1.8-py3-none-any.whl", hash = "sha256:63c132bbbed01578a06712a2d1f497bb62d9c1c0d329b7903a866228027263b2", size = 98188, upload-time = "2024-12-21T18:38:41.666Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/e2/79c688af8b210d232694e31e59da9f6ec747bae31c3f5946e4e9b98860d5/click-8.4.2-py3-none-any.whl", hash = "sha256:e6f9f66136c816745b9d65817da91d61d957fb16e02e4dcd0552553c5a197b76", size = 119243, upload-time = "2026-06-24T17:45:13.73Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## 背景

AWS Bedrock 于 2026-07-13 上线 OpenAI GPT-5.6 系列（Sol/Terra/Luna，走 bedrock-mantle Responses API）。此前 mantle 模型靠静态注册表手工维护，每次新模型上线都需要改代码。本 PR 一次性解决：补齐 GPT-5.6 支持，并新增自动发现机制，之后新模型上线代码零改动。

## 变更内容

### GPT-5.6 支持
- 注册三个型号及可用 region（来源：AWS Bedrock model cards）：
  - `openai.gpt-5.6-sol` — us-east-1, us-east-2
  - `openai.gpt-5.6-terra` / `openai.gpt-5.6-luna` — us-east-1, us-east-2, us-west-2
- 定价 scraper 适配定价页新的**五列表格**（GPT-5.6 上线后新增 cache write 列，旧四列正则完全匹配不到），兼容旧格式；cache write 不单独入库——calculate_cost 按 input × 1.25 计费，与官方公布写入价一致（Sol: 5.00 × 1.25 = 6.25）
- `gpt-5.6` 加入 reasoning 模型列表（不传 temperature/top_p）

### mantle 模型自动发现
- 注册表改为两层：**静态种子表**（兜底）+ **ListModels 动态发现层**（按模型覆盖静态表，静态模型永不消失）
- 探测 `GET /v1/models`（IAM action `bedrock-mantle:ListModels`，注意路径在 mantle host 的 `/v1` 下、不在 `/openai/v1` 前缀下），region 列表可配置（`MANTLE_DISCOVERY_REGIONS`，默认 us-east-1/us-east-2/us-west-2）
- 调度：启动时（定价初始化前）+ 每日 UTC 1:55（刻意排在 2:00 定价更新前，新模型和价格同周期就位）+ 管理端手动触发定价更新时
- 降级安全：发现失败（无权限/限流）保留原注册表，只可能漏新模型，不影响现有路由
- 显示名与定价页名称改为双向推导（`openai.gpt-5.6-sol` ⇄ `GPT-5.6 Sol`），删除手工名称映射表
- 可观测性：发现新模型、定价页出现未知 GPT 行时打 WARNING

### IAM
现有 Terraform 已授 `bedrock-mantle:*`，已覆盖 ListModels，**无需权限变更**（仅更新注释）。

## 验证
- 真实定价页 HTML：11 条价格记录全部正确提取（5 模型 × 各自 region），价格与官网一致
- 全链路模拟：注入虚构 `openai.gpt-5.7` 后路由/显示名/定价匹配全部自动工作
- 无权限场景实测：ListModels 返回 401 时正确降级到静态表
- 新增 15 个测试（`test_mantle_registry.py`）全过；全套测试 112 过 / 4 失败（4 个为 main 分支既有失败，与本 PR 无关，已用 git stash 验证）
- pre-commit 全过