### PR TITLE
refactor: mantle 注册表清理（#81 代码审查跟进）

### DIFF
--- a/backend/app/api/admin/endpoints/models.py
+++ b/backend/app/api/admin/endpoints/models.py
@@ -165,7 +165,7 @@ async def list_aws_available_models(
             except Exception as e:
                 logger.warning(f"Failed to fetch Gemini models (non-fatal): {e}")
 
-        # Inject OpenAI GPT-5.5/5.4 (mantle) — not discoverable via Bedrock APIs
+        # Inject mantle-served OpenAI models — not discoverable via Bedrock APIs
         mantle_models = get_mantle_models()
         models.extend(mantle_models)
         logger.info(f"Added {len(mantle_models)} mantle models to available list")

--- a/backend/app/api/admin/endpoints/pricing.py
+++ b/backend/app/api/admin/endpoints/pricing.py
@@ -31,15 +31,6 @@ async def update_pricing(
         Update statistics
     """
     try:
-        # Refresh the mantle (OpenAI) model registry first so pricing rows for
-        # newly launched models can be matched in this same update.
-        from app.services.mantle_models import refresh_mantle_registry
-
-        try:
-            await refresh_mantle_registry()
-        except Exception as e:
-            logger.warning(f"Mantle model discovery failed (non-fatal): {e}")
-
         updater = PricingUpdater(db)
         stats = await updater.update_all_pricing()
 

--- a/backend/app/api/anthropic/endpoints/messages.py
+++ b/backend/app/api/anthropic/endpoints/messages.py
@@ -175,7 +175,7 @@ async def create_message(
                 start_time=start_time,
             )
 
-        # Route OpenAI GPT-5.5/5.4 (mantle) to the Responses API
+        # Route mantle-served OpenAI models to the Responses API
         if _is_mantle_model(request_data.model):
             return await _handle_mantle_via_anthropic(
                 request_data=request_data,
@@ -959,7 +959,7 @@ async def _stream_gemini_as_anthropic(
 
 
 # ---------------------------------------------------------------------------
-# OpenAI GPT-5.5/5.4 (mantle) routing via Anthropic Messages endpoint
+# Mantle (OpenAI) routing via Anthropic Messages endpoint
 # ---------------------------------------------------------------------------
 
 
@@ -1004,7 +1004,7 @@ async def _handle_mantle_via_anthropic(
     start_time: float,
 ):
     """
-    Forward a GPT-5.5/5.4 (mantle) request received on the Anthropic endpoint.
+    Forward a mantle (OpenAI) request received on the Anthropic endpoint.
 
     Converts Anthropic-format messages to OpenAI-style messages, calls the
     MantleClient (which translates to the Responses API and signs with SigV4),
@@ -1107,7 +1107,7 @@ async def _stream_mantle_as_anthropic(
     start_time: float,
 ) -> AsyncGenerator[str, None]:
     """
-    Stream a mantle (GPT-5.5/5.4) response converted to Anthropic SSE format.
+    Stream a mantle (OpenAI) response converted to Anthropic SSE format.
 
     MantleClient.invoke_stream yields OpenAI-format SSE chunks; we convert each
     to Anthropic streaming events (mirrors the Gemini streaming bridge).

--- a/backend/app/api/v1/endpoints/chat.py
+++ b/backend/app/api/v1/endpoints/chat.py
@@ -229,7 +229,7 @@ async def create_chat_completion(
                 start_time=start_time,
             )
 
-        # Route OpenAI GPT-5.5/5.4 (mantle) to the Responses API directly
+        # Route mantle-served OpenAI models to the Responses API directly
         if is_openai_mantle_model(request_data.model):
             return await _handle_mantle_request(
                 request_data=request_data,
@@ -564,7 +564,7 @@ async def _handle_mantle_request(
     start_time: float,
 ):
     """
-    Forward a chat completion request to AWS mantle (OpenAI GPT-5.5/5.4).
+    Forward a chat completion request to AWS mantle (OpenAI models).
 
     Converts the OpenAI ChatCompletions payload to the Responses API internally;
     the request is routed (and SigV4-signed) to the model's region automatically.
@@ -633,7 +633,7 @@ async def stream_mantle_completion(
     start_time: float,
 ) -> AsyncGenerator[str, None]:
     """
-    Stream a mantle (GPT-5.5/5.4) completion via the Responses API.
+    Stream a mantle (OpenAI) completion via the Responses API.
 
     MantleClient.invoke_stream yields OpenAI-format SSE chunks; we forward them
     verbatim and extract usage from any chunk that carries a usage object.

--- a/backend/app/api/v1/endpoints/responses.py
+++ b/backend/app/api/v1/endpoints/responses.py
@@ -1,7 +1,7 @@
 """
 OpenAI Responses API endpoint (native passthrough for AWS mantle).
 
-GPT-5.5 / GPT-5.4 are served by AWS's "mantle" inference engine through the
+Mantle-served OpenAI models (see the mantle_models registry) go through the
 **OpenAI Responses API**. The OpenAI-compatible ``/v1/chat/completions`` and the
 Anthropic ``/v1/messages`` endpoints translate to/from the Responses format,
 which necessarily flattens Responses-only features (built-in tools, multimodal
@@ -36,7 +36,10 @@ from app.models.model import Model
 from app.models.token import APIToken
 from app.services.background_tasks import BackgroundTaskManager
 from app.services.mantle_client import MantleClient
-from app.services.mantle_models import is_openai_mantle_model
+from app.services.mantle_models import (
+    get_mantle_model_regions,
+    is_openai_mantle_model,
+)
 
 router = APIRouter()
 logger = logging.getLogger(__name__)
@@ -68,7 +71,7 @@ async def create_response(
     """
     Create a model response (OpenAI Responses API, native passthrough).
 
-    Only mantle-served models (GPT-5.5/5.4) are accepted here — other models do
+    Only mantle-served models (see mantle_models registry) are accepted — others do
     not have a Responses API backend. The request body is forwarded to mantle
     verbatim and the native response is returned unchanged.
     """
@@ -102,7 +105,7 @@ async def create_response(
             status_code=400,
             detail=(
                 f"Model '{model}' is not available on the Responses API. "
-                "This endpoint serves OpenAI GPT-5.6/5.5/5.4 (mantle) only; "
+                f"Available models: {sorted(get_mantle_model_regions())}; "
                 "use /v1/chat/completions for other models."
             ),
         )

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -74,7 +74,7 @@ class Settings(BaseSettings):
         description="Google Cloud region for Vertex AI",
     )
 
-    # OpenAI-on-Bedrock (mantle) settings — GPT-5.6/5.5/5.4 via Responses API
+    # OpenAI-on-Bedrock (mantle) settings — GPT-5.x via Responses API
     MANTLE_SIGV4_SERVICE: str = Field(
         default="bedrock",
         description="SigV4 service name used to sign mantle (OpenAI Responses API) requests. "
@@ -245,34 +245,27 @@ class Settings(BaseSettings):
         "Empty string disables model degradation.",
     )
 
+    @staticmethod
+    def _csv_list(value: str) -> List[str]:
+        """Parse a comma-separated setting into a list (strips stray quotes)."""
+        cleaned = (value or "").strip('"').strip("'")
+        return [item.strip() for item in cleaned.split(",") if item.strip()]
+
     def get_mantle_discovery_regions(self) -> List[str]:
         """Get mantle ListModels probe regions as a list."""
-        regions = (self.MANTLE_DISCOVERY_REGIONS or "").strip('"').strip("'")
-        return [r.strip() for r in regions.split(",") if r.strip()]
+        return self._csv_list(self.MANTLE_DISCOVERY_REGIONS)
 
     def get_allowed_origins(self) -> List[str]:
         """Get CORS allowed origins as a list."""
-        if not self.ALLOWED_ORIGINS or self.ALLOWED_ORIGINS == "":
-            return ["*"]
-        # Remove quotes if present
-        origins = self.ALLOWED_ORIGINS.strip('"').strip("'")
-        return [origin.strip() for origin in origins.split(",") if origin.strip()]
+        return self._csv_list(self.ALLOWED_ORIGINS) or ["*"]
 
     def get_microsoft_redirect_uris(self) -> List[str]:
         """Get allowed Microsoft OAuth redirect URIs as a list."""
-        if not self.MICROSOFT_REDIRECT_URIS:
-            return []
-        # Remove quotes if present
-        uris = self.MICROSOFT_REDIRECT_URIS.strip('"').strip("'")
-        return [uri.strip() for uri in uris.split(",") if uri.strip()]
+        return self._csv_list(self.MICROSOFT_REDIRECT_URIS)
 
     def get_cognito_redirect_uris(self) -> List[str]:
         """Get allowed Cognito OAuth redirect URIs as a list."""
-        if not self.COGNITO_REDIRECT_URIS:
-            return []
-        # Remove quotes if present
-        uris = self.COGNITO_REDIRECT_URIS.strip('"').strip("'")
-        return [uri.strip() for uri in uris.split(",") if uri.strip()]
+        return self._csv_list(self.COGNITO_REDIRECT_URIS)
 
     @validator("LOG_LEVEL")
     def validate_log_level(cls, v):

--- a/backend/app/services/mantle_client.py
+++ b/backend/app/services/mantle_client.py
@@ -1,7 +1,7 @@
 """
 OpenAI-on-Bedrock (mantle) API client service.
 
-GPT-5.5 / GPT-5.4 are served by AWS's "mantle" inference engine through the
+Mantle-served OpenAI models (see the mantle_models registry) go through the
 **OpenAI Responses API** (``https://bedrock-mantle.{region}.api.aws/openai/v1``
 → ``/responses``), not through the boto3 ``converse`` / ``invoke_model`` paths.
 
@@ -21,49 +21,10 @@ import uuid
 from typing import Any, AsyncGenerator, Dict, List, Optional, Tuple
 
 import httpx
-from botocore.auth import SigV4Auth
-from botocore.awsrequest import AWSRequest
-
-from app.core.config import get_settings
 from app.services.mantle_models import MANTLE_BASE_URL, resolve_mantle_region
+from app.services.mantle_signing import signed_headers
 
 logger = logging.getLogger(__name__)
-
-
-# ---------------------------------------------------------------------------
-# SigV4 signing
-# ---------------------------------------------------------------------------
-
-
-async def _signed_headers(
-    method: str, url: str, body_bytes: bytes, region: str
-) -> Dict[str, str]:
-    """Return SigV4-signed headers for a mantle request.
-
-    Credentials come from the shared BedrockClient aioboto3 session (reuses the
-    EKS Pod IRSA/STS chain, including a SessionToken → ``X-Amz-Security-Token``).
-    In aiobotocore both ``get_credentials`` and ``get_frozen_credentials`` are
-    coroutines and must be awaited (unlike sync botocore).
-
-    The signature is computed over the EXACT *body_bytes* that will be sent.
-    """
-    from app.services.bedrock import BedrockClient
-
-    session = BedrockClient.get_instance().session
-    creds = await session.get_credentials()
-    if creds is None:
-        raise RuntimeError("No AWS credentials available to sign mantle request")
-    frozen = await creds.get_frozen_credentials()
-
-    service = get_settings().MANTLE_SIGV4_SERVICE
-    aws_req = AWSRequest(
-        method=method,
-        url=url,
-        data=body_bytes,
-        headers={"Content-Type": "application/json"},
-    )
-    SigV4Auth(frozen, service, region).add_auth(aws_req)
-    return dict(aws_req.headers)
 
 
 # ---------------------------------------------------------------------------
@@ -241,7 +202,11 @@ def _openai_tool_choice_to_responses(tool_choice: Any) -> Optional[Any]:
     return None
 
 
-_REASONING_MODEL_PATTERNS = ("gpt-5.6", "gpt-5.5", "o1", "o3", "o4")
+# Model families whose mantle-served members are reasoning models (reject
+# temperature/top_p).  Family prefixes rather than exact versions so
+# auto-discovered future releases (e.g. gpt-5.7) are classified without a code
+# change.  gpt-5.4 included: it is version-gated the same way by AWS.
+_REASONING_MODEL_PATTERNS = ("gpt-5.", "gpt-6.", "o1", "o3", "o4")
 
 
 def _is_reasoning_model(model: str) -> bool:
@@ -420,7 +385,7 @@ def extract_cached_tokens_from_chunk(data: dict) -> Optional[int]:
 
 
 class MantleClient:
-    """Client for the OpenAI Responses API served by AWS mantle (GPT-5.5/5.4)."""
+    """Client for the OpenAI Responses API served by AWS mantle."""
 
     @staticmethod
     def _endpoint(model: str) -> Tuple[str, str]:
@@ -462,7 +427,7 @@ class MantleClient:
         send_body["stream"] = False
         cls._strip_unsupported_params(send_body)
         body_bytes = json.dumps(send_body).encode("utf-8")
-        headers = await _signed_headers("POST", url, body_bytes, region)
+        headers = await signed_headers("POST", url, body_bytes, region)
 
         async with httpx.AsyncClient(timeout=3600) as client:
             resp = await client.post(url, headers=headers, content=body_bytes)
@@ -496,7 +461,7 @@ class MantleClient:
         send_body["stream"] = True
         cls._strip_unsupported_params(send_body)
         body_bytes = json.dumps(send_body).encode("utf-8")
-        headers = await _signed_headers("POST", url, body_bytes, region)
+        headers = await signed_headers("POST", url, body_bytes, region)
         headers["Accept"] = "text/event-stream"
 
         async with httpx.AsyncClient(timeout=3600) as client:
@@ -523,7 +488,7 @@ class MantleClient:
         body = _openai_to_responses(payload)
         body["stream"] = False
         body_bytes = json.dumps(body).encode("utf-8")
-        headers = await _signed_headers("POST", url, body_bytes, region)
+        headers = await signed_headers("POST", url, body_bytes, region)
         request_id = f"chatcmpl-{uuid.uuid4().hex}"
 
         async with httpx.AsyncClient(timeout=3600) as client:
@@ -558,7 +523,7 @@ class MantleClient:
         body = _openai_to_responses(payload)
         body["stream"] = True
         body_bytes = json.dumps(body).encode("utf-8")
-        headers = await _signed_headers("POST", url, body_bytes, region)
+        headers = await signed_headers("POST", url, body_bytes, region)
         headers["Accept"] = "text/event-stream"
 
         chunk_id = f"chatcmpl-{uuid.uuid4().hex}"

--- a/backend/app/services/mantle_models.py
+++ b/backend/app/services/mantle_models.py
@@ -1,12 +1,11 @@
 """
 OpenAI-on-Bedrock (mantle) model registry.
 
-GPT-5.6 (Sol/Terra/Luna) and GPT-5.5 / GPT-5.4 are served by AWS's "mantle"
-inference engine through the
-OpenAI Responses API (``https://bedrock-mantle.{region}.api.aws/openai/v1``),
-**not** through the standard boto3 ``converse`` / ``invoke_model`` paths.  They
-do not appear in ``list-foundation-models`` / ``list-inference-profiles`` or the
-Price List API, so they need their own static registry:
+Mantle-served OpenAI models (GPT-5.x) go through the OpenAI Responses API
+(``https://bedrock-mantle.{region}.api.aws/openai/v1``), **not** through the
+standard boto3 ``converse`` / ``invoke_model`` paths.  They do not appear in
+``list-foundation-models`` / ``list-inference-profiles`` or the Price List
+API, so they need their own registry:
 
   * routing — each model is only available in specific regions, and requests
     must be sent to a region where the model lives (independent of the local
@@ -24,15 +23,18 @@ The registry has two layers:
     fallback;
   * a discovered layer populated by ``refresh_mantle_registry()``, which calls
     the mantle ``ListModels`` API (``GET /v1/models``, IAM action
-    ``bedrock-mantle:ListModels``) per candidate region at startup and on a
-    daily schedule.  Discovered entries override the static seed per model;
-    static models never disappear, so a failed discovery can only miss NEW
-    models, never break existing routing.
+    ``bedrock-mantle:ListModels``) per candidate region at startup and before
+    every pricing update.  Discovered entries override the static seed per
+    model; static models never disappear, so a failed discovery can only miss
+    NEW models, never break existing routing.
 """
 
+import asyncio
 import logging
 import re
 from typing import Dict, List, Optional
+
+import httpx
 
 from app.core.config import get_settings
 
@@ -50,8 +52,15 @@ MANTLE_MODEL_REGIONS: Dict[str, List[str]] = {
     "openai.gpt-5.4": ["us-east-2", "us-west-2"],
 }
 
-# Discovered layer — set by refresh_mantle_registry(), None until first run.
-_discovered_model_regions: Optional[Dict[str, List[str]]] = None
+# Effective registry served to all callers.  Starts as the static seed;
+# refresh_mantle_registry() replaces it with {**static, **discovered} so the
+# merge cost is paid once per refresh, not on every request.
+_model_regions: Dict[str, List[str]] = MANTLE_MODEL_REGIONS
+
+# Escape hatch for models whose AWS display name is not a mechanical transform
+# of the model ID (see mantle_display_name).  Empty today; add an entry here
+# instead of patching the derivation heuristics when AWS breaks the convention.
+MANTLE_DISPLAY_NAME_OVERRIDES: Dict[str, str] = {}
 
 # mantle OpenAI-compatible endpoint base URL (per region).
 MANTLE_BASE_URL = "https://bedrock-mantle.{region}.api.aws/openai/v1"
@@ -62,51 +71,72 @@ MANTLE_LIST_MODELS_URL = "https://bedrock-mantle.{region}.api.aws/v1/models"
 
 
 def get_mantle_model_regions() -> Dict[str, List[str]]:
-    """Effective registry: discovered entries override the static seed.
-
-    Static models missing from the discovered layer are preserved so a partial
-    discovery (e.g. one region probe failing) never removes known models.
-    """
-    if _discovered_model_regions:
-        merged = dict(MANTLE_MODEL_REGIONS)
-        merged.update(_discovered_model_regions)
-        return merged
-    return MANTLE_MODEL_REGIONS
-
-
-def set_discovered_mantle_models(regions: Optional[Dict[str, List[str]]]) -> None:
-    """Replace the discovered layer (called by refresh_mantle_registry)."""
-    global _discovered_model_regions
-    _discovered_model_regions = regions
+    """Effective registry: static seed, overridden per model by discovery."""
+    return _model_regions
 
 
 def mantle_display_name(model_id: str) -> str:
     """Derive the human/pricing-page display name from a mantle model ID.
 
     "openai.gpt-5.6-sol" → "GPT-5.6 Sol";  "openai.gpt-5.5" → "GPT-5.5".
-    Digit-led tokens attach to the previous token with a hyphen; the rest are
-    capitalized words.  This is the inverse of the normalization used by
-    mantle_pricing_name_to_id, so the two stay consistent for new models.
+    Splits the ID suffix before letter-led tokens only, so version dots and
+    digits stay attached.  Kept consistent with the normalization in
+    mantle_pricing_name_to_id so derived names round-trip.  For models whose
+    AWS name breaks this convention, add a MANTLE_DISPLAY_NAME_OVERRIDES entry.
     """
-    tokens = model_id.split(".", 1)[-1].split("-")
-    parts: List[str] = []
-    for token in tokens:
-        if parts and token[:1].isdigit():
-            parts[-1] += f"-{token}"
-        elif token.lower().startswith("gpt"):
-            parts.append(token.upper())
-        else:
-            parts.append(token.capitalize())
-    return " ".join(parts)
+    override = MANTLE_DISPLAY_NAME_OVERRIDES.get(model_id)
+    if override:
+        return override
+    first, *rest = re.split(r"-(?=[a-z])", model_id.split(".", 1)[-1])
+    return " ".join([first.upper(), *map(str.capitalize, rest)])
+
+
+def mantle_pricing_name_to_id(display_name: str) -> Optional[str]:
+    """Map an AWS pricing-page display name to a registry model ID.
+
+    Normalizes "GPT-5.6 Sol" → "gpt-5.6-sol" and matches it against the
+    ``openai.``-suffix of every registry entry, so newly discovered models
+    match their pricing rows without a hand-maintained name table.
+    """
+    normalized = re.sub(r"[\s\-]+", "-", display_name.strip().lower())
+    for model_id in _model_regions:
+        if model_id.split(".", 1)[-1] == normalized:
+            return model_id
+    return None
+
+
+async def _probe_region_models(client: httpx.AsyncClient, region: str) -> List[str]:
+    """List mantle model IDs available in one region ([] on any failure)."""
+    # Lazy import: mantle_signing pulls in BedrockClient at call time.
+    from app.services.mantle_signing import signed_headers
+
+    url = MANTLE_LIST_MODELS_URL.format(region=region)
+    try:
+        headers = await signed_headers("GET", url, b"", region)
+        resp = await client.get(url, headers=headers)
+        if resp.status_code != 200:
+            logger.warning(
+                f"mantle ListModels failed in {region}: "
+                f"status={resp.status_code}, body={resp.text[:200]}"
+            )
+            return []
+        entries = (resp.json() or {}).get("data") or []
+    except Exception as e:
+        logger.warning(f"mantle ListModels probe failed in {region}: {e}")
+        return []
+    return [
+        entry["id"] for entry in entries if isinstance(entry, dict) and entry.get("id")
+    ]
 
 
 async def discover_mantle_models() -> Dict[str, List[str]]:
     """Discover mantle-served models via the ListModels API.
 
     Probes ``GET /v1/models`` (IAM action ``bedrock-mantle:ListModels``) in
-    every candidate region from ``MANTLE_DISCOVERY_REGIONS`` and aggregates a
-    model → available-regions map.  Region order follows the configured
-    candidate order, so the first entry is a stable preferred region.
+    every candidate region from ``MANTLE_DISCOVERY_REGIONS`` concurrently and
+    aggregates a model → available-regions map.  Region order follows the
+    configured candidate order, so the first entry is a stable preferred
+    region.
 
     Only ``openai.*`` model IDs are kept, and ``openai.gpt-oss-*`` is excluded
     — the open-weight models run through the standard Bedrock converse path,
@@ -116,34 +146,19 @@ async def discover_mantle_models() -> Dict[str, List[str]]:
     region with a warning; an empty overall result means callers should keep
     the previous registry.
     """
-    import httpx
+    regions = get_settings().get_mantle_discovery_regions()
+    if not regions:
+        return {}
 
-    # Lazy import: mantle_client imports from this module at module level.
-    from app.services.mantle_client import _signed_headers
+    async with httpx.AsyncClient(timeout=30.0) as client:
+        results = await asyncio.gather(
+            *(_probe_region_models(client, region) for region in regions)
+        )
 
     model_regions: Dict[str, List[str]] = {}
-    for region in get_settings().get_mantle_discovery_regions():
-        url = MANTLE_LIST_MODELS_URL.format(region=region)
-        try:
-            headers = await _signed_headers("GET", url, b"", region)
-            async with httpx.AsyncClient(timeout=30.0) as client:
-                resp = await client.get(url, headers=headers)
-            if resp.status_code != 200:
-                logger.warning(
-                    f"mantle ListModels failed in {region}: "
-                    f"status={resp.status_code}, body={resp.text[:200]}"
-                )
-                continue
-            entries = (resp.json() or {}).get("data") or []
-        except Exception as e:
-            logger.warning(f"mantle ListModels probe failed in {region}: {e}")
-            continue
-
-        for entry in entries:
-            model_id = entry.get("id") if isinstance(entry, dict) else None
-            if not model_id or not model_id.startswith("openai."):
-                continue
-            if "gpt-oss" in model_id:
+    for region, model_ids in zip(regions, results):
+        for model_id in model_ids:
+            if not model_id.startswith("openai.") or "gpt-oss" in model_id:
                 continue
             model_regions.setdefault(model_id, []).append(region)
 
@@ -156,50 +171,40 @@ async def discover_mantle_models() -> Dict[str, List[str]]:
 
 
 async def refresh_mantle_registry() -> Dict[str, List[str]]:
-    """Refresh the discovered layer from ListModels; returns the new mapping.
+    """Refresh the effective registry from ListModels; returns the new mapping.
 
-    New models (absent from both the static seed and the previous discovered
-    layer) are logged prominently so operators notice launches — but note the
-    model is NOT usable for billing until the pricing update task also finds
-    its price row (calculate_cost raises for unpriced models, and the pricing
-    task runs right after this in the scheduler).
+    New models (absent from the current registry) are logged prominently so
+    operators notice launches — but note the model is NOT usable for billing
+    until the pricing update also finds its price row (calculate_cost raises
+    for unpriced models; update_all_pricing calls this before matching rows).
 
-    On empty discovery (all probes failed / no permission) the previous
-    registry is kept untouched.
+    Never raises: discovery is best-effort, and on empty discovery (probes
+    failed / no permission / discovery disabled) the previous registry is kept.
     """
-    previous = set(get_mantle_model_regions())
-    discovered = await discover_mantle_models()
-    if not discovered:
-        logger.warning(
-            "mantle model discovery returned nothing "
-            "(missing bedrock-mantle:ListModels permission?); "
-            "keeping existing registry"
-        )
-        return get_mantle_model_regions()
+    global _model_regions
 
-    new_models = set(discovered) - previous
+    if not get_settings().get_mantle_discovery_regions():
+        logger.info("mantle model discovery disabled; using static registry")
+        return _model_regions
+
+    try:
+        discovered = await discover_mantle_models()
+    except Exception as e:
+        logger.warning(f"mantle model discovery failed: {e}")
+        return _model_regions
+    if not discovered:
+        logger.warning("mantle model discovery returned nothing; keeping registry")
+        return _model_regions
+
+    new_models = set(discovered) - set(_model_regions)
     if new_models:
         logger.warning(
             f"mantle discovery found NEW models not in the static registry: "
             f"{sorted(new_models)} — they will be routed automatically; "
             f"verify pricing rows exist after the next pricing update"
         )
-    set_discovered_mantle_models(discovered)
-    return get_mantle_model_regions()
-
-
-def mantle_pricing_name_to_id(display_name: str) -> Optional[str]:
-    """Map an AWS pricing-page display name to a registry model ID.
-
-    Normalizes "GPT-5.6 Sol" → "gpt-5.6-sol" and matches it against the
-    ``openai.``-suffix of every registry entry, so newly discovered models
-    match their pricing rows without a hand-maintained name table.
-    """
-    normalized = re.sub(r"[\s\-]+", "-", display_name.strip().lower())
-    for model_id in get_mantle_model_regions():
-        if model_id.split(".", 1)[-1] == normalized:
-            return model_id
-    return None
+    _model_regions = {**MANTLE_MODEL_REGIONS, **discovered}
+    return _model_regions
 
 
 def is_openai_mantle_model(model_id: str) -> bool:
@@ -209,7 +214,7 @@ def is_openai_mantle_model(model_id: str) -> bool:
     would wrongly capture the open-weight ``openai.gpt-oss-*`` models, which run
     through the standard Bedrock converse path.
     """
-    return model_id in get_mantle_model_regions()
+    return model_id in _model_regions
 
 
 def resolve_mantle_region(model_id: str) -> str:
@@ -219,7 +224,7 @@ def resolve_mantle_region(model_id: str) -> str:
     cross-region latency); otherwise use the model's preferred region.  Raises
     KeyError for non-mantle models — callers guard with is_openai_mantle_model.
     """
-    regions = get_mantle_model_regions()[model_id]
+    regions = _model_regions[model_id]
     local = get_settings().AWS_REGION
     return local if local in regions else regions[0]
 
@@ -231,14 +236,12 @@ def get_mantle_models() -> List[Dict]:
     ``list_aws_available_models`` so the frontend renders them uniformly.
     """
     models: List[Dict] = []
-    for model_id in get_mantle_model_regions():
-        # "openai.gpt-5.6-sol" → "GPT-5.6 Sol"
-        friendly_name = mantle_display_name(model_id)
+    for model_id in _model_regions:
         models.append(
             {
                 "model_id": model_id,
-                "model_name": friendly_name,
-                "friendly_name": friendly_name,
+                "model_name": mantle_display_name(model_id),
+                "friendly_name": mantle_display_name(model_id),
                 "provider": "openai-mantle",
                 "is_cross_region": False,
                 "cross_region_type": None,

--- a/backend/app/services/mantle_signing.py
+++ b/backend/app/services/mantle_signing.py
@@ -1,0 +1,45 @@
+"""
+SigV4 signing for AWS mantle (OpenAI-on-Bedrock) HTTP requests.
+
+Lives in its own module so both the registry (``mantle_models``, discovery
+probes) and the inference client (``mantle_client``) can import it at module
+level without creating a cycle between them.
+"""
+
+from typing import Dict
+
+from botocore.auth import SigV4Auth
+from botocore.awsrequest import AWSRequest
+
+from app.core.config import get_settings
+
+
+async def signed_headers(
+    method: str, url: str, body_bytes: bytes, region: str
+) -> Dict[str, str]:
+    """Return SigV4-signed headers for a mantle request.
+
+    Credentials come from the shared BedrockClient aioboto3 session (reuses the
+    EKS Pod IRSA/STS chain, including a SessionToken → ``X-Amz-Security-Token``).
+    In aiobotocore both ``get_credentials`` and ``get_frozen_credentials`` are
+    coroutines and must be awaited (unlike sync botocore).
+
+    The signature is computed over the EXACT *body_bytes* that will be sent.
+    """
+    from app.services.bedrock import BedrockClient
+
+    session = BedrockClient.get_instance().session
+    creds = await session.get_credentials()
+    if creds is None:
+        raise RuntimeError("No AWS credentials available to sign mantle request")
+    frozen = await creds.get_frozen_credentials()
+
+    service = get_settings().MANTLE_SIGV4_SERVICE
+    aws_req = AWSRequest(
+        method=method,
+        url=url,
+        data=body_bytes,
+        headers={"Content-Type": "application/json"},
+    )
+    SigV4Auth(frozen, service, region).add_auth(aws_req)
+    return dict(aws_req.headers)

--- a/backend/app/services/pricing.py
+++ b/backend/app/services/pricing.py
@@ -81,7 +81,7 @@ class ModelPricing:
             if is_gemini_model(model):
                 region = "global"
             elif is_openai_mantle_model(model):
-                # GPT-5.5/5.4 are billed in the region they're routed to —
+                # mantle models are billed in the region they're routed to —
                 # matches the routing in mantle_client.py.
                 region = resolve_mantle_region(model)
             else:

--- a/backend/app/services/pricing_updater.py
+++ b/backend/app/services/pricing_updater.py
@@ -29,6 +29,7 @@ from app.models.model_pricing import ModelPricing
 from app.services.mantle_models import (
     get_mantle_model_regions,
     mantle_pricing_name_to_id,
+    refresh_mantle_registry,
 )
 
 logger = logging.getLogger(__name__)
@@ -62,9 +63,14 @@ class PricingUpdater:
             "region": settings.AWS_REGION,
         }
 
-        # 0. Build dynamic model name → model ID mapping from Bedrock API
-        # This auto-discovers new models so the static mapping table stays minimal
+        # 0. Discover models so pricing rows can be matched below.
+        # Bedrock: dynamic model name → ID mapping keeps the static table minimal.
+        # Mantle (OpenAI): refresh the registry so newly launched models get
+        # their pricing-page rows matched in this same run — owning the ordering
+        # here means every pricing trigger (scheduler, admin, startup) gets a
+        # fresh registry without call-site coordination.
         PricingUpdater._dynamic_mapping_cache = self._build_dynamic_mapping()
+        await refresh_mantle_registry()
 
         # Track all base model IDs that already have pricing (from any source)
         found_model_ids: Set[str] = set()
@@ -806,7 +812,7 @@ class PricingUpdater:
             f"for region {target_region}"
         )
 
-        # OpenAI GPT-5.5/5.4 (mantle) live in a separate plain-text table on the
+        # OpenAI (mantle) models live in a separate plain-text table on the
         # same page — not in the data-pricing-markup sections handled above.
         # Fully additive: appends per-region rows without touching anything above.
         try:
@@ -823,7 +829,7 @@ class PricingUpdater:
         return pricing_data
 
     def _scrape_openai_text_pricing(self, html: str) -> List[Dict]:
-        """Parse the OpenAI (GPT-5.6/5.5/5.4) plain-text pricing table.
+        """Parse the OpenAI (mantle) plain-text pricing table.
 
         These models are served by AWS mantle and do not appear in the
         ``data-pricing-markup`` sections or the Price List API.  On the pricing
@@ -855,39 +861,46 @@ class PricingUpdater:
         # "$ 5.50" / "$5.00" / "$3.125&nbsp;" — space and trailing entities vary.
         money_re = re.compile(r"\$\s*([\d.]+)")
 
+        registry = get_mantle_model_regions()
+
         # Dedup: display names repeat across the per-region tables, but the prices
         # are identical, so the first occurrence per model is authoritative.
         seen_names: Set[str] = set()
         pricing_data: List[Dict] = []
 
         for row_match in row_re.finditer(html):
+            # Cheap pre-filter before cell extraction: mantle model display
+            # names all carry a version digit-dot pattern ("GPT-5.6 Sol").
+            if not re.search(r"\d\.\d", row_match.group(1)):
+                continue
             cells = [c.strip() for c in cell_re.findall(row_match.group(1))]
             if len(cells) not in (4, 5):
                 continue
             display_name = cells[0]
-            if not display_name.startswith("GPT-") or display_name in seen_names:
-                continue
-            model_id = mantle_pricing_name_to_id(display_name)
-            if not model_id:
-                # Row for a model the registry doesn't know — likely a brand-new
-                # launch discovery hasn't picked up yet.  Loud so operators see it.
-                logger.warning(
-                    f"OpenAI pricing row '{display_name}' has no matching mantle "
-                    f"registry entry; skipping (model not yet discovered?)"
-                )
-                seen_names.add(display_name)
-                continue
-
-            prices = [money_re.search(c) for c in cells[1:]]
-            if len(cells) == 5:
-                # input | cache write (may be "-") | cache read | output
-                input_m, _write_m, cached_m, output_m = prices
-            else:
-                # legacy: input | cache read | output
-                input_m, cached_m, output_m = prices
-            if not (input_m and cached_m and output_m):
+            if display_name in seen_names:
                 continue
             seen_names.add(display_name)
+            model_id = mantle_pricing_name_to_id(display_name)
+            if not model_id:
+                if display_name.startswith("GPT-"):
+                    # OpenAI-looking row the registry doesn't know — likely a
+                    # brand-new launch discovery hasn't picked up yet.  Loud so
+                    # operators see it.
+                    logger.warning(
+                        f"OpenAI pricing row '{display_name}' has no matching "
+                        f"mantle registry entry; skipping (not yet discovered?)"
+                    )
+                continue
+
+            # 5-column rows (since GPT-5.6) insert a cache-write cell after the
+            # input price; it has no DB column (calculate_cost bills writes at
+            # input × 1.25, matching the published prices), so drop it and both
+            # layouts reduce to: input | cache read | output.
+            if len(cells) == 5:
+                cells.pop(2)
+            input_m, cached_m, output_m = (money_re.search(c) for c in cells[1:])
+            if not (input_m and cached_m and output_m):
+                continue
 
             input_per_1m = Decimal(input_m.group(1))
             cached_per_1m = Decimal(cached_m.group(1))
@@ -895,7 +908,7 @@ class PricingUpdater:
 
             # Write one row per region the model can be invoked in, keyed by the
             # same region resolve_mantle_region() will produce at billing time.
-            for region in get_mantle_model_regions().get(model_id, []):
+            for region in registry.get(model_id, []):
                 pricing_data.append(
                     {
                         "model_id": model_id,

--- a/backend/app/tasks/pricing_tasks.py
+++ b/backend/app/tasks/pricing_tasks.py
@@ -45,19 +45,6 @@ async def refresh_profile_cache_task():
         logger.error(f"Profile cache refresh task failed: {e}", exc_info=True)
 
 
-async def refresh_mantle_registry_task():
-    """Background task to discover mantle (OpenAI) models via ListModels."""
-    logger.info("Starting mantle model discovery task...")
-
-    try:
-        from app.services.mantle_models import refresh_mantle_registry
-
-        registry = await refresh_mantle_registry()
-        logger.info(f"Mantle model discovery completed: {len(registry)} models")
-    except Exception as e:
-        logger.error(f"Mantle model discovery task failed: {e}", exc_info=True)
-
-
 async def update_gemini_pricing_task():
     """Background task to update Google Gemini model pricing."""
     logger.info("Starting Gemini pricing update task...")
@@ -94,17 +81,8 @@ def start_scheduler():
         replace_existing=True,
     )
 
-    # Mantle model discovery MUST run BEFORE the AWS pricing update so newly
-    # discovered models get their pricing-page rows matched in the same cycle.
-    scheduler.add_job(
-        refresh_mantle_registry_task,
-        trigger=CronTrigger(hour=1, minute=55),
-        id="refresh_mantle_registry",
-        name="Discover mantle (OpenAI) models via ListModels",
-        replace_existing=True,
-    )
-
     # Schedule AWS pricing update daily at 2:00 AM UTC
+    # (mantle model discovery runs inside update_all_pricing itself)
     scheduler.add_job(
         update_pricing_task,
         trigger=CronTrigger(hour=2, minute=0),
@@ -124,8 +102,7 @@ def start_scheduler():
 
     scheduler.start()
     logger.info(
-        "Scheduler started (profile cache: 1:50, mantle discovery: 1:55, "
-        "AWS pricing: 2:00, Gemini: 2:30 UTC)"
+        "Scheduler started (profile cache: 1:50, AWS pricing: 2:00, Gemini: 2:30 UTC)"
     )
 
 

--- a/backend/main.py
+++ b/backend/main.py
@@ -3,6 +3,7 @@ FastAPI application entry point for Kolya BR Proxy.
 AI Gateway service providing OpenAI-compatible access to AWS Bedrock Claude models.
 """
 
+import asyncio
 import logging
 from contextlib import asynccontextmanager
 from typing import AsyncGenerator
@@ -52,19 +53,19 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
     bedrock = BedrockClient.get_instance()
     logger.info("BedrockClient initialized")
 
-    await bedrock.refresh_profile_cache()
-    logger.info("Inference profile cache populated")
-
-    # Discover mantle (OpenAI GPT-5.x) models BEFORE pricing init so the first
-    # pricing run matches rows for newly launched models. Non-fatal: falls back
-    # to the static registry in mantle_models.py.
+    # Mantle (OpenAI GPT-5.x) model discovery runs concurrently with the
+    # profile cache refresh — both are independent network I/O.  Discovery
+    # never raises (falls back to the static registry); pricing runs also
+    # refresh it themselves, this just warms routing before first traffic.
     from app.services.mantle_models import refresh_mantle_registry
 
-    try:
-        mantle_registry = await refresh_mantle_registry()
-        logger.info(f"Mantle model registry ready: {len(mantle_registry)} models")
-    except Exception as e:
-        logger.warning(f"Mantle model discovery failed (using static registry): {e}")
+    _, mantle_registry = await asyncio.gather(
+        bedrock.refresh_profile_cache(), refresh_mantle_registry()
+    )
+    logger.info(
+        f"Inference profile cache populated; "
+        f"mantle registry ready ({len(mantle_registry)} models)"
+    )
 
     # Initialize pricing data if database is empty
     from app.core.database import async_session_maker

--- a/backend/tests/test_mantle_registry.py
+++ b/backend/tests/test_mantle_registry.py
@@ -6,29 +6,44 @@ from app.services import mantle_models as mm
 
 
 @pytest.fixture(autouse=True)
-def _reset_discovered_layer():
+def _reset_registry():
     """Each test starts from the static seed only."""
-    mm.set_discovered_mantle_models(None)
+    mm._model_regions = mm.MANTLE_MODEL_REGIONS
     yield
-    mm.set_discovered_mantle_models(None)
+    mm._model_regions = mm.MANTLE_MODEL_REGIONS
+
+
+async def _refresh_with(monkeypatch, discovered):
+    async def _fake_discover():
+        return discovered
+
+    monkeypatch.setattr(mm, "discover_mantle_models", _fake_discover)
+    return await mm.refresh_mantle_registry()
 
 
 class TestRegistryMerge:
     def test_static_seed_without_discovery(self):
-        regions = mm.get_mantle_model_regions()
-        assert regions == mm.MANTLE_MODEL_REGIONS
+        assert mm.get_mantle_model_regions() == mm.MANTLE_MODEL_REGIONS
 
-    def test_discovered_overrides_static_per_model(self):
-        mm.set_discovered_mantle_models({"openai.gpt-5.6-sol": ["us-west-2"]})
-        regions = mm.get_mantle_model_regions()
-        assert regions["openai.gpt-5.6-sol"] == ["us-west-2"]
+    @pytest.mark.asyncio
+    async def test_discovered_overrides_static_per_model(self, monkeypatch):
+        registry = await _refresh_with(
+            monkeypatch, {"openai.gpt-5.6-sol": ["us-west-2"]}
+        )
+        assert registry["openai.gpt-5.6-sol"] == ["us-west-2"]
         # Static models absent from discovery are preserved
-        assert regions["openai.gpt-5.5"] == mm.MANTLE_MODEL_REGIONS["openai.gpt-5.5"]
+        assert registry["openai.gpt-5.5"] == mm.MANTLE_MODEL_REGIONS["openai.gpt-5.5"]
 
-    def test_discovered_new_model_is_routable(self):
-        mm.set_discovered_mantle_models({"openai.gpt-5.7": ["us-east-2"]})
+    @pytest.mark.asyncio
+    async def test_discovered_new_model_is_routable(self, monkeypatch):
+        await _refresh_with(monkeypatch, {"openai.gpt-5.7": ["us-east-2"]})
         assert mm.is_openai_mantle_model("openai.gpt-5.7")
         assert mm.resolve_mantle_region("openai.gpt-5.7") == "us-east-2"
+
+    @pytest.mark.asyncio
+    async def test_empty_discovery_keeps_previous_registry(self, monkeypatch):
+        registry = await _refresh_with(monkeypatch, {})
+        assert registry == mm.MANTLE_MODEL_REGIONS
 
     def test_gpt_oss_never_matches(self):
         assert not mm.is_openai_mantle_model("openai.gpt-oss-120b")
@@ -47,6 +62,12 @@ class TestDisplayNames:
     def test_display_name(self, model_id, expected):
         assert mm.mantle_display_name(model_id) == expected
 
+    def test_display_name_override_wins(self, monkeypatch):
+        monkeypatch.setitem(
+            mm.MANTLE_DISPLAY_NAME_OVERRIDES, "openai.gpt-5.5", "Custom Name"
+        )
+        assert mm.mantle_display_name("openai.gpt-5.5") == "Custom Name"
+
     @pytest.mark.parametrize(
         "display_name,expected",
         [
@@ -63,25 +84,3 @@ class TestDisplayNames:
         for model_id in mm.get_mantle_model_regions():
             name = mm.mantle_display_name(model_id)
             assert mm.mantle_pricing_name_to_id(name) == model_id
-
-
-class TestRefreshRegistry:
-    @pytest.mark.asyncio
-    async def test_empty_discovery_keeps_previous_registry(self, monkeypatch):
-        async def _no_models():
-            return {}
-
-        monkeypatch.setattr(mm, "discover_mantle_models", _no_models)
-        registry = await mm.refresh_mantle_registry()
-        assert registry == mm.MANTLE_MODEL_REGIONS
-
-    @pytest.mark.asyncio
-    async def test_discovery_result_is_applied(self, monkeypatch):
-        async def _models():
-            return {"openai.gpt-5.7": ["us-east-1", "us-east-2"]}
-
-        monkeypatch.setattr(mm, "discover_mantle_models", _models)
-        registry = await mm.refresh_mantle_registry()
-        assert registry["openai.gpt-5.7"] == ["us-east-1", "us-east-2"]
-        # Static seed still present
-        assert "openai.gpt-5.5" in registry


### PR DESCRIPTION
## 背景

对 #81（GPT-5.6 支持 + mantle 自动发现）做了四维度代码审查（复用/简化/效率/层次），本 PR 落地全部修复。纯重构：外部行为不变（除下述两处刻意的行为改进），14 个文件 +276/−286。

## 主要修复

### 层次（结构性最强的一条）
- **`refresh_mantle_registry()` 收归 `update_all_pricing()` step 0 所有**（与既有的 `_build_dynamic_mapping()` 同位）。删除了 1:55 独立 cron job 和 admin endpoint 的前置调用——"发现必须先于定价"从三处调用点各自维护的 cron 时序约定，变为结构保证；未来任何新的定价触发路径自动获得新鲜注册表。
- **`_REASONING_MODEL_PATTERNS` 改为家族前缀**（`gpt-5.` / `gpt-6.`）。原来精确到版本号，与自动发现自相矛盾：gpt-5.7 上线会被自动路由但被误判为非 reasoning 模型，转发 temperature/top_p 导致请求时报错。
- responses.py 的 400 错误信息从注册表派生（不再硬编码 "GPT-5.6/5.5/5.4"），并清理了全库 9 处易过期的版本枚举文案。

### 复用
- SigV4 签名移入新的 `mantle_signing` 模块——原来 mantle_models 惰性 import mantle_client 的私有 `_signed_headers`，形成双向依赖 + 跨模块引用私有符号。
- config.py 四处相同的 CSV 解析收敛为 `_csv_list`。

### 简化
- 注册表合并从每次读取时计算改为 refresh 时一次赋值；删除 `set_discovered_mantle_models` 间接层。
- `mantle_display_name` 从 10 行状态循环简化为 `re.split` 两行，并新增 `MANTLE_DISPLAY_NAME_OVERRIDES` 逃生舱：AWS 命名不规则时加一行映射即可。
- scraper 4/5 列分支统一；发现禁用时不再误报权限告警。

### 效率
- 发现探测串行→`asyncio.gather` 并发 + 共享 httpx client（原最坏 3×30s 串行）。
- 启动时发现与 profile cache 刷新并发，不再叠加启动延迟。
- 热路径（每请求 2-3 次）不再有 dict 拷贝。

## 验证
- 15 个注册表测试全过（含新增的 override 逃生舱测试）
- 真实定价页 HTML：scraper 输出与重构前完全一致（11 行）
- reasoning 分类：`openai.gpt-5.7-nova` → True（未来型号自动正确）
- 无循环 import；pre-commit 全过
- 4 个 test_pricing 失败为 main 既有问题（本地无 mock 打真实 AWS API 所致），与本 PR 无关